### PR TITLE
Keen font stack avoid system font superseding noto

### DIFF
--- a/lib/keen/styles/variables.scss
+++ b/lib/keen/styles/variables.scss
@@ -2,10 +2,7 @@
 @import 'md-colors';
 
 // The UI font stack
-$font-stack: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-  'Fira Sans', 'Droid Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-  'Segoe UI Symbol' !default;
-
+$font-stack: inherit;
 // Base font size
 $base-font-size: 100% !default; // typically 16px in most browsers
 


### PR DESCRIPTION
Mentioned here by @jonboiser https://github.com/learningequality/kolibri-design-system/issues/33

This line looks like it would load the wrong font in some cases.

I didn't actually replicate this - but it seems like this is where the problem lies.

To test in Kolibri - find your `kolibri/core/package.json` entry for `"kolibri-design-system"` to the value: `git@github.com:nucleogenesis/kolibri-design-system-1.git#keen-font`

Then `yarn install --force` and load up the Kolibri dev server.