### PR TITLE
Batch of bug fixes

### DIFF
--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -279,12 +279,12 @@
     width: 100%;
     max-width: $crumb-max-width;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    vertical-align: middle;
     // this is overriden with inline styles on the last
     // breadcrumb in the template
     text-decoration: underline;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
   }
 
   .breadcrumbs-dropdown-wrapper {

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -68,6 +68,7 @@
             <span
               class="breadcrumbs-crumb-text"
               dir="auto"
+              style="text-decoration: none;"
             >
               {{ crumb.text }}
             </span>
@@ -281,6 +282,9 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     vertical-align: middle;
+    // this is overriden with inline styles on the last
+    // breadcrumb in the template
+    text-decoration: underline;
   }
 
   .breadcrumbs-dropdown-wrapper {

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -83,14 +83,16 @@
       labelStyle() {
         let styles = {};
         let margins = 0;
+        let leftLtr = this.isRtl ? 'marginRight' : 'marginLeft';
+        let rightLtr = this.isRtl ? 'marginLeft' : 'marginRight';
         // Margin for icons - use em to match parent font size
         if (this.iconAfter || this.$slots['iconAfter']) {
-          styles['marginRight'] = '1.975em'; // scale with parent font size
+          styles[rightLtr] = '1.975em'; // scale with parent font size
           margins += 1.975;
         }
 
         if (this.icon || this.$slots['icon']) {
-          styles['marginLeft'] = '1.975em'; // scale with parent font size
+          styles[leftLtr] = '1.975em'; // scale with parent font size
           margins += 1.975;
         }
 

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -110,7 +110,7 @@
   .labeled-icon-wrapper {
     position: relative;
     display: inline-block;
-    max-width: 100%;
+    width: 100%;
   }
 
   .icon {

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -6,6 +6,7 @@
     :href="href"
     :download="download"
     dir="auto"
+    target="_blank" rel="noopener noreferrer"
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -6,7 +6,8 @@
     :href="href"
     :download="download"
     dir="auto"
-    target="_blank" rel="noopener noreferrer"
+    target="_blank"
+    rel="noopener noreferrer"
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >


### PR DESCRIPTION
Somewhat (for now) related Kolibri PR: https://github.com/learningequality/kolibri/pull/7360 - somewhat related in that the fixes below don't depend on that PR and that PR doesn't (yet) depend on this one.

- 03ce517 Fixes: https://github.com/learningequality/kolibri-design-system/issues/81 - where KLabeledIcon margins were off in RTL languages.
- 29ba2b9 Fixes: https://github.com/learningequality/kolibri-design-system/issues/25 - KExternalLink now securely opens in a new tab
- f5a35d5 Fixes: https://github.com/learningequality/kolibri/issues/7355 - Breadcrumbs without underlines
- 3ce9698 Fixes: https://github.com/learningequality/kolibri/issues/7378 - KLabeledIcon margins/sizing wrap issue


