### PR TITLE
Buttons! KButtonGroup, KIconButton, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,30 +129,3 @@ Icons are drawn from https://github.com/material-icons/material-icons and then c
 ```bash
 yarn run precompile-svgs
 ```
-
-### Development in parallel with other applications
-
-If you are working on this repository and want to see live updates to the component library here in other applications that are using this library, then you will need to do a few things.
-
-1. While in the root of your local `kolibri-design-system` repository, run `yarn link`.
-2. In the application where you intend to use `kolibri-design-system` remove the reference to `kolibri-design-system` from the `package.json` of that project.
-3. In the root of the application where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system && yarn install`.
-
-Now, when you run the application your changes in `kolibri-design-system` will be updated live where your app expects its dependency on `kolibri-design-system` to live.
-
-For example, given that you have `~/kolibri` and `~/kolibri-design-system` folders with their respective local repositories.
-
-```
-cd ~/kolibri-design-system
-yarn link
-cd ~/kolibri
-```
-
-Remove the reference to `kolibri-design-system` from `kolibri/core/package.json`
-
-```
-yarn link kolibri-design-system && yarn install
-yarn run devserver
-```
-
-Now you're all set to see your changes to the Kolibri Design System working live in Kolibri!

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -9,7 +9,11 @@
           appearance="raised-button"
           @click="showDropdown = !showDropdown"
         />
-        <div v-if="showDropdown" class="breadcrumbs-dropdown">
+        <div
+          v-if="showDropdown"
+          class="breadcrumbs-dropdown"
+          :style="{ background: $themeTokens.surface }"
+        >
           <ol class="breadcrumbs-dropdown-items">
             <li
               v-for="(crumb, index) in collapsedCrumbs"
@@ -270,13 +274,12 @@
   }
 
   .breadcrumbs-dropdown {
-    @extend %dropshadow-16dp;
+    @extend %dropshadow-8dp;
 
     position: absolute;
-    z-index: 100;
+    z-index: 8;
     padding: 16px;
     font-weight: bold;
-    background: white;
   }
 
   .breadcrumbs-dropdown-items {

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -3,25 +3,28 @@
   <div v-show="showSingleItem || crumbs.length > 1">
     <nav class="breadcrumbs">
       <div v-show="collapsedCrumbs.length" class="breadcrumbs-dropdown-wrapper">
-        <UiIconButton :hasDropdown="true" size="small">
-          <KIcon icon="arrow_down" />
-          <div slot="dropdown" class="breadcrumbs-dropdown">
-            <ol class="breadcrumbs-dropdown-items">
-              <li
-                v-for="(crumb, index) in collapsedCrumbs"
-                :key="index"
-                class="breadcrumbs-dropdown-item"
-              >
-                <KRouterLink
-                  :text="crumb.text"
-                  :to="crumb.link"
-                  :style="{ maxWidth: `${collapsedCrumbMaxWidth}px` }"
-                  dir="auto"
-                />
-              </li>
-            </ol>
-          </div>
-        </UiIconButton>
+        <KIconButton
+          size="small"
+          :icon="showDropdown ? 'arrow_up' : 'arrow_down'"
+          appearance="raised-button"
+          @click="showDropdown = !showDropdown"
+        />
+        <div v-if="showDropdown" class="breadcrumbs-dropdown">
+          <ol class="breadcrumbs-dropdown-items">
+            <li
+              v-for="(crumb, index) in collapsedCrumbs"
+              :key="index"
+              class="breadcrumbs-dropdown-item"
+            >
+              <KRouterLink
+                :text="crumb.text"
+                :to="crumb.link"
+                :style="{ maxWidth: `${collapsedCrumbMaxWidth}px` }"
+                dir="auto"
+              />
+            </li>
+          </ol>
+        </div>
       </div>
 
       <ol class="breadcrumbs-visible-items">
@@ -93,7 +96,6 @@
   import throttle from 'lodash/throttle';
   import every from 'lodash/every';
   import keys from 'lodash/keys';
-  import UiIconButton from './keen/UiIconButton';
   import KResponsiveElementMixin from './KResponsiveElementMixin';
 
   const DROPDOWN_BTN_WIDTH = 55;
@@ -110,7 +112,6 @@
    */
   export default {
     name: 'KBreadcrumbs',
-    components: { UiIconButton },
     mixins: [KResponsiveElementMixin],
     props: {
       /**
@@ -145,6 +146,7 @@
       // Each object contains:
       // text, router-link 'to' object, vue ref, a resize sensor, and its collapsed state
       crumbs: [],
+      showDropdown: false,
     }),
     computed: {
       collapsedCrumbs() {
@@ -247,6 +249,8 @@
 
 <style lang="scss" scoped>
 
+  @import './styles/definitions';
+
   .breadcrumbs {
     margin-top: 8px;
     margin-bottom: 8px;
@@ -266,6 +270,10 @@
   }
 
   .breadcrumbs-dropdown {
+    position: absolute;
+    @extend %dropshadow-16dp;
+    background: white;
+    z-index: 100;
     padding: 16px;
     font-weight: bold;
   }

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -270,12 +270,13 @@
   }
 
   .breadcrumbs-dropdown {
-    position: absolute;
     @extend %dropshadow-16dp;
-    background: white;
+
+    position: absolute;
     z-index: 100;
     padding: 16px;
     font-weight: bold;
+    background: white;
   }
 
   .breadcrumbs-dropdown-items {

--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -25,16 +25,19 @@
         <KIcon
           v-if="isCurrentlyIndeterminate"
           :style="notBlank"
+          class="indeterminate"
           icon="indeterminate_check_box"
         />
         <KIcon
           v-else-if="!isCurrentlyIndeterminate && isCurrentlyChecked"
           :style="[ notBlank, activeOutline ]"
+          class="checked"
           icon="check_box"
         />
         <KIcon
           v-else
           :style="[ blank, activeOutline ]"
+          class="unchecked"
           icon="check_box_outline_blank"
         />
 
@@ -226,6 +229,15 @@
     .k-checkbox-label {
       cursor: default;
     }
+  }
+
+  // KIcon overrides
+  .indeterminate,
+  .unchecked,
+  .checked {
+    height: $checkbox-height;
+    width: $checkbox-height;
+    top: 0;
   }
 
 </style>

--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -235,9 +235,9 @@
   .indeterminate,
   .unchecked,
   .checked {
-    height: $checkbox-height;
-    width: $checkbox-height;
     top: 0;
+    width: $checkbox-height;
+    height: $checkbox-height;
   }
 
 </style>

--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -25,19 +25,19 @@
         <KIcon
           v-if="isCurrentlyIndeterminate"
           :style="notBlank"
-          class="indeterminate"
+          class="checkbox-icon"
           icon="indeterminate_check_box"
         />
         <KIcon
           v-else-if="!isCurrentlyIndeterminate && isCurrentlyChecked"
           :style="[ notBlank, activeOutline ]"
-          class="checked"
+          class="checkbox-icon"
           icon="check_box"
         />
         <KIcon
           v-else
           :style="[ blank, activeOutline ]"
-          class="unchecked"
+          class="checkbox-icon"
           icon="check_box_outline_blank"
         />
 
@@ -232,9 +232,7 @@
   }
 
   // KIcon overrides
-  .indeterminate,
-  .unchecked,
-  .checked {
+  .checkbox-icon {
     top: 0;
     width: $checkbox-height;
     height: $checkbox-height;

--- a/lib/KIcon/index.vue
+++ b/lib/KIcon/index.vue
@@ -268,13 +268,14 @@
 
 <style lang="scss" scoped>
 
+  @import '../styles/definitions';
+
   svg {
     position: relative;
     top: 0.125em;
     width: 1.125em;
     height: 1.125em;
-    // 1s and not $core-time because it works
-    transition: fill 1s ease;
+    transition: fill $core-time ease;
   }
 
   .rtl-flip-icon {

--- a/lib/KIcon/index.vue
+++ b/lib/KIcon/index.vue
@@ -266,13 +266,15 @@
 </script>
 
 
-<style scoped>
+<style lang="scss" scoped>
 
   svg {
     position: relative;
     top: 0.125em;
     width: 1.125em;
     height: 1.125em;
+    // 1s and not $core-time because it works
+    transition: fill 1s ease;
   }
 
   .rtl-flip-icon {

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <span class="labeled-icon-wrapper">
+  <span class="labeled-icon-wrapper" v-on="$listeners">
     <span class="icon">
       <slot name="icon">
         <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" style="top: 2px;" />

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -3,7 +3,7 @@
   <span class="labeled-icon-wrapper">
     <div class="icon">
       <slot name="icon">
-        <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" />
+        <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" style="top: 2px;" />
       </slot>
     </div>
     <div class="label" :style="{ color: color || $themeTokens.text }">

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -16,7 +16,7 @@
         </slot>
       </span>
     </span>
-    <span class="iconAfter">
+    <span class="icon-after">
       <slot name="iconAfter">
         <KIcon v-if="iconAfter" :icon="iconAfter" :color="color || $themeTokens.text" style="top: 2px;" />
       </slot>
@@ -77,11 +77,11 @@
       labelStyle() {
         let styles = {};
         // Margin for icons - use em to match parent font size
-        if(this.iconAfter || this.$slots['iconAfter']) {
+        if (this.iconAfter || this.$slots['iconAfter']) {
           styles['marginRight'] = '1.975em';
         }
 
-        if(this.icon || this.$slots['icon']) {
+        if (this.icon || this.$slots['icon']) {
           styles['marginLeft'] = '1.975em';
         }
 
@@ -105,7 +105,7 @@
     left: 0;
   }
 
-  .iconAfter {
+  .icon-after {
     position: absolute;
     right: 0;
   }

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -3,10 +3,10 @@
   <span class="labeled-icon-wrapper">
     <div class="icon">
       <slot name="icon">
-        <KIcon v-if="icon" :icon="icon" />
+        <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" />
       </slot>
     </div>
-    <div class="label">
+    <div class="label" :style="{ color: color || $themeTokens.text }">
       <!-- nest slot inside span to get alignment and flow correct for mixed RLT/LTR -->
       <span dir="auto" class="debug-warning">
         <!-- Use zero-width space when empty -->
@@ -31,6 +31,11 @@
     props: {
       // If provided, will render a KIcon with the same 'icon' prop
       icon: {
+        type: String,
+        required: false,
+      },
+      // If provided
+      color: {
         type: String,
         required: false,
       },

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -1,19 +1,26 @@
 <template>
 
   <span class="labeled-icon-wrapper">
-    <div class="icon">
+    <span class="icon">
       <slot name="icon">
         <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" style="top: 2px;" />
       </slot>
-    </div>
-    <div class="label" :style="{ color: color || $themeTokens.text }">
+    </span>
+    <span class="label" :style="labelStyle">
       <!-- nest slot inside span to get alignment and flow correct for mixed RLT/LTR -->
       <span dir="auto" class="debug-warning">
         <!-- Use zero-width space when empty -->
-        <slot v-if="!labelEmpty">{{ label }}</slot>
-        <template v-else>&#8203;</template>
+        <slot>
+          <span v-if="!labelEmpty">{{ label }}</span>
+          <span v-else>&#8203;</span>
+        </slot>
       </span>
-    </div>
+    </span>
+    <span class="iconAfter">
+      <slot name="iconAfter">
+        <KIcon v-if="iconAfter" :icon="iconAfter" :color="color || $themeTokens.text" style="top: 2px;" />
+      </slot>
+    </span>
   </span>
 
 </template>
@@ -29,12 +36,17 @@
       KIcon,
     },
     props: {
-      // If provided, will render a KIcon with the same 'icon' prop
+      // If provided, will render a KIcon using the value given as the `icon` prop. The icon will be prepended to the label.
       icon: {
         type: String,
         required: false,
       },
-      // If provided
+      // If provided, will render a KICon using the value given as the `icon` prop. The iconAfter will be appended to the label.
+      iconAfter: {
+        type: String,
+        required: false,
+      },
+      // If provided, determines the color of the label and any icons that are provided.
       color: {
         type: String,
         required: false,
@@ -62,6 +74,19 @@
           (defaultSlot.children && defaultSlot.children.length)
         );
       },
+      labelStyle() {
+        let styles = {};
+        // Margin for icons - use em to match parent font size
+        if(this.iconAfter || this.$slots['iconAfter']) {
+          styles['marginRight'] = '1.975em';
+        }
+
+        if(this.icon || this.$slots['icon']) {
+          styles['marginLeft'] = '1.975em';
+        }
+
+        return styles;
+      },
     },
   };
 
@@ -80,9 +105,13 @@
     left: 0;
   }
 
+  .iconAfter {
+    position: absolute;
+    right: 0;
+  }
+
   .label {
-    display: block;
-    margin-left: 1.925em; /* scale with parent font size */
+    display: inline-block;
   }
 
   .debug-warning > svg {

--- a/lib/KRadioButton.vue
+++ b/lib/KRadioButton.vue
@@ -179,6 +179,7 @@
     opacity: 0;
   }
 
+  // KIcon overrides
   .checked,
   .unchecked {
     position: absolute;

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -13,6 +13,7 @@ import KFixedGridItem from './grids/KFixedGridItem';
 import KGrid from './grids/KGrid';
 import KGridItem from './grids/KGridItem';
 import KIcon from './KIcon';
+import KIconButton from './buttons-and-links/KIconButton';
 import KLabeledIcon from './KLabeledIcon';
 import KLinearLoader from './loaders/KLinearLoader';
 import KModal from './KModal';
@@ -94,6 +95,7 @@ export default function KThemePlugin(Vue) {
   Vue.component('KGrid', KGrid);
   Vue.component('KGridItem', KGridItem);
   Vue.component('KIcon', KIcon);
+  Vue.component('KIconButton', KIconButton);
   Vue.component('KLabeledIcon', KLabeledIcon);
   Vue.component('KLinearLoader', KLinearLoader);
   Vue.component('KModal', KModal);

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -2,6 +2,7 @@ import computedClass from './styles/computedClass';
 
 import KBreadcrumbs from './KBreadcrumbs';
 import KButton from './buttons-and-links/KButton';
+import KButtonGroup from './buttons-and-links/KButtonGroup';
 import KCheckbox from './KCheckbox';
 import KCircularLoader from './loaders/KCircularLoader';
 import KDropdownMenu from './KDropdownMenu';
@@ -81,6 +82,7 @@ export default function KThemePlugin(Vue) {
 
   // globally-accessible components
   Vue.component('KButton', KButton);
+  Vue.component('KButtonGroup', KButtonGroup);
   Vue.component('KBreadcrumbs', KBreadcrumbs);
   Vue.component('KCheckbox', KCheckbox);
   Vue.component('KCircularLoader', KCircularLoader);

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -20,6 +20,7 @@
       icon="dropdown"
       class="dropdown-arrow"
       :style="arrowStyles"
+      style="width: 24px; height: 24px;"
     />
   </component>
 
@@ -69,6 +70,10 @@
         required: false,
         default: false,
       },
+      icon: {
+        type: String,
+        required: false,
+      }
     },
     computed: {
       htmlTag() {

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -9,12 +9,23 @@
     :disabled="disabled"
     tabindex="0"
     @click="handleClick"
-    @keyup.enter.stop.prevent="handelPressEnter"
+    @keyup.enter.stop.prevent="handlePressEnter"
   >
+    <slot name="icon">
+      <KIcon v-if="icon" :icon="icon" :color="$themeTokens.textInverted" />
+    </slot>
+
     <slot v-if="$slots.default"></slot>
+
     <template v-else>
       <span>{{ text }}</span>
     </template>
+
+    <slot name="iconAfter">
+      <KIcon v-if="iconAfter" :icon="iconAfter" :color="$themeTokens.textInverted" />
+    </slot>
+
+    <!-- Dropdown arrow icon -->
     <KIcon
       v-if="hasDropdown"
       icon="dropdown"
@@ -70,10 +81,20 @@
         required: false,
         default: false,
       },
+      /**
+       * If provided, prepends a KIcon to the text in the button
+       */
       icon: {
         type: String,
         required: false,
-      }
+      },
+      /**
+       * If provided, appends an KIcon to the text in the button.
+       */
+      iconAfter: {
+        type: String,
+        required: false,
+      },
     },
     computed: {
       htmlTag() {
@@ -101,7 +122,7 @@
         this.blurWhenClicked();
         this.$emit('click', event);
       },
-      handelPressEnter(event) {
+      handlePressEnter(event) {
         this.blurWhenClicked();
         // HACK: for 'a' tags, the 'click' event is not getting fired
         if (this.htmlTag === 'a') {

--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -1,0 +1,28 @@
+<template>
+
+  <span class="button-group">
+    <slot></slot>
+  </span>
+
+</template>
+
+
+<script>
+
+export default {
+  name: "KButtonGroup",
+}
+
+</script>
+
+
+<style lang="scss" scoped>
+  .button-group {
+    overflow: none;
+  }
+  /* KButton can produce <a> or <button> tags */
+  .button-group > a,
+  .button-group > button {
+    margin: 8px;
+  }
+</style>

--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -1,8 +1,8 @@
 <template>
 
-  <span class="button-group">
+  <div class="button-group">
     <slot></slot>
-  </span>
+  </div>
 
 </template>
 
@@ -26,6 +26,7 @@
 <style lang="scss" scoped>
 
   .button-group {
+    display: inline-block;
     overflow: hidden;
   }
 

--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -30,9 +30,9 @@
   }
 
   /* KButton can produce <a> or <button> tags */
-  .button-group > a,
-  .button-group > button {
-    margin: 8px;
+  .button-group > a:not(:first-child),
+  .button-group > button:not(:first-child) {
+    margin-left: 16px;
   }
 
 </style>

--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -8,6 +8,12 @@
 
 
 <script>
+/**
+ * Used to create a consistently spaced horizontal set of buttons and/or links.
+ *
+ * KButtonGroup works with KButton, KIconButton, KRouterLink and KExternalLink and any <a> or <button> tags.
+ * in it's default slot.
+ */
 
 export default {
   name: "KButtonGroup",

--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -8,27 +8,31 @@
 
 
 <script>
-/**
- * Used to create a consistently spaced horizontal set of buttons and/or links.
- *
- * KButtonGroup works with KButton, KIconButton, KRouterLink and KExternalLink and any <a> or <button> tags.
- * in it's default slot.
- */
 
-export default {
-  name: "KButtonGroup",
-}
+  /**
+   * Used to create a consistently spaced horizontal set of buttons and/or links.
+   *
+   * KButtonGroup works with KButton, KIconButton, KRouterLink and KExternalLink and any <a> or <button> tags.
+   * in it's default slot.
+   */
+
+  export default {
+    name: 'KButtonGroup',
+  };
 
 </script>
 
 
 <style lang="scss" scoped>
+
   .button-group {
-    overflow: none;
+    overflow: hidden;
   }
+
   /* KButton can produce <a> or <button> tags */
   .button-group > a,
   .button-group > button {
     margin: 8px;
   }
+
 </style>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -6,8 +6,16 @@
     :href="href"
     :download="download"
     dir="auto"
+    @mouseenter="hovering = true"
+    @mouseleave="hovering = false"
   >
-    {{ text }}
+    <KIcon
+      v-if="icon"
+      :icon="icon"
+      style="top: 4px;"
+      :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+    />
+    <span :style="spanStyle">{{ text }}</span>
   </a>
 
 </template>
@@ -38,6 +46,34 @@
         type: String,
         required: false,
       },
+      /**
+       * If provided, shows a KIcon in front of the text
+       */
+      icon: {
+        type: String,
+        required: false,
+      }
+    },
+    data() {
+      return {
+        hovering: false,
+      }
+    },
+    computed: {
+      /**
+       * If icon is provided, add 8px margin between the icon and the text
+       */
+      spanStyle() {
+        if(this.icon) {
+          if(this.isRtl) {
+            return { marginRight: '8px' }
+          } else {
+            return { marginLeft: '8px' };
+          }
+        } else {
+          return {};
+        }
+      }
     },
   };
 

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -69,28 +69,28 @@
       iconAfter: {
         type: String,
         required: false,
-      }
+      },
     },
     data() {
       return {
         hovering: false,
-      }
+      };
     },
     computed: {
       /**
        * If icon is provided, add 8px margin between the icon and the text
        */
       spanStyle() {
-        if(this.icon) {
-          if(this.isRtl) {
-            return { marginRight: '8px' }
+        if (this.icon) {
+          if (this.isRtl) {
+            return { marginRight: '8px' };
           } else {
             return { marginLeft: '8px' };
           }
         } else {
           return {};
         }
-      }
+      },
     },
   };
 

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -9,13 +9,23 @@
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >
-    <KIcon
-      v-if="icon"
-      :icon="icon"
-      style="top: 4px;"
-      :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
-    />
+    <slot name="icon">
+      <KIcon
+        v-if="icon"
+        :icon="icon"
+        style="top: 4px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+    </slot>
     <span :style="spanStyle">{{ text }}</span>
+    <slot name="iconAfter">
+      <KIcon
+        v-if="iconAfter"
+        :icon="iconAfter"
+        style="top: 4px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+    </slot>
   </a>
 
 </template>
@@ -50,6 +60,13 @@
        * If provided, shows a KIcon in front of the text
        */
       icon: {
+        type: String,
+        required: false,
+      },
+      /**
+       * If provided, shows a KIcon after the text
+       */
+      iconAfter: {
         type: String,
         required: false,
       }

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -1,4 +1,5 @@
 <template>
+
   <KButton
     :color="color"
     :disabled="disabled"
@@ -11,87 +12,87 @@
     <!-- UiIconButton used flexbox - 7px is the magic centering number -->
     <KIcon :icon="icon" :color="color" :style="iconStyles" />
   </KButton>
+
 </template>
 
 
 <script>
 
-export default {
-  name: "KIconButton",
-  props: {
-    appearance: {
-      type: String,
-      default: 'flat-button',
-      required: false,
+  export default {
+    name: 'KIconButton',
+    props: {
+      appearance: {
+        type: String,
+        default: 'flat-button',
+        required: false,
+      },
+      icon: {
+        type: String,
+        required: true,
+      },
+      /* color: hex or rgb[a] color */
+      color: {
+        type: String,
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+      buttonType: {
+        type: String,
+        default: 'button',
+        required: false,
+      },
+      size: {
+        type: String,
+        default: null,
+      },
+      ariaLabel: {
+        type: String,
+      },
     },
-    icon: {
-      type: String,
-      required: true,
+    computed: {
+      appearanceOverrides() {
+        const hover =
+          this.appearance === 'flat-button' ? { backgroundColor: 'rgba(0,0,0,.1)' } : {};
+        return {
+          ...this.sizeStyles,
+          // Circle
+          borderRadius: '50%',
+          // Remove mins & padding
+          minHeight: '0px',
+          minWidth: '0px',
+          padding: '0',
+          ':hover': hover,
+        };
+      },
+      sizeStyles() {
+        switch (this.size) {
+          case 'mini':
+            return { width: '24px', height: '24px' };
+          case 'small':
+            return { width: '32px', height: '32px' };
+          case 'large':
+            return { width: '48px', height: '48px' };
+          default:
+            return { width: '40px', height: '40px' };
+        }
+      },
+      iconStyles() {
+        const sizes = { width: '24px', height: '24px' };
+        switch (this.size) {
+          case 'mini':
+            return { ...sizes, top: '0px' };
+          case 'small':
+            return { ...sizes, top: '4px' };
+          default:
+            return { ...sizes, top: '7px' };
+        }
+      },
     },
-    /* color: hex or rgb[a] color */
-    color: {
-      type: String,
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    buttonType: {
-      type: String,
-      default: "button",
-      required: false,
-    },
-    size: {
-      type: String,
-      default: null,
-    },
-    ariaLabel: {
-      type: String,
-    }
-  },
-  computed: {
-    appearanceOverrides() {
-      const hover = this.appearance === 'flat-button' ? { backgroundColor: "rgba(0,0,0,.1)" } : {};
-      return {
-        ...this.sizeStyles,
-        // Circle
-        borderRadius: '50%',
-        // Remove mins & padding
-        minHeight: '0px',
-        minWidth: '0px',
-        padding: '0',
-        ":hover": hover
-      };
-    },
-    sizeStyles() {
-      switch(this.size) {
-        case 'mini':
-          return { width: '24px', height: '24px' }
-        case 'small':
-          return { width: '32px', height: '32px' }
-        case 'large':
-          return { width: '48px', height: '48px' }
-        default:
-          return { width: '40px', height: '40px' }
-      }
-    },
-    iconStyles() {
-      const sizes = { width: '24px', height: '24px' };
-      switch(this.size) {
-        case 'mini':
-          return { ...sizes, top: '0px' }
-        case 'small':
-          return { ...sizes, top: '4px' }
-        default:
-          return { ...sizes, top: '7px' }
-      };
-    },
-  }
-}
+  };
 
 </script>
 
 
-<style lang="scss" scoped>
-
-</style>
+<style lang="scss" scoped></style>

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -1,0 +1,97 @@
+<template>
+  <KButton
+    :color="color"
+    :disabled="disabled"
+    :appearance="appearance"
+    :appearanceOverrides="appearanceOverrides"
+    :buttonType="buttonType"
+    :aria-label="ariaLabel"
+    v-on="$listeners"
+  >
+    <!-- UiIconButton used flexbox - 7px is the magic centering number -->
+    <KIcon :icon="icon" :color="color" :style="iconStyles" />
+  </KButton>
+</template>
+
+
+<script>
+
+export default {
+  name: "KIconButton",
+  props: {
+    appearance: {
+      type: String,
+      default: 'flat-button',
+      required: false,
+    },
+    icon: {
+      type: String,
+      required: true,
+    },
+    /* color: hex or rgb[a] color */
+    color: {
+      type: String,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    buttonType: {
+      type: String,
+      default: "button",
+      required: false,
+    },
+    size: {
+      type: String,
+      default: null,
+    },
+    ariaLabel: {
+      type: String,
+    }
+  },
+  computed: {
+    appearanceOverrides() {
+      const hover = this.appearance === 'flat-button' ? { backgroundColor: "rgba(0,0,0,.1)" } : {};
+      return {
+        ...this.sizeStyles,
+        // Circle
+        borderRadius: '50%',
+        // Remove mins & padding
+        minHeight: '0px',
+        minWidth: '0px',
+        padding: '0',
+        ":hover": hover
+      };
+    },
+    sizeStyles() {
+      switch(this.size) {
+        case 'mini':
+          return { width: '24px', height: '24px' }
+        case 'small':
+          return { width: '32px', height: '32px' }
+        case 'large':
+          return { width: '48px', height: '48px' }
+        default:
+          return { width: '40px', height: '40px' }
+      }
+    },
+    iconStyles() {
+      const sizes = { width: '24px', height: '24px' };
+      switch(this.size) {
+        case 'mini':
+          return { ...sizes, top: '0px' }
+        case 'small':
+          return { ...sizes, top: '4px' }
+        default:
+          return { ...sizes, top: '7px' }
+      };
+    },
+  }
+}
+
+</script>
+
+
+<style lang="scss" scoped>
+
+</style>

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -2,7 +2,16 @@
 
   <!-- no extra whitespace inside link -->
   <router-link :class="buttonClasses" :to="to" dir="auto">
-    {{ text }}
+    <span @mouseenter="hovering = true" @mouseleave="hovering = false">
+      <KIcon
+        v-if="icon"
+        :icon="icon"
+        style="top: 4px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+      <!-- Keep on the same line to avoid empty underlined spacing -->
+      <span :style="spanStyle">{{ text }}</span>
+    </span>
   </router-link>
 
 </template>
@@ -26,6 +35,34 @@
         required: true,
         type: Object,
       },
+      /**
+       * If provided, shows a KIcon in front of the text
+       */
+      icon: {
+        type: String,
+        required: false,
+      }
+    },
+    data() {
+      return {
+        hovering: false,
+      }
+    },
+    computed: {
+      /**
+       * If icon is provided, add 8px margin between the icon and the text
+       */
+      spanStyle() {
+        if(this.icon) {
+          if(this.isRtl) {
+            return { marginRight: '8px' }
+          } else {
+            return { marginLeft: '8px' };
+          }
+        } else {
+          return {};
+        }
+      }
     },
   };
 

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -2,16 +2,26 @@
 
   <!-- no extra whitespace inside link -->
   <router-link :class="buttonClasses" :to="to" dir="auto">
-    <span @mouseenter="hovering = true" @mouseleave="hovering = false">
+    <KLabeledIcon @mouseenter="hovering = true" @mouseleave="hovering = false">
       <KIcon
         v-if="icon"
+        slot="icon"
         :icon="icon"
-        style="top: 4px;"
+        style="top: 0px; height: 24px; width: 24px;"
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
+
       <!-- Keep on the same line to avoid empty underlined spacing -->
-      <span :style="spanStyle">{{ text }}</span>
-    </span>
+      <span>{{ text }}</span>
+
+      <KIcon
+        v-if="iconAfter"
+        slot="iconAfter"
+        :icon="iconAfter"
+        style="top: 0px; height: 24px; width: 24px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+    </KLabeledIcon>
   </router-link>
 
 </template>
@@ -41,27 +51,18 @@
       icon: {
         type: String,
         required: false,
-      }
+      },
+      /**
+       * If provided, shows a KIcon after the text
+       */
+      iconAfter: {
+        type: String,
+        required: false,
+      },
     },
     data() {
       return {
         hovering: false,
-      }
-    },
-    computed: {
-      /**
-       * If icon is provided, add 8px margin between the icon and the text
-       */
-      spanStyle() {
-        if(this.icon) {
-          if(this.isRtl) {
-            return { marginRight: '8px' }
-          } else {
-            return { marginLeft: '8px' };
-          }
-        } else {
-          return {};
-        }
       }
     },
   };

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -63,7 +63,7 @@
     data() {
       return {
         hovering: false,
-      }
+      };
     },
   };
 

--- a/lib/buttons-and-links/buttons.scss
+++ b/lib/buttons-and-links/buttons.scss
@@ -41,7 +41,8 @@ a.button {
 }
 
 .link,
-.link .label > span > span{ // KRouterLink target text
+.link .label > span > span {
+  // KRouterLink target text
   display: inline-block;
   padding: 0;
   text-align: left;

--- a/lib/buttons-and-links/buttons.scss
+++ b/lib/buttons-and-links/buttons.scss
@@ -40,7 +40,8 @@ a.button {
   box-shadow: $raised-shadow;
 }
 
-.link {
+.link,
+.link .label > span > span{ // KRouterLink target text
   display: inline-block;
   padding: 0;
   text-align: left;

--- a/lib/buttons-and-links/buttons.scss
+++ b/lib/buttons-and-links/buttons.scss
@@ -10,7 +10,6 @@ $raised-shadow: 0 1px 5px rgba(0, 0, 0, 0.2), 0 2px 2px rgba(0, 0, 0, 0.14),
   max-width: 100%;
   min-height: 36px;
   padding: 0 16px;
-  margin: 8px;
   overflow: hidden;
   font-size: 14px;
   font-weight: bold;


### PR DESCRIPTION
# Overview

~**WIP**~

** Ready for Review**

HOW TO:

- Checkout this branch locally,
- Checkout https://github.com/learningequality/kolibri/pull/6696 this branch locally
- `cd /path/to/design-system` and: `yarn link`
- `cd /path/to/kolibri` and remove the entry for `kolibri-design-system` from the `kolibri/core/package.json`
- `yarn link kolibri-design-system` then `yarn install`

Now you can run the devserver and will be using this branch :+1: 

## KButtonGroup

Related Issue: https://github.com/learningequality/kolibri/issues/5900
Related Kolibri PR: https://github.com/learningequality/kolibri/pull/6696

### What was done

- Remove 8px base margin on buttons.
- Create KButtonGroup - puts 8px margin on all `<a>` and `<button>` direct children of the `<span>` wrapper (with a CSS `.class > a, .class > button` selector).
... a lot of other stuff...
- Updates to KLabeledButton, KButton, KRouterLink, KExternalLink

_In Kolibri_

- Wrapped adjacent `KButton`s with the new `KButtonGroup`.
- *Strong note* that buttons which previously were 8px offset from - say - the edge of their wrapping container are now aligned with them. A good example of this is any button at the top-right of a table in Coach or Facility. There are likely other places where this is the case.


## KIconButton

Circular buttons replacing all UIIconButtons in Kolibri

## KRouterLink, ExternalLink, Button Icon slots/props