### PR TITLE
UiButton cursor:default -> cursor:pointer

### DIFF
--- a/lib/keen/UiButton.vue
+++ b/lib/keen/UiButton.vue
@@ -212,7 +212,7 @@ export default {
     background: none;
     border-radius: $ui-default-border-radius;
     border: none;
-    cursor: default;
+    cursor: pointer;
     display: inline-flex;
     font-family: $font-stack;
     font-size: $ui-button-font-size;


### PR DESCRIPTION
Fixes: https://github.com/learningequality/kolibri-design-system/issues/33

Now it is `cursor: pointer`

In Kolibri - a good place to have seen this was in the user profile dropdown.