### PR TITLE
Adds `add` icon `add_circle_outline`

### DIFF
--- a/lib/KIcon/iconDefinitions.js
+++ b/lib/KIcon/iconDefinitions.js
@@ -277,6 +277,7 @@ const KolibriIcons = {
   dragHorizontal: { icon: require('./precompiled-icons/le/drag_horizontal.vue').default },
   classes: { icon: require('./precompiled-icons/le/class.vue').default },
   email: { icon: require('./precompiled-icons/material-icons/mail_outline/baseline.vue').default },
+  sidebar: { icon: require('./precompiled-icons/material-icons/vertical_split/baseline.vue').default },
 };
 
 export { KolibriIcons };

--- a/lib/KIcon/iconDefinitions.js
+++ b/lib/KIcon/iconDefinitions.js
@@ -242,7 +242,9 @@ const KolibriIcons = {
     rtlFlip: true,
   },
   systemUpdate: { icon: require('./precompiled-icons/material-icons/build/baseline.vue').default },
-  add: { icon: require('./precompiled-icons/material-icons/add_circle_outline/baseline.vue').default },
+  add: {
+    icon: require('./precompiled-icons/material-icons/add_circle_outline/baseline.vue').default,
+  },
   remove: { icon: require('./precompiled-icons/mdi/minus-circle-outline.vue').default },
   emptyTopic: {
     icon: require('./precompiled-icons/material-icons/folder_open/baseline.vue').default,
@@ -277,7 +279,9 @@ const KolibriIcons = {
   dragHorizontal: { icon: require('./precompiled-icons/le/drag_horizontal.vue').default },
   classes: { icon: require('./precompiled-icons/le/class.vue').default },
   email: { icon: require('./precompiled-icons/material-icons/mail_outline/baseline.vue').default },
-  sidebar: { icon: require('./precompiled-icons/material-icons/vertical_split/baseline.vue').default },
+  sidebar: {
+    icon: require('./precompiled-icons/material-icons/vertical_split/baseline.vue').default,
+  },
 };
 
 export { KolibriIcons };

--- a/lib/KIcon/iconDefinitions.js
+++ b/lib/KIcon/iconDefinitions.js
@@ -242,6 +242,7 @@ const KolibriIcons = {
     rtlFlip: true,
   },
   systemUpdate: { icon: require('./precompiled-icons/material-icons/build/baseline.vue').default },
+  add: { icon: require('./precompiled-icons/material-icons/add_circle_outline/baseline.vue').default },
   remove: { icon: require('./precompiled-icons/mdi/minus-circle-outline.vue').default },
   emptyTopic: {
     icon: require('./precompiled-icons/material-icons/folder_open/baseline.vue').default,

--- a/lib/KIcon/iconDefinitions.js
+++ b/lib/KIcon/iconDefinitions.js
@@ -276,6 +276,7 @@ const KolibriIcons = {
   collapseAll: { icon: require('./precompiled-icons/mdi/collapse-all.vue').default },
   dragHorizontal: { icon: require('./precompiled-icons/le/drag_horizontal.vue').default },
   classes: { icon: require('./precompiled-icons/le/class.vue').default },
+  email: { icon: require('./precompiled-icons/material-icons/mail_outline/baseline.vue').default },
 };
 
 export { KolibriIcons };

--- a/lib/KIcon/index.vue
+++ b/lib/KIcon/index.vue
@@ -23,7 +23,7 @@
         type: String,
         required: true,
         validator(value) {
-          if(Object.keys(KolibriIcons).includes(value)) {
+          if (Object.keys(KolibriIcons).includes(value)) {
             return true;
           } else {
             /* eslint-disable-next-line no-console */

--- a/lib/KIcon/index.vue
+++ b/lib/KIcon/index.vue
@@ -26,6 +26,7 @@
           if(Object.keys(KolibriIcons).includes(value)) {
             return true;
           } else {
+            /* eslint-disable-next-line no-console */
             console.error(`KIcon: No icon defined for token: ${value}`);
             return false;
           }

--- a/lib/KIcon/index.vue
+++ b/lib/KIcon/index.vue
@@ -23,7 +23,12 @@
         type: String,
         required: true,
         validator(value) {
-          return Object.keys(KolibriIcons).includes(value);
+          if(Object.keys(KolibriIcons).includes(value)) {
+            return true;
+          } else {
+            console.error(`KIcon: No icon defined for token: ${value}`);
+            return false;
+          }
         },
       },
       /**

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -13,6 +13,7 @@
       v-if="tooltip"
       open-on="hover"
       position="bottom"
+      style="z-index: 24;"
     >
       {{ tooltip }}
     </UiTooltip>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "0.2.1",
+  "version": "0.2.2-beta",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3930,12 +3930,7 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001027.tgz#45dce6c61128324c4534e18ceff6e58e8de76694"
   integrity sha512-Ublzr9IN2X91lTvJzehRUlK+hREae1Hi+0TIh7rH5fAcsuPWycwBAszhRGF22gf5xbDXXUdYQ6fSfPSQEqQhkw==
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001016, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001023:
-  version "1.0.30001122"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001122.tgz"
-  integrity sha512-pxjw28CThdrqfz06nJkpAc5SXM404TXB/h5f4UJX+rrXJKE/1bu/KAILc2AY+O6cQIFtRjV9qOR2vaEp9LDGUA==
-
-caniuse-lite@^1.0.30001043:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001016, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001023, caniuse-lite@^1.0.30001043:
   version "1.0.30001122"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001122.tgz"
   integrity sha512-pxjw28CThdrqfz06nJkpAc5SXM404TXB/h5f4UJX+rrXJKE/1bu/KAILc2AY+O6cQIFtRjV9qOR2vaEp9LDGUA==


### PR DESCRIPTION
Fixes https://github.com/learningequality/kolibri-design-system/issues/109

Adds the missing icons:

- KDS Token: `sidebar` - https://material.io/resources/icons/?search=vertical_split&style=baseline
- KDS Token: `email` - https://material.io/resources/icons/?search=mail&icon=mail_outline&style=baseline
- KDS Token: `add` - https://material.io/resources/icons/?search=add&icon=add_circle_outline&style=baseline

Also:

- Bumps the version of KDS to `v0.2.2-beta`.