### PR TITLE
KExternalLink to *not* open in new tab (for now)

### DIFF
--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -6,8 +6,6 @@
     :href="href"
     :download="download"
     dir="auto"
-    target="_blank"
-    rel="noopener noreferrer"
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >


### PR DESCRIPTION
Unexpected side effect of opening KExternalLinks in a new tab is fixed.

Related to https://github.com/learningequality/kolibri/issues/7482 and https://github.com/learningequality/kolibri/issues/7480