### PR TITLE
Inline SVG

### DIFF
--- a/lib/KIcon.vue
+++ b/lib/KIcon.vue
@@ -1,66 +1,10 @@
-<template>
-
-  <!-- eslint-disable max-len -->
-
-  <!-- tracking -->
-  <mat-svg v-if="icon === 'correct'" name="check_circle" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'helpNeeded'" name="error" category="alert" :style="style" />
-  <mat-svg v-else-if="icon === 'hint'" name="lightbulb_outline" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'incorrect'" name="close" category="navigation" :style="style" />
-  <mat-svg v-else-if="icon === 'inProgress'" name="access_time" category="device" :style="style" />
-  <mat-svg v-else-if="icon === 'mastered'" name="stars" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'notStarted'" name="brightness_1" category="image" :style="style" />
-  <mat-svg v-else-if="icon === 'rectified'" name="lens" category="image" :style="style" />
-  <!-- coaching -->
-  <mat-svg v-else-if="icon === 'coach'" name="local_library" category="maps" :style="style" />
-  <mat-svg v-else-if="icon === 'lesson'" name="import_contacts" category="communication" :style="style" />
-  <mat-svg v-else-if="icon === 'question'" name="keyboard_arrow_right" category="hardware" :style="style" :class="flip" />
-  <mat-svg v-else-if="icon === 'quiz'" name="assignment_late" category="action" :style="style" />
-  <!-- content -->
-  <mat-svg v-else-if="icon === 'app' || icon === 'html5'" name="widgets" category="device" :style="style" />
-  <mat-svg v-else-if="icon === 'audio'" name="audiotrack" category="image" :style="style" />
-  <mat-svg v-else-if="icon === 'channel'" name="apps" category="navigation" :style="style" />
-  <mat-svg v-else-if="icon === 'doc' || icon === 'document'" name="book" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'exercise'" name="assignment" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'topic'" name="folder" category="file" :style="style" />
-  <mat-svg v-else-if="icon === 'video'" name="ondemand_video" category="notification" :style="style" />
-  <mat-svg v-else-if="icon === 'slideshow'" name="photo_library" category="image" :style="style" />
-  <mat-svg v-else-if="icon === 'unlistedchannel'" name="lock_open" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'multiple'" name="view_module" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'done'" name="done" category="action" :style="style" />
-  <!-- users -->
-  <mat-svg v-else-if="icon === 'classroom'" name="business" category="communication" :style="style" />
-  <mat-svg v-else-if="icon === 'group'" category="action" name="group_work" :style="style" />
-  <mat-svg v-else-if="icon === 'people'" name="people" category="social" :style="style" />
-  <mat-svg v-else-if="icon === 'person'" name="person" category="social" :style="style" />
-  <mat-svg v-else-if="icon === 'permission'" name="vpn_key" category="communication" :style="style" />
-  <!-- misc -->
-  <mat-svg v-else-if="icon === 'dot'" name="brightness_1" category="image" :style="style" />
-  <mat-svg v-else-if="icon === 'error'" name="error" category="alert" :style="style" />
-  <!-- UI -->
-  <mat-svg v-else-if="icon === 'back'" name="arrow_back" category="navigation" :style="style" :class="flip" />
-  <mat-svg v-else-if="icon === 'forward'" name="arrow_forward" category="navigation" :style="style" :class="flip" />
-  <mat-svg v-else-if="icon === 'clear'" name="clear" category="content" :style="style" />
-  <mat-svg v-else-if="icon === 'dropdown'" name="arrow_drop_down" category="navigation" :style="style" />
-  <mat-svg v-else-if="icon === 'language'" name="language" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'logout'" name="exit_to_app" category="action" :style="style" :class="flip" />
-  <mat-svg v-else-if="icon === 'menu'" name="menu" category="navigation" :style="style" />
-  <mat-svg v-else-if="icon === 'search'" name="search" category="action" :style="style" />
-  <!-- side nav -->
-  <mat-svg v-else-if="icon === 'learn'" name="school" category="social" :style="style" />
-  <mat-svg v-else-if="icon === 'device'" name="tablet_mac" category="hardware" :style="style" />
-  <mat-svg v-else-if="icon === 'profile'" name="account_circle" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'login'" name="exit_to_app" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'logout'" name="exit_to_app" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'coach'" name="assessment" category="action" :style="style" />
-  <mat-svg v-else-if="icon === 'facility'" name="settings_input_antenna" category="action" :style="style" />
-
-  <!--eslint-enable-->
-
-</template>
-
+<!--
+  No template here. This component uses a render function dynamically
+  below in the created() lifecycle hook
+-->
 
 <script>
