### PR TITLE
Fix breadcrumbs overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist
 # pregenerated output
 docs/gitBranch.js
 docs/jsdocs.js
+
+# IDE
+.idea

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -55,6 +55,7 @@
             <span
               :style="{ maxWidth: `${lastCrumbMaxWidth}px` }"
               dir="auto"
+              class="link-text"
             >
               {{ crumb.text }}
             </span>
@@ -313,7 +314,8 @@
   .breadcrumbs-visible-item {
     display: inline-block;
     vertical-align: middle;
-    &:first-child {
+
+    /deep/ .link-text {
       display: inline-block;
       max-width: 300px;
       overflow: hidden;

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -1,12 +1,19 @@
 <template>
 
-  <div v-show="showSingleItem || crumbs.length > 1">
+  <div
+    v-show="showSingleItem || crumbs.length > 1"
+    :class="{'breadcrumbs-collapsed': collapsedCrumbs.length}"
+  >
     <nav class="breadcrumbs">
-      <div v-show="collapsedCrumbs.length" class="breadcrumbs-dropdown-wrapper">
+      <div
+        v-show="collapsedCrumbs.length"
+        class="breadcrumbs-dropdown-wrapper"
+      >
         <KIconButton
           size="small"
           :icon="showDropdown ? 'arrow_up' : 'arrow_down'"
           appearance="raised-button"
+          :style="{ verticalAlign: 'middle' }"
           @click="showDropdown = !showDropdown"
         />
         <div
@@ -24,9 +31,11 @@
                 class="krouter-item"
                 :text="crumb.text"
                 :to="crumb.link"
-                :style="{ maxWidth: `${collapsedCrumbMaxWidth}px` }"
-                dir="auto"
-              />
+              >
+                <template #text="{ text }">
+                  <span class="breadcrumbs-crumb-text" dir="auto">{{ text }}</span>
+                </template>
+              </KRouterLink>
             </li>
           </ol>
         </div>
@@ -44,7 +53,11 @@
               :text="crumb.text"
               :to="crumb.link"
               dir="auto"
-            />
+            >
+              <template #text="{ text }">
+                <span class="breadcrumbs-crumb-text">{{ text }}</span>
+              </template>
+            </KRouterLink>
           </li>
 
           <li
@@ -53,9 +66,8 @@
             class="breadcrumb-visible-item-last breadcrumbs-visible-item"
           >
             <span
-              :style="{ maxWidth: `${lastCrumbMaxWidth}px` }"
+              class="breadcrumbs-crumb-text"
               dir="auto"
-              class="link-text"
             >
               {{ crumb.text }}
             </span>
@@ -75,7 +87,11 @@
             :key="index"
             class="breadcrumbs-visible-item breadcrumbs-visible-item-notlast"
           >
-            <KRouterLink :text="crumb.text" :to="crumb.link" tabindex="-1" />
+            <KRouterLink :text="crumb.text" :to="crumb.link" tabindex="-1">
+              <template #text="{ text }">
+                <span class="breadcrumbs-crumb-text">{{ text }}</span>
+              </template>
+            </KRouterLink>
           </li>
 
           <li
@@ -84,7 +100,9 @@
             :key="index"
             class="breadcrumb-visible-item-last breadcrumbs-visible-item"
           >
-            <span :style="{ maxWidth: `${lastCrumbMaxWidth}px` }">{{ crumb.text }}</span>
+            <span class="breadcrumbs-crumb-text">
+              {{ crumb.text }}
+            </span>
           </li>
         </template>
       </ol>
@@ -105,8 +123,6 @@
   import KResponsiveElementMixin from './KResponsiveElementMixin';
 
   const DROPDOWN_BTN_WIDTH = 55;
-  const DROPDOWN_SIDE_PADDING = 32; // pulled from .breadcrumbs-dropdown
-  const MAX_CRUMB_WIDTH = 300; // pulled from .breadcrumbs-visible-item class
 
   function validateLinkObject(object) {
     const validKeys = ['name', 'path', 'params', 'query'];
@@ -160,15 +176,6 @@
       },
       parentWidth() {
         return this.elementWidth;
-      },
-      lastCrumbMaxWidth() {
-        if (this.collapsedCrumbs.length) {
-          return Math.min(this.parentWidth - DROPDOWN_BTN_WIDTH, MAX_CRUMB_WIDTH);
-        }
-        return Math.min(this.parentWidth, MAX_CRUMB_WIDTH);
-      },
-      collapsedCrumbMaxWidth() {
-        return Math.min(this.parentWidth - DROPDOWN_SIDE_PADDING, MAX_CRUMB_WIDTH);
       },
     },
     watch: {
@@ -256,17 +263,30 @@
 <style lang="scss" scoped>
 
   @import './styles/definitions';
+  $crumbMaxWidth: 300px;
 
   .breadcrumbs {
     margin-top: 8px;
     margin-bottom: 8px;
     font-size: 16px;
     font-weight: bold;
+    white-space: nowrap;
+  }
+
+  .breadcrumbs-crumb-text {
+    display: inline-block;
+    width: 100%;
+    max-width: $crumbMaxWidth;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
   }
 
   .breadcrumbs-dropdown-wrapper {
     display: inline-block;
     vertical-align: middle;
+
     &::after {
       margin-right: 8px;
       margin-left: 8px;
@@ -279,6 +299,7 @@
     @extend %dropshadow-8dp;
 
     position: absolute;
+    max-width: 100%;
     z-index: 8;
     padding: 16px;
     font-weight: bold;
@@ -294,35 +315,34 @@
     display: block;
     padding-top: 8px;
     padding-bottom: 8px;
+
     .krouter-item {
-      display: inline-block;
-      max-width: 300px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      width: 100%;
+      /deep/  {
+        max-width: 100%;
+      }
     }
   }
 
   .breadcrumbs-visible-items {
     display: inline-block;
+    width: 100%;
     padding: 0;
     margin: 0;
     vertical-align: middle;
     list-style: none;
+    white-space: nowrap;
+
+    .breadcrumbs-collapsed & {
+      // account for dropdown button width
+      width: calc(100% - 55px);
+    }
   }
 
   .breadcrumbs-visible-item {
     display: inline-block;
+    max-width: 100%;
     vertical-align: middle;
-
-    /deep/ .link-text {
-      display: inline-block;
-      max-width: 300px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      vertical-align: middle;
-    }
   }
 
   .breadcrumbs-visible-item-notlast {

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -318,9 +318,6 @@
 
     .krouter-item {
       width: 100%;
-      /deep/  {
-        max-width: 100%;
-      }
     }
   }
 

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -56,6 +56,12 @@
         type: String,
         required: false,
       },
+      // If provided, will limit label width to this value
+      maxWidth: {
+        type: String,
+        required: false,
+        default: '100%',
+      },
     },
     computed: {
       labelEmpty() {
@@ -76,16 +82,22 @@
       },
       labelStyle() {
         let styles = {};
+        let margins = 0;
         // Margin for icons - use em to match parent font size
         if (this.iconAfter || this.$slots['iconAfter']) {
           styles['marginRight'] = '1.975em'; // scale with parent font size
+          margins += 1.975;
         }
 
         if (this.icon || this.$slots['icon']) {
           styles['marginLeft'] = '1.975em'; // scale with parent font size
+          margins += 1.975;
         }
 
-        return styles;
+        const maxWidth = (margins > 0)
+          ? `calc(${this.maxWidth} - ${margins}em)`
+          : this.maxWidth;
+        return { ...styles, maxWidth };
       },
     },
   };
@@ -98,6 +110,7 @@
   .labeled-icon-wrapper {
     position: relative;
     display: inline-block;
+    max-width: 100%;
   }
 
   .icon {

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -18,7 +18,7 @@
     <slot v-if="$slots.default"></slot>
 
     <template v-else>
-      <span>{{ text }}</span>
+      <span class="link-text">{{ text }}</span>
     </template>
 
     <slot name="iconAfter">

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -17,7 +17,7 @@
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
     </slot>
-    <span :style="spanStyle">{{ text }}</span>
+    <span class="link-text" :style="spanStyle">{{ text }}</span>
     <slot name="iconAfter">
       <KIcon
         v-if="iconAfter"

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -12,7 +12,7 @@
       />
 
       <!-- Keep on the same line to avoid empty underlined spacing -->
-      <span>{{ text }}</span>
+      <span class="link-text">{{ text }}</span>
 
       <KIcon
         v-if="iconAfter"

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -2,7 +2,7 @@
 
   <!-- no extra whitespace inside link -->
   <router-link :class="buttonClasses" :to="to" dir="auto">
-    <KLabeledIcon @mouseenter="hovering = true" @mouseleave="hovering = false">
+    <KLabeledIcon @mouseenter="hovering = true" @mouseleave="hovering = false" :maxWidth="maxWidth">
       <KIcon
         v-if="icon"
         slot="icon"
@@ -12,7 +12,9 @@
       />
 
       <!-- Keep on the same line to avoid empty underlined spacing -->
-      <span class="link-text">{{ text }}</span>
+      <slot name="text" :text="text">
+        <span>{{ text }}</span>
+      </slot>
 
       <KIcon
         v-if="iconAfter"
@@ -58,6 +60,14 @@
       iconAfter: {
         type: String,
         required: false,
+      },
+      /**
+       * Set a max width for content
+       */
+      maxWidth: {
+        type: String,
+        required: false,
+        default: '100%',
       },
     },
     data() {

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -13,7 +13,7 @@
 
       <!-- Keep on the same line to avoid empty underlined spacing -->
       <slot name="text" :text="text">
-        <span>{{ text }}</span>
+        <span class="link-text">{{ text }}</span>
       </slot>
 
       <KIcon

--- a/lib/buttons-and-links/buttons.scss
+++ b/lib/buttons-and-links/buttons.scss
@@ -41,7 +41,7 @@ a.button {
 }
 
 .link,
-.link .label > span > span {
+.link .link-text {
   // KRouterLink target text
   display: inline-block;
   padding: 0;


### PR DESCRIPTION
See regression issue here https://github.com/learningequality/kolibri/issues/7140

- Added `text` slot to `<KRouterLink>`
- Added `maxWidth` prop to `<KRouterLink>` and `<KLabeledIcon>`
- Added `.breadcrumbs-crumb-text` styling to handle text overflow
- Reduced specificity of global selectors styling the link text

![Screenshot from 2020-07-01 10-16-47](https://user-images.githubusercontent.com/819838/86272803-03ad7d00-bb84-11ea-9345-e492ebd50595.png)
![Screenshot from 2020-07-01 10-16-20](https://user-images.githubusercontent.com/819838/86272811-07d99a80-bb84-11ea-9824-77d95c663c1d.png)
![Screenshot from 2020-07-01 10-16-04](https://user-images.githubusercontent.com/819838/86272819-0b6d2180-bb84-11ea-8fb4-cd9cecf9a0c2.png)
