### PR TITLE
Button examples

### DIFF
--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -70,11 +70,13 @@
         <KButtonGroup style="margin-bottom: 8px;">
           <KButton text="Primary" :primary="true" appearance="raised-button" />
           <KButton text="Secondary" :primary="false" appearance="raised-button" />
+          <KIconButton tooltip="KIconButton" icon="plus" :primary="true" appearance="raised-button" />
         </KButtonGroup>
         <br>
         <KButtonGroup>
           <KButton text="Primary" :primary="true" appearance="flat-button" />
           <KButton text="Secondary" :primary="false" appearance="flat-button" />
+          <KIconButton tooltip="KIconButton" icon="plus" :primary="false" appearance="flat-button" />
         </KButtonGroup>
       </DocsShow>
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -51,11 +51,13 @@
           hyperlink-like appearance for deemphasized actions, or actions inline within text
         </li>
       </ul>
-      <!-- TODO: add a flat secondary icon button to these examples below. See Google doc for example -->
       <DocsShow>
-        <KButton text="Raised button" :primary="true" appearance="raised-button" />
-        <KButton text="Flat button" :primary="true" appearance="flat-button" />
-        <KButton text="Basic link" :primary="true" appearance="basic-link" />
+        <KButtonGroup>
+          <KButton text="Raised button" :primary="true" appearance="raised-button" />
+          <KButton text="Flat button" :primary="true" appearance="flat-button" />
+          <KIconButton tooltip="A tooltip" text="Flat button" :primary="false" icon="plus" appearance="flat-button" />
+          <KButton text="Basic link" :primary="true" appearance="basic-link" />
+        </KButtonGroup>
       </DocsShow>
 
       <p>
@@ -65,11 +67,15 @@
       </p>
 
       <DocsShow>
-        <KButton text="Primary" :primary="true" appearance="raised-button" />
-        <KButton text="Secondary" :primary="false" appearance="raised-button" />
+        <KButtonGroup style="margin-bottom: 8px;">
+          <KButton text="Primary" :primary="true" appearance="raised-button" />
+          <KButton text="Secondary" :primary="false" appearance="raised-button" />
+        </KButtonGroup>
         <br>
-        <KButton text="Primary" :primary="true" appearance="flat-button" />
-        <KButton text="Secondary" :primary="false" appearance="flat-button" />
+        <KButtonGroup>
+          <KButton text="Primary" :primary="true" appearance="flat-button" />
+          <KButton text="Secondary" :primary="false" appearance="flat-button" />
+        </KButtonGroup>
       </DocsShow>
 
       <p>
@@ -78,10 +84,14 @@
       <p>
         Buttons can also contain both text and an icon. Based on the need, the icon can come either before or after the text. This should be used sparingly - only when the icon significantly adds value to the meaning of the button.
       </p>
-      <!-- TODO: implement 2 examples - one with icon appearing before text, the other with and icon appearing after the text. See Google doc for examples -->
-      <p>
-        <b>TODO: INSERT BUTTONS WITH ICONS HERE</b>
-      </p>
+
+      <DocsShow>
+        <KButtonGroup>
+          <KButton text="Previous" :primary="true" icon="back" appearance="raised-button" />
+          <KButton text="Next" :primary="true" iconAfter="forward" appearance="raised-button" />
+        </KButtonGroup>
+      </DocsShow>
+
     </DocsPageSection>
     <DocsPageSection title="Label text" anchor="#labels">
       <ul>
@@ -122,9 +132,12 @@
         Always include a tooltip with the name of the action for icon buttons.
       </p>
       <!-- TODO: implement icon button that shows an example tooltip label on hover. See Google doc for example -->
-      <p>
-        <b>TODO: INSERT ICON BUTTON EXAMPLE HERE</b>
-      </p>
+      <DocsShow>
+        <KButtonGroup>
+          <KIconButton tooltip="Add" text="Flat button" :primary="true" icon="plus" appearance="raised-button" />
+          <KIconButton tooltip="Subtract" text="Flat button" :primary="false" icon="minus" appearance="flat-button" />
+        </KButtonGroup>
+      </DocsShow>
 
     </DocsPageSection>
 
@@ -133,9 +146,13 @@
         There are variations of buttons which can open a dropdown menu:
       </p>
       <!-- TODO: implement 3 examples: primary button, primary flat button, and secondary icon button that function as dropdowns. See Google doc for example -->
