### PR TITLE
kuitextbox autofocus directive expects object

### DIFF
--- a/lib/KTextbox/KeenUiTextbox.vue
+++ b/lib/KTextbox/KeenUiTextbox.vue
@@ -107,11 +107,13 @@
 
   import autosize from 'autosize';
 
-  function autofocus(el, { value }) {
-    if (value) {
-      el.focus();
-    }
-  }
+  const autofocus = {
+    inserted(el, { value }) {
+      if (value) {
+        el.focus();
+      }
+    },
+  };
 
   export default {
     name: 'KeenUiTextbox',


### PR DESCRIPTION
KeenUITextbox has the `autofocus` directive. The value for `autofocus` in vanilla KeenUIText box imports from a file that exports an object like the one that is defined in the changes in this PR.

The issue was that when trying to login with a username that requires a password, I was not being autofocused to the password textbox and the password textbox was disabled.