### PR TITLE
Fix display for `KLabeledIcon` with `iconAfter` & overflowing text

### DIFF
--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -125,6 +125,9 @@
 
   .label {
     display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: top;
   }
 
   .debug-warning > svg {


### PR DESCRIPTION
## Summary

Using a `KLabeledIcon` component with the `iconAfter` property and label or slot text that overflows the maximum width of the `KLabeledIcon` causes the icon to overlap the text.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/389782/89586027-8de0a500-d804-11ea-9538-857e3e79a497.png)

After:
![image](https://user-images.githubusercontent.com/389782/89588198-caae9b00-d808-11ea-8ed7-c22e4de9a48c.png)