-      <p>
-        <b>TODO: INSERT DROPDOWN BUTTON EXAMPLES HERE</b>
-      </p>
+      <DocsShow>
+        <KDropdownMenu style="margin-right: 8px;" text="Primary" :primary="true" :options="['Primary', 'Dropdown']" appearance="raised-button" />
+        <KDropdownMenu style="margin-right: 8px;" text="Secondary" :primary="false" :options="['Secondary', 'Dropdown']" appearance="raised-button" />
+        <KDropdownMenu text="Icon dropdown" :primary="false" :options="['Icon button', 'Flat button', 'Dropdown']" appearance="raised-button">
+          <KIconButton slot="button" tooltip="Dropdown options" icon="optionsHorizontal" appearance="flat-button" :primary="false" />
+        </KDropdownMenu>
+      </DocsShow>
 
     </DocsPageSection>
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -133,10 +133,9 @@
       <p>
         Always include a tooltip with the name of the action for icon buttons.
       </p>
-      <!-- TODO: implement icon button that shows an example tooltip label on hover. See Google doc for example -->
       <DocsShow>
         <KButtonGroup>
-          <KIconButton tooltip="Add" text="Flat button" :primary="true" icon="plus" appearance="raised-button" />
+          <KIconButton tooltip="Add" text="Flat button" :primary="true" icon="plus" appearance="flat-button" />
           <KIconButton tooltip="Subtract" text="Flat button" :primary="false" icon="minus" appearance="flat-button" />
         </KButtonGroup>
       </DocsShow>

--- a/docs/pages/icons/IconBlock.vue
+++ b/docs/pages/icons/IconBlock.vue
@@ -1,8 +1,12 @@
 <template>
 
   <div class="block-wrapper">
-    <div class="innner-icon-block">
-      <KIcon :icon="aliasList[0]" class="icon" />
+    <div class="inner-icon-block">
+      <KIcon
+        v-if="aliasList && aliasList.length"
+        :icon="aliasList[0]"
+        class="icon"
+      />
     </div>
     <div class="code alias">
       <div v-for="(aliasItem, index) in aliasList" :key="index">
@@ -45,7 +49,7 @@
     min-height: 40px;
   }
 
-  .innner-icon-block {
+  .inner-icon-block {
     position: absolute;
     width: 40px;
     height: 40px;

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -6,7 +6,9 @@
       ref="buttonContainer"
       class="button-container dib"
     >
+      <slot name="button"></slot>
       <KButton
+        v-if="!$slots.button"
         ref="button"
         :text="text"
         :appearance="appearance"

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -17,6 +17,7 @@
       v-if="icon" 
       :icon="icon" 
       :color="iconColor"
+      class="prop-icon"
     />
 
     <slot v-if="$slots.default"></slot>
@@ -31,6 +32,7 @@
       v-if="iconAfter" 
       :icon="iconAfter"
       :color="iconColor"
+      class="prop-icon"
     />
 
     <!-- Dropdown arrow icon -->
@@ -167,6 +169,10 @@
   .dropdown-arrow {
     position: relative;
     top: 6px;
+  }
+
+  .prop-icon {
+    top: 3px;
   }
 
 </style>

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -9,6 +9,13 @@
     :aria-label="ariaLabel"
     v-on="$listeners"
   >
+    <UiTooltip
+      v-if="tooltip"
+      open-on="hover"
+      position="bottom"
+    >
+      {{ tooltip }}
+    </UiTooltip>
     <!-- UiIconButton used flexbox - 7px is the magic centering number -->
     <KIcon :icon="icon" :color="color" :style="iconStyles" />
   </KButton>
@@ -18,8 +25,11 @@
 
 <script>
 
+  import UiTooltip from '../keen/UiTooltip.vue';
+
   export default {
     name: 'KIconButton',
+    components: { UiTooltip },
     props: {
       appearance: {
         type: String,
@@ -49,6 +59,10 @@
       },
       ariaLabel: {
         type: String,
+      },
+      tooltip: {
+        type: String,
+        required: true,
       },
     },
     computed: {

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -60,9 +60,11 @@
       ariaLabel: {
         type: String,
       },
+      // TODO: This ought to be required
       tooltip: {
         type: String,
-        required: true,
+        required: false,
+        default: null,
       },
     },
     computed: {


### PR DESCRIPTION
Implements examples for the Buttons based on @jtamiace 's initial documentation docs for buttons and the feedback in the comments.

Includes code changes surrounding tooltips on KIconButtons and `icon` prop alignment in KButton.

Fixes https://github.com/learningequality/kolibri-design-system/issues/69