### PR TITLE
remove undefined prop reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ yarn run precompile-svgs
 
 ### Development in parallel with other applications
 
-If you are working on this repository and want to see live updates to the component library here in other applications that are using this library, then you will need to do a few things.
+If you are working on the design system library code in this repo and want to see local updates reflected in other applications that are using this library, then you will need to do a few things.
 
 1. While in the root of your local `kolibri-design-system` repository, run `yarn link`.
 2. In the application where you intend to use `kolibri-design-system` remove the reference to `kolibri-design-system` from the `package.json` of that project.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ If you are working on the design system library code in this repo and want to se
 
 1. While in the root of your local `kolibri-design-system` repository, run `yarn link`.
 2. In the application where you intend to use `kolibri-design-system` remove the reference to `kolibri-design-system` from the `package.json` of that project.
-3. In the root of the application where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system && yarn install`.
+3. In the root of the application where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system` and then `yarn install`.
 
 Now, when you run the application your changes in `kolibri-design-system` will be updated live where your app expects its dependency on `kolibri-design-system` to live.
 

--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -9,9 +9,7 @@
   -->
 
 
-  <transition
-    :name="disableTransition ? null : 'ui-progress-circular--transition-fade'"
-  >
+  <transition name="ui-progress-circular--transition-fade">
     <div
       class="ui-progress-circular"
       :class="[classes, { delay }]"

--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -104,10 +104,6 @@
         default: 32,
       },
       stroke: Number,
-      disableTransition: {
-        type: Boolean,
-        default: false,
-      },
     },
 
     computed: {


### PR DESCRIPTION
seeing lots of errors like this in current 0.14 Kolibri:

```
KCircularLoader.vue?7265:9 [Vue warn]: Property or method "disableTransition" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.

found in

---> <KCircularLoader> at node_modules/kolibri-design-system/lib/loaders/KCircularLoader.vue
       <TaskPanel> at kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
         <TransitionGroup>
           <ManageTasksPage> at kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
             <WithAuthMessage>
               <KPageContainer> at node_modules/kolibri-design-system/lib/KPageContainer.vue
                 <CoreBase> at kolibri/core/assets/src/views/CoreBase/index.vue
                   <Root>
```