### PR TITLE
KCircularLoader `disableTransition` prop returns

### DIFF
--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -106,6 +106,10 @@
         default: 32,
       },
       stroke: Number,
+      disableTransition: {
+        type: Boolean,
+        default: false,
+      },
     },
 
     computed: {


### PR DESCRIPTION
This prop was removed but it is referenced in the file.

Was removed previously here: https://github.com/learningequality/kolibri-design-system/commit/6c34335e14efa40f426118fe5bde191e55b166c4

@indirectlylit do you recall if this was on purpose (and we should instead remove the reference) or should we keep this prop in?