### PR TITLE
change port to 4000 to avoid conflicts with kolibri in dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-watch": "yarn lint -m",
     "pregenerate": "node utils/pregenerate.js",
     "precompile-svgs": "rm -rf lib/KIcon/material-svg && node utils/precompileSvgs.js",
-    "_dev-only": "nuxt",
+    "_dev-only": "nuxt --port 4000",
     "_lint-watch-fix": "yarn lint -w -m",
     "_test": "jest",
     "_pregenerate-watch": "chokidar \"**/K*.vue\" -c \"node utils/pregenerate.js\""


### PR DESCRIPTION
You can't run KDS and Kolibri simultaneously locally because Kolibri web pack starts at 3000 - which is where nuxt runs.

This change will work until Kolibri builds 1000 plugins.