+  const VueTemplateCompiler = require('vue-template-compiler');
 
   const iconTypes = [
     // tracking
@@ -137,16 +81,37 @@
         required: false,
       },
     },
+    created() {
+      const SVG_FILE_PREFIX = "data:image/svg+xml;base64,";
+
+      const styles = ":style=style";
+      const a11yAttrs = `role="presentation" focusable="false"`;
+      const cssClass = `:class="rtlClass"`;
+
+      // ... hard coded svg below ...
+      const svgFile = require("@material-icons/svg/svg/arrow_back/baseline.svg");
+      const svgBase64 = svgFile.replace(SVG_FILE_PREFIX, "");
+      const svgElementString = atob(svgBase64);
+      const styledAndAccessibleSvg = svgElementString.replace("<svg", `<svg ${cssClass} ${styles} ${a11yAttrs}`);
+      console.log(styledAndAccessibleSvg);
+      console.log(typeof(styledAndAccessibleSvg));
+      const template = VueTemplateCompiler.compileToFunctions(styledAndAccessibleSvg);
+      this.$options.render = template.render;
+    },
     computed: {
+      /* eslint-disable kolibri/vue-no-unused-properties */
+      // We are generating a string template using these computed properties so
+      // they are indeed being used in the created() lifecycle hook
       style() {
         if (this.color) {
           return { fill: this.color };
         }
         return { fill: this.$themeTokens.text };
       },
-      flip() {
-        return this.isRtl ? 'rtl-flip-icon' : null;
+      rtlClass() {
+        return this.isRtl ? 'rtl-flip-icon' : '';
       },
+      /* eslint-enable kolibri/vue-no-unused-properties */
     },
   };
 
@@ -154,13 +119,6 @@
 
 
 <style lang="scss" scoped>
