### PR TITLE
Fix for 0.14 to KButtonGroup

### DIFF
--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -27,7 +27,6 @@
 
   .button-group {
     display: inline-block;
-    overflow: hidden;
   }
 
   /* KButton can produce <a> or <button> tags */


### PR DESCRIPTION
The overflow is unnecessary and hides the shadow. If it is not unnecessary we'll hear about it for sure but I haven't seen any issues.