### PR TITLE
Allow force showing invalidText in KTextbox

### DIFF
--- a/lib/KTextbox/index.vue
+++ b/lib/KTextbox/index.vue
@@ -69,10 +69,20 @@
         default: false,
       },
       /**
-       * Text displayed if input is invalid
+       * Text displayed when the user is notified of invalid input
        */
       invalidText: {
         type: String,
+        required: false,
+      },
+      /**
+       * Show the `invalidText` even if the user has not focused or change the input
+       * Note that `false` here does not mean the text will never show but `true`
+       * does mean that it will definitely show.
+       */
+      showInvalidText: {
+        type: Boolean,
+        default: false,
         required: false,
       },
       /**
@@ -141,7 +151,7 @@
     },
     computed: {
       showInvalidMessage() {
-        return this.invalid && this.changedOrFocused;
+        return this.invalid && (this.changedOrFocused || this.showInvalidText);
       },
     },
     watch: {

--- a/lib/KTextbox/index.vue
+++ b/lib/KTextbox/index.vue
@@ -76,9 +76,8 @@
         required: false,
       },
       /**
-       * Show the `invalidText` even if the user has not focused or change the input
-       * Note that `false` here does not mean the text will never show but `true`
-       * does mean that it will definitely show.
+       * Show the `invalidText` even if the user has not focused or change the input.
+       * `invalid` must also be `true` for this to take effect.
        */
       showInvalidText: {
         type: Boolean,


### PR DESCRIPTION
Discussed on Slack that KTextbox validation messages will not show if that KTextbox was never focused or altered.

Adds `showInvalidText` prop w/ comments. Adjusted comment on `invalidText` prop as well to be more clear.

In Kolibri `kolibri/core/package.json` change:

`"kolibri-design-system": "github:nucleogenesis/kolibri-design-system-1#big-keen-ui-vendoring"`

to this:

`"kolibri-design-system": "github:nucleogenesis/kolibri-design-system-1#allow-forced-invalid-textbox"`

Then `yarn install --check-files` and you should be good to go testing this with Kolibri.