### PR TITLE
Kbutton icon color

### DIFF
--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -106,9 +106,13 @@
     },
     computed: {
       iconColor() {
-        return this.primary
-          ? this.$themeTokens.textInverted
-          : this.$themeTokens.primary;
+        if(this.primary) {
+          return this.appearance === 'raised-button'
+            ? this.$themeTokens.textInverted
+            : this.$themeTokens.primary;
+        } else {
+          return this.$themeTokens.text;
+        }
       },
       htmlTag() {
         // Necessary to allow basic links to be rendered as 'inline' instead of

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -106,7 +106,7 @@
     },
     computed: {
       iconColor() {
-        if(this.primary) {
+        if (this.primary) {
           return this.appearance === 'raised-button'
             ? this.$themeTokens.textInverted
             : this.$themeTokens.primary;

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -106,7 +106,7 @@
     },
     computed: {
       iconColor() {
-        return this.appearance === 'raised-button'
+        return this.primary
           ? this.$themeTokens.textInverted
           : this.$themeTokens.primary;
       },


### PR DESCRIPTION
The logic for "what color should the icon be" for a KButton w/ an icon or iconAfter prop did not account for all options.

Spin this up and add this to a page you can view in KDS to test it:

```
<label>Primary & Raised - White Text</label>
<KButton :primary="true" icon="facility" text="Facility" appearance="raised-button" />
<br /><br />
<label>Secondary & Raised - Text (Black) Text</label>
<KButton :primary="false" icon="facility" text="Facility" appearance="raised-button" />
<br /><br />
<label>Primary & Flat - Primary (Purple) Text</label>
<KButton :primary="true" icon="facility" text="Facility" appearance="flat-button" />
<br /><br />
<label>Secondary & Flat - Text (Black) Text</label>
<KButton :primary="false" icon="facility" text="Facility" appearance="flat-button" />
<br /><br />
```