### PR TITLE
bump to beta6

### DIFF
--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -110,7 +110,7 @@
   .labeled-icon-wrapper {
     position: relative;
     display: inline-block;
-    width: 100%;
+    max-width: 100%;
   }
 
   .icon {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "0.2.0-beta5",
+  "version": "0.2.0-beta6",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "license": "MIT",


### PR DESCRIPTION
Bump so that Kolibri pulls the proper latest and doesn't use cached version.