-
-  svg {
-    position: relative;
-    top: 0.125em;
-    width: 1.125em;
-    height: 1.125em;
-  }
 
   .rtl-flip-icon {
     transform: scaleX(-1);

--- a/lib/KIcon.vue
+++ b/lib/KIcon.vue
@@ -6,72 +6,12 @@
 <script>
   const VueTemplateCompiler = require('vue-template-compiler');
 
-  const iconTypes = [
-    // tracking
-    'correct',
-    'helpNeeded',
-    'hint',
-    'incorrect',
-    'inProgress',
-    'mastered',
-    'notStarted',
-    'rectified',
-    // coaching
-    'coach',
-    'lesson',
-    'question',
-    'quiz',
-    // content
-    'app',
-    'audio',
-    'channel',
-    'doc',
-    'document',
-    'exercise',
-    'topic',
-    'video',
-    'html5',
-    'slideshow',
-    'unlistedchannel',
-    'multiple',
-    'done',
-    // users
-    'classroom',
-    'group',
-    'people',
-    'permission',
-    'person',
-    // misc
-    'dot',
-    'error',
-    // UI
-    'back',
-    'forward',
-    'clear',
-    'dropdown',
-    'language',
-    'logout',
-    'menu',
-    'search',
-    // side nav
-    'learn',
-    'device',
-    'profile',
-    'login',
-    'logout',
-    'coach',
-    'facility',
-  ];
-
   export default {
     name: 'KIcon',
     props: {
       icon: {
         type: String,
-        required: true,
-        validator(value) {
-          return iconTypes.includes(value);
-        },
+        required: false,
       },
       /**
        * color to apply to the icon
@@ -80,16 +20,36 @@
         type: String,
         required: false,
       },
+      materialName: {
+        type: String,
+        required: false,
+      }
     },
     created() {
+      // Make sure we have icon or materialName. Favor icon - so if both are given
+      // materialName is ignored.
+
+      // TODO: This will be updated to pull the icon from the upcoming dictionary
+      let fileName = this.icon ? this.icon : this.materialName;
+      if(!fileName) {
+        console.error("Cannot render icon without one of the two props 'icon' or 'materialName'");
+        return;
+      }
       const SVG_FILE_PREFIX = "data:image/svg+xml;base64,";
 
       const styles = ":style=style";
       const a11yAttrs = `role="presentation" focusable="false"`;
       const cssClass = `:class="rtlClass"`;
 
-      // ... hard coded svg below ...
-      const svgFile = require("@material-icons/svg/svg/arrow_back/baseline.svg");
+      // Dynamically pull in the icon requested and console an error if we cannot find it.
+      let svgFile;
+      try {
+        svgFile = require(`@material-icons/svg/svg/${fileName}/baseline.svg`);
+      } catch(e) {
+        console.error(`Could not load SVG for ${fileName}`);
+        return;
+      }
+
       const svgBase64 = svgFile.replace(SVG_FILE_PREFIX, "");
       const svgElementString = atob(svgBase64);
       const styledAndAccessibleSvg = svgElementString.replace("<svg", `<svg ${cssClass} ${styles} ${a11yAttrs}`);
@@ -118,7 +78,7 @@
 </script>
 
 
-<style lang="scss" scoped>
+<style scoped>
 
   .rtl-flip-icon {
     transform: scaleX(-1);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lib"
   ],
   "dependencies": {
+    "@material-icons/svg": "git+https://github.com/material-icons/material-icons.git",
     "aphrodite": "https://github.com/learningequality/aphrodite/",
     "autosize": "^3.0.21",
     "css-element-queries": "^1.2.0",
@@ -26,7 +27,8 @@
     "lodash": "^4.17.15",
     "material-design-icons": "^3.0.1",
     "popper.js": "^1.14.6",
-    "purecss": "^0.6.2"
+    "purecss": "^0.6.2",
+    "vue-template-compiler": "^2.6.11"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,6 +929,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@material-icons/svg@git+https://github.com/material-icons/material-icons.git":
+  version "0.0.1"
+  resolved "git+https://github.com/material-icons/material-icons.git#61b8cc912486959dec9830948d7df8e7763f6c94"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -4711,7 +4715,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4898,11 +4902,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -5334,7 +5333,7 @@ eslint-module-utils@^2.4.1:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@^2.20.0:
+eslint-plugin-import@^2.19.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz#802423196dcb11d9ce8435a5fc02a6d3b46939b3"
   integrity sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==
@@ -6105,13 +6104,6 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -6963,7 +6955,7 @@ hyphenate-style-name@^1.0.2:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6998,13 +6990,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^3.3.5:
   version "3.3.10"
@@ -7132,7 +7117,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -8574,7 +8559,7 @@ kolibri-tools@../kolibri/packages/kolibri-tools:
     eslint "^6.8.0"
     eslint-config-prettier "^6.9.0"
     eslint-config-vue "^2.0.2"
-    eslint-plugin-import "^2.20.0"
+    eslint-plugin-import "^2.19.1"
     eslint-plugin-jest "^23.3.0"
     eslint-plugin-kolibri "0.13.0-dev.10"
     eslint-plugin-vue "^6.1.2"
@@ -8591,13 +8576,13 @@ kolibri-tools@../kolibri/packages/kolibri-tools:
     launch-editor-middleware "^2.2.1"
     mini-css-extract-plugin "^0.4.0"
     mkdirp "^0.5.1"
-    node-sass "^4.12.0"
+    node-sass "^4.9.1"
     optimize-css-assets-webpack-plugin "5.0.1"
     postcss-loader "^2.0.6"
-    prettier "^1.18.2"
+    prettier "^1.13.7"
     query-ast "^1.0.1"
     rewire "^2.5.2"
-    sass-loader "^8.0.0"
+    sass-loader "^7.0.3"
     scss-parser "^1.0.0"
     semver "^5.6.0"
     shelljs "^0.7.4"
@@ -8618,7 +8603,7 @@ kolibri-tools@../kolibri/packages/kolibri-tools:
     vue-jest "^3.0.0"
     vue-loader "^15.7.0"
     vue-style-loader "^3.0.3"
-    vue-template-compiler "^2.6.11"
+    vue-template-compiler "~2.6.10"
     webpack "^4.6.0"
     webpack-bundle-analyzer "^3.0.3"
     webpack-bundle-tracker "https://github.com/learningequality/webpack-bundle-tracker"
@@ -8833,7 +8818,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -9568,27 +9553,12 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -9713,15 +9683,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
-  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -9840,22 +9801,6 @@ node-object-hash@^1.2.0:
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-1.4.2.tgz#385833d85b229902b75826224f6077be969a9e94"
   integrity sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ==
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.47:
   version "1.1.49"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.49.tgz#67ba5a3fac2319262675ef864ed56798bb33b93e"
@@ -9874,7 +9819,7 @@ node-res@^5.0.1:
     on-finished "^2.3.0"
     vary "^1.1.2"
 
-node-sass@^4.12.0:
+node-sass@^4.9.1:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
   integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
@@ -9912,7 +9857,7 @@ nomnom@^1.8.1:
   dependencies:
     abbrev "1"
 
-nopt@^4.0.1, nopt@~4.0.1:
+nopt@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
   integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
@@ -9981,27 +9926,6 @@ normalize.css@^8.0.1:
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
   integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-all@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
@@ -10031,7 +9955,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -11816,7 +11740,7 @@ prettier@1.16.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.3.tgz#8c62168453badef702f34b45b6ee899574a6a65d"
   integrity sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==
 
-prettier@^1.12.1, prettier@^1.18.2:
+prettier@^1.12.1, prettier@^1.13.7, prettier@^1.18.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
@@ -12100,16 +12024,6 @@ raw-loader@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
   integrity sha1-DD0L6u2KAclm2Xh793goElKpeao=
-
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
 
 react-is@^16.8.4:
   version "16.12.0"
@@ -12692,7 +12606,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -12810,15 +12724,15 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
-sass-loader@^8.0.0:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
-  integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
+sass-loader@^7.0.3:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
+  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
   dependencies:
     clone-deep "^4.0.1"
-    loader-utils "^1.2.3"
-    neo-async "^2.6.1"
-    schema-utils "^2.6.1"
+    loader-utils "^1.0.1"
+    neo-async "^2.5.0"
+    pify "^4.0.1"
     semver "^6.3.0"
 
 sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
@@ -13656,7 +13570,7 @@ strip-json-comments@1.0.4, strip-json-comments@1.0.x:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
   integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
 
-strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -13954,19 +13868,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 temp@^0.8.1, temp@^0.8.3:
   version "0.8.4"
@@ -14950,7 +14851,7 @@ vue-style-loader@^4.1.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.11:
+vue-template-compiler@^2.6.11, vue-template-compiler@~2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
   integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
@@ -15490,7 +15391,7 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
# WORK IN PROGRESS

Here is an implementation that I came up with that will pull in SVG files and inline them without using webpack.

How?

- `require('@material-icons/svg/svg/MATERIAL_NAME/ICON_TYPE.svg')` gets the SVG file URL back. We strip the `data:svg...` nonsense off of it, leaving us with the Base64 representation.
- We decode the B64 to a string of the HTML `<svg ...` element. 
- We compile that as a template using the `vue-template-compiler`
- We use a `render()` function in KIcon to render the icon without any wrapping elements (avoiding using `v-html` on a div or span).
- Eliminated the need for the `svg-icon-inline-loader` altogether (semi in-progress) - KIcon _will_ allow targeting specific material icons outside of our own internal design definitions.

Additional notes:

- We inline the a11y attrs which are inserted in the `svg-icon-inline-loader` package here: https://github.com/learningequality/svg-icon-inline-loader/blob/9f137b273af978eda901c6f92b648be30322a15d/index.js#L121

- I removed the CSS for the `svg` element for now - but that's because the styling was different between an SVG in Kolibri being inserted using `mat-svg` rather than `KIcon` - I'll probably return it but this is something we'll need to consider if we go through and replace every `<mat-svg` in Kolibri with `<KIcon>` - basically the CSS there imposes an `18px` width/height but the SVGs are default given in `24px` size - so when you render using `mat-svg` you get `24px` but with `KIcon` you would get `18px` instead.

- The class for isRtl didn't seem to be used? I made sure it works with this implementation.

- It is worth noting that we can override styles and classes when using `KIcon` a la `<KIcon icon="correct" color="green" style="width: 100px; height: 200px;" class="my-fancy-class" />` and they are directly applied to the resulting `<svg>` element.

TODOs

- I think that I'll create an dictionary (object) where keys are "Kolibri Design Names" which refer to the material names. This would be easy to update and refer to

- I'll add some props to allow for targeting of specific types (outline, baseline, etc) and to allow for us to target specific material icons if we want.

- Figure out whether we reimplement the `svg {}` css styles or not and how to address the differences between items rendered with `mat-svg` in Kolibri.

