### PR TITLE
z-index needs a Number and refuses to parseInt() for you

### DIFF
--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -19,7 +19,7 @@
     <UiPopover
       v-if="!disabled"
       ref="popover"
-      z-index="12"
+      :z-index="12"
       :trigger="$refs.buttonContainer"
       :containFocus="false"
       :dropdownPosition="position"


### PR DESCRIPTION
I saw a bunch of console logs like this all over in Kolibri:

```
vue.runtime.esm.js:619 [Vue warn]: Invalid prop: type check failed for prop "zIndex". Expected Number with value 12, got String with value "12".

found in

---> <UiPopover> at design-system/lib/keen/UiPopover.vue
       <KDropdownMenu> at design-system/lib/KDropdownMenu.vue
         <CoreTable> at kolibri/core/assets/src/views/CoreTable.vue
           <UserTable> at kolibri/plugins/facility/assets/src/views/UserTable.vue
             <PaginatedListContainer> at kolibri/core/assets/src/views/PaginatedListContainer.vue
               <KPageContainer> at design-system/lib/KPageContainer.vue
                 <UserPage> at kolibri/plugins/facility/assets/src/views/UserPage/index.vue
                   <CoreBase> at kolibri/core/assets/src/views/CoreBase/index.vue
                     <Root>
```

Just need to use the `:` on the prop so the value we give is passed to the component as JS rather than a string.