### PR TITLE
Adding icons to button documentation

### DIFF
--- a/docs/common/DocsAnchorTarget.vue
+++ b/docs/common/DocsAnchorTarget.vue
@@ -14,13 +14,23 @@
 
 <script>
 
+  import log from 'loglevel';
+
   export default {
     name: 'DocsAnchorTarget',
     props: {
       anchor: {
         type: String,
         validator(value) {
-          return value.match(/^#[a-zA-Z0-9_-]*$/);
+          if (!value.startsWith('#')) {
+            log.warn(`'anchor' prop value '${value}' must start with a '#'`);
+            return false;
+          }
+          if (!value.match(/^#[a-zA-Z0-9_-]*$/)) {
+            log.warn(`'anchor' prop value '${value}' must match /^#[a-zA-Z0-9_-]*$/`);
+            return false;
+          }
+          return true;
         },
       },
     },

--- a/docs/common/DocsDoNot.vue
+++ b/docs/common/DocsDoNot.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <div class="show">
+    <div v-if="$slots.do" class="show">
       <div class="header">
         <span class="mark do">✔</span> Do
       </div>
@@ -9,7 +9,7 @@
         <slot name="do"></slot>
       </div>
     </div>
-    <div class="show">
+    <div v-if="$slots.not" class="show">
       <div class="header">
         <span class="mark not">✘</span> Don't
       </div>

--- a/docs/common/DocsShow.vue
+++ b/docs/common/DocsShow.vue
@@ -27,8 +27,7 @@
 <style lang="scss" scoped>
 
   .show {
-    padding-right: 24px;
-    padding-left: 24px;
+    padding: 8px 24px;
     margin: 8px;
     border: 1px solid #dedede;
     border-radius: 4px;

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -19,6 +19,7 @@
       </p>
 
       <p>As such, there are three components that all behave similarly, but are used for different purposes:</p>
+      <!-- TODO: add a flat secondary icon button to these examples below. See Google doc for example -->
       <ul>
         <li>
           <code>KButton</code> is used to create <code>&lt;button&gt;</code> tags with
@@ -37,7 +38,6 @@
     </DocsPageSection>
 
     <DocsPageSection title="Visual styles" anchor="#visualstyles">
-
       <p>
         There are 3 main appearances of button and link components.
         (Remember that a button component can visually look like a link,
@@ -77,16 +77,23 @@
       <p>
         Note that we don't use a "secondary basic link" style.
       </p>
+      <p>
+        Buttons can also contain both text and an icon. Based on the need, the icon can come either before or after the text. This should be used sparingly - only when the icon significantly adds value to the meaning of the button.
+      </p>
+      <!-- TODO: implement 2 examples - one with icon appearing before text, the other with and icon appearing after the text. See Google doc for examples -->
+      <p>
+        <b>TODO: INSERT BUTTONS WITH ICONS HERE</b>
+      </p>
     </DocsPageSection>
     <DocsPageSection title="Label text" anchor="#labels">
       <ul>
-        <li>Labels should typically have a single word, or two at most</li>
+        <li>Labels should typically have a single word, or two at most, although there is an exception for links</li>
         <li>
           Avoid ambiguity; be specific about the action that will be performed. For example,
           use 'Save' instead of 'OK'
         </li>
         <li>Never use commas or other punctuation</li>
-        <li>Do not add icons to buttons</li>
+        <li>For raised and flat buttons, always use all-caps text</li>
       </ul>
     </DocsPageSection>
 
@@ -102,6 +109,57 @@
       </ul>
 
     </DocsPageSection>
+
+    <DocsPageSection title="Icon buttons" anchor="icon_buttons">
+      <p>
+        Use icon buttons for editors, or in situations where using text buttons would hinder the user experience.
+      </p>
+      <p>
+        Default to using flat secondary style for icon buttons.
+      </p>
+      <p>
+        Be sure to consider internationalization, translation, and cultural meaning in the use of icon buttons.
+      </p>
+      <p>
+        Always include a tooltip with the name of the action for icon buttons.
+      </p>
+      <!-- TODO: implement icon button that shows an example tooltip label on hover. See Google doc for example -->
+      <p>
+        <b>TODO: INSERT ICON BUTTON EXAMPLE HERE</b>
+      </p>
+
+    </DocsPageSection>
+
+    <DocsPageSection title="Dropdowns" anchor="dropdowns">
+      <p>
+        There are variations of buttons which can open a dropdown menu:
+      </p>
+      <!-- TODO: implement 3 examples: primary button, primary flat button, and secondary icon button that function as dropdowns. See Google doc for example -->
+      <p>
+        <b>TODO: INSERT DROPDOWN BUTTON EXAMPLES HERE</b>
+      </p>
+
+    </DocsPageSection>
+
+    <DocsPageSection title="Visual specs" anchor="specs" />
+    <ul>
+      <li>Border radius: 2px</li>
+      <li>Elevation: 4dp</li>
+      <li>Font size: 14px</li>
+      <li>Icon size: 14px</li>
+      <li>Text button padding: 8px 16px</li>
+      <li>Icon button padding: 8px</li>
+    </ul>
+    <p>
+      Don't:
+    </p>
+    <ul>
+      <li>Use outlines for buttons</li>
+      <li>Use full-width buttons</li>
+      <li>Set arbitrary fixed widths</li>
+      <li>Change the border radius</li>
+      <li>Change the drop-shadow</li>
+    </ul>
 
   </DocsPageTemplate>
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -108,7 +108,7 @@
 
     </DocsPageSection>
 
-    <DocsPageSection title="Icon buttons" anchor="icon_buttons">
+    <DocsPageSection title="Icon buttons" anchor="#icon_buttons">
       <p>
         Use icon buttons for editors, or in situations where using text buttons would hinder the user experience.
       </p>
@@ -128,7 +128,7 @@
 
     </DocsPageSection>
 
-    <DocsPageSection title="Dropdowns" anchor="dropdowns">
+    <DocsPageSection title="Dropdowns" anchor="#dropdowns">
       <p>
         There are variations of buttons which can open a dropdown menu:
       </p>
@@ -139,7 +139,7 @@
 
     </DocsPageSection>
 
-    <DocsPageSection title="Visual specs" anchor="specs" />
+    <DocsPageSection title="Visual specs" anchor="#specs" />
     <ul>
       <li>Border radius: 2px</li>
       <li>Elevation: 4dp</li>

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -17,9 +17,7 @@
         or control-click to open a page in a new tab, then a link should be used.
         Otherwise, a button should be used.
       </p>
-
       <p>As such, there are three components that all behave similarly, but are used for different purposes:</p>
-      <!-- TODO: add a flat secondary icon button to these examples below. See Google doc for example -->
       <ul>
         <li>
           <code>KButton</code> is used to create <code>&lt;button&gt;</code> tags with
@@ -53,7 +51,7 @@
           hyperlink-like appearance for deemphasized actions, or actions inline within text
         </li>
       </ul>
-
+      <!-- TODO: add a flat secondary icon button to these examples below. See Google doc for example -->
       <DocsShow>
         <KButton text="Raised button" :primary="true" appearance="raised-button" />
         <KButton text="Flat button" :primary="true" appearance="flat-button" />

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -148,16 +148,17 @@
       <li>Text button padding: 8px 16px</li>
       <li>Icon button padding: 8px</li>
     </ul>
-    <p>
-      Don't:
-    </p>
-    <ul>
-      <li>Use outlines for buttons</li>
-      <li>Use full-width buttons</li>
-      <li>Set arbitrary fixed widths</li>
-      <li>Change the border radius</li>
-      <li>Change the drop-shadow</li>
-    </ul>
+    <DocsDoNot>
+      <template v-slot:not>
+        <ul>
+          <li>Use outlines for buttons</li>
+          <li>Use full-width buttons</li>
+          <li>Set arbitrary fixed widths</li>
+          <li>Change the border radius</li>
+          <li>Change the drop-shadow</li>
+        </ul>
+      </template>
+    </DocsDoNot>
 
   </DocsPageTemplate>
 


### PR DESCRIPTION
### Changes

- Added documentation for icon buttons 
- Added documentation for buttons that happen to have icons
- Allows for ability to hide "Do" and "Do not" blocks in `DocsDoNot.vue`

### To do

- Add component examples. I tried to indicate this as comments in code and bolded in the documentation page. I did attempt to make examples of the buttons myself but deleted because I am unsure whether the `KButton.vue` and/or `KIconButton.vue` files themselves need changes

### Reference
https://docs.google.com/document/d/1ullAljzj7w813xpn2t6DUYzRKBLQsg7W4k6ahASLv6k/edit#


![screencapture-localhost-3000-buttons-2020-06-30-14_23_57](https://user-images.githubusercontent.com/6668144/86178597-731c6180-badd-11ea-8871-32a6017fbc98.png)
