### PR TITLE
Ensure that `KDropdownMenu`'s popover menu has the correct z-index.

### DIFF
--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -19,6 +19,7 @@
     <UiPopover
       v-if="!disabled"
       ref="popover"
+      z-index="12"
       :trigger="$refs.buttonContainer"
       :containFocus="false"
       :dropdownPosition="position"


### PR DESCRIPTION
The download menu was drawing underneath slideshow content in Kolibri, as reported here: https://github.com/learningequality/kolibri/issues/7175

This makes sure that when active, the popover menu renders above the slideshow content (at a z-index of 12 in accordance with the material design spec).