### PR TITLE
update link usage

### DIFF
--- a/docs/common/DocsColorBlock.vue
+++ b/docs/common/DocsColorBlock.vue
@@ -6,9 +6,12 @@
       <code>{{ name }}</code><DocsAnchorTarget v-if="definition" :anchor="anchor" />
     </div>
     <div class="code value">
-      <DocsInternalLink v-if="isToken && showTokenCrossLink" :href="tokenAnchor">
-        <code>{{ tokenSource }}</code>
-      </DocsInternalLink>
+      <DocsInternalLink
+        v-if="isToken && showTokenCrossLink"
+        code
+        :text="tokenSource"
+        :href="tokenAnchor"
+      />
       <code v-else-if="isToken">{{ tokenSource }}</code>
       <code v-else>{{ value }}</code>
     </div>

--- a/docs/pages/KSwitch.vue
+++ b/docs/pages/KSwitch.vue
@@ -12,9 +12,7 @@
         A switch toggle is used to select and execute an action instantly, in real time. A switch is toggled successfully when the switch thumb slides to the other side of the track upon click or press.
       </p>
       <p>
-        For selections that require a confirmation to execute and are housed in a form, use <DocsInternalLink href="/KCheckbox" code>
-          KCheckbox
-        </DocsInternalLink> component instead.
+        For selections that require a confirmation to execute and are housed in a form, use <DocsInternalLink code text="KCheckbox" href="/KCheckbox" /> component instead.
       </p>
     </DocsPageSection>
 
@@ -33,27 +31,19 @@
       <ul>
         <li>
           Thumb ON color:
-          <DocsInternalLink href="/colors#palette-green-v_500" code>
-            palette.green.v_500
-          </DocsInternalLink>
+          <DocsInternalLink code text="palette.green.v_500" href="/colors#palette-green-v_500" />
         </li>
         <li>
           Track ON color:
-          <DocsInternalLink href="/colors#palette-green-v_200" code>
-            palette.green.v_200
-          </DocsInternalLink>
+          <DocsInternalLink code text="palette.green.v_200" href="/colors#palette-green-v_200" />
         </li>
         <li>
           Thumb OFF color:
-          <DocsInternalLink href="/colors#palette-grey-v_400" code>
-            palette.grey.v_400
-          </DocsInternalLink>
+          <DocsInternalLink code text="palette.grey.v_400" href="/colors#palette-grey-v_400" />
         </li>
         <li>
           Track OFF color:
-          <DocsInternalLink href="/colors#palette-grey-v_50" code>
-            palette.grey.v_50
-          </DocsInternalLink>
+          <DocsInternalLink code text="palette.grey.v_50" href="/colors#palette-grey-v_50" />
         </li>
       </ul>
     </DocsPageSection>

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -40,17 +40,11 @@
       </p>
       <p>
         Color tokens are by themselves abstract and defined by a purpose, not a color value. A
-        <DocsInternalLink href="#theme">
-          theme
-        </DocsInternalLink>
+        <DocsInternalLink text="theme" href="#theme" />
         makes them concrete by mapping them to specific
-        <DocsInternalLink href="#brand">
-          brand colors
-        </DocsInternalLink>
+        <DocsInternalLink text="brand colors" href="#brand" />
         and
-        <DocsInternalLink href="#palette">
-          palette colors
-        </DocsInternalLink>.
+        <DocsInternalLink text="palette colors" href="#palette" />.
       </p>
       <p>
         When using tokens, it's very important to use them because of their purposes, not because of their color values. Multiple tokens will commonly share a single color value.

--- a/docs/pages/errors/index.vue
+++ b/docs/pages/errors/index.vue
@@ -96,13 +96,13 @@
       </h3>
       <p>
         Banners are appended to the app bar and notify the user about global system errors and/or notifications that affect the whole app experience.
-      </p>      
+      </p>
       <img src="./banner.png">
       <h3>
         Error summary
       </h3>
       <p>
-        Error summaries should appear at the top of the page and use an alert component. Use them in forms or for page-level errors that are not associated with a specific component or location on the page. 
+        Error summaries should appear at the top of the page and use an alert component. Use them in forms or for page-level errors that are not associated with a specific component or location on the page.
       </p>
       <img src="./alert.png">
       <h3>
@@ -162,7 +162,7 @@
         Progressive disclosure
       </h3>
       <p>
-        Error messages are important, but should not overwhelm the user. Apply the concept of <DocsExternalLink href="https://www.interaction-design.org/literature/topics/progressive-disclosure" text="progressive disclosure" /> to prevent surprises and frustration. 
+        Error messages are important, but should not overwhelm the user. Apply the concept of <DocsExternalLink href="https://www.interaction-design.org/literature/topics/progressive-disclosure" text="progressive disclosure" /> to prevent surprises and frustration.
       </p>
       <p>
         For error messages, this means not showing all error messages at once. Show enough information for the user to discover where the problem is, and present the detail they need at the moment of resolving the error.

--- a/docs/pages/errors/index.vue
+++ b/docs/pages/errors/index.vue
@@ -25,9 +25,7 @@
 
     <DocsPageSection title="Language" anchor="#language">
       <p>
-        Follow the <DocsInternalLink href="/writing">
-          writing guidelines
-        </DocsInternalLink> with a special focus on clear, concise, and natural language. Explain causes of errors if it will help the user resolve their issue, but do not use complex technical terms and run-on explanations.
+        Follow the <DocsInternalLink text="writing guidelines" href="/writing" /> with a special focus on clear, concise, and natural language. Explain causes of errors if it will help the user resolve their issue, but do not use complex technical terms and run-on explanations.
       </p>
       <p>
         Error messages should also be actionable. Offer the solution as an action when possible and make sure the action label is specific to the outcome. If including an action isn’t possible, then briefly explain how the user can fix their problem.
@@ -179,9 +177,7 @@
 
     <DocsPageSection title="Accessibility" anchor="#accessibility">
       <p>
-        Do not use red color as the only indicator for errors. Color alone is not sufficient to indicate an error state. Errors must be accompanied by an additional visual indicator such as an icon as mentioned in <DocsInternalLink href="/errors#components">
-          inline error messages
-        </DocsInternalLink>.
+        Do not use red color as the only indicator for errors. Color alone is not sufficient to indicate an error state. Errors must be accompanied by an additional visual indicator such as an icon as mentioned in <DocsInternalLink text="inline error messages" href="/errors#components" />.
       </p>
       <p>
         Important information to resolve errors should also be keyboard accessible. Avoid using snackbars and tooltips as the primary way to access this critical information.

--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -15,13 +15,7 @@
         The design system includes both documentation design patterns and a shared front-end UI library. Together, these provide solutions to common design and implementation needs in Kolibri products.
       </p>
       <p>
-        If the design system is failing to achieve the objectives above, it needs to be updated. Your contributions and input are appreciated. For more information, see the <DocsInternalLink href="#updates">
-          Updates
-        </DocsInternalLink> section below, the <DocsExternalLink href="https://github.com/learningequality/kolibri-design-system">
-          GitHub repository
-        </DocsExternalLink>, or the <DocsExternalLink href="https://www.notion.so/learningequality/Kolibri-Design-System-for-LE-products-976ea82b50f844ea9149a7abed497ea9">
-          Notion project
-        </DocsExternalLink>.
+        If the design system is failing to achieve the objectives above, it needs to be updated. Your contributions and input are appreciated. For more information, see the <DocsInternalLink text="Updates" href="#updates" /> section below, the <DocsExternalLink text="GitHub repository" href="https://github.com/learningequality/kolibri-design-system" />, or the <DocsExternalLink text="Notion project" href="https://www.notion.so/learningequality/Kolibri-Design-System-for-LE-products-976ea82b50f844ea9149a7abed497ea9" />.
       </p>
     </DocsPageSection>
     <DocsPageSection title="Scope" anchor="#scope">
@@ -66,16 +60,10 @@
       <ul>
         <li>Share ideas or concerns with Devon, Jessica, Khang, and Jacob directly, or file issues in this repo.</li>
         <li>
-          Submit a <DocsExternalLink href="https://github.com/learningequality/kolibri-design-system/pulls">
-            pull request
-          </DocsExternalLink> or <DocsExternalLink href="https://github.com/learningequality/kolibri-design-system/issues">
-            issue
-          </DocsExternalLink> to the GitHub repo
+          Submit a <DocsExternalLink text="pull request" href="https://github.com/learningequality/kolibri-design-system/pulls" /> or <DocsExternalLink text="issue" href="https://github.com/learningequality/kolibri-design-system/issues" /> to the GitHub repo
         </li>
         <li>
-          Leave a comment in the <DocsExternalLink href="https://www.notion.so/learningequality/Kolibri-Design-System-for-LE-products-976ea82b50f844ea9149a7abed497ea9">
-            Notion project
-          </DocsExternalLink>
+          Leave a comment in the <DocsExternalLink text="Notion project" href="https://www.notion.so/learningequality/Kolibri-Design-System-for-LE-products-976ea82b50f844ea9149a7abed497ea9" />
         </li>
       </ul>
     </DocsPageSection>

--- a/docs/pages/layout/index.vue
+++ b/docs/pages/layout/index.vue
@@ -20,9 +20,7 @@
       </h3>
       <ul>
         <li>
-          Background color: <DocsInternalLink href="/colors#tokens-surface" code>
-            tokens.surface
-          </DocsInternalLink> (<code>#ffffff</code>)
+          Background color: <DocsInternalLink code text="tokens.surface" href="/colors#tokens-surface" /> (<code>#ffffff</code>)
         </li>
         <li>Default border radius: 4px</li>
         <li>Elevation: 1dp</li>
@@ -51,9 +49,7 @@
       <ul>
         <li>Width: 1px</li>
         <li>
-          Color: <DocsInternalLink href="/colors#tokens-fineLine" code>
-            tokens.fineline
-          </DocsInternalLink> (<code>#dedede</code>)
+          Color: <DocsInternalLink code text="tokens.fineline" href="/colors#tokens-fineLine" /> (<code>#dedede</code>)
         </li>
       </ul>
     </DocsPageSection>

--- a/docs/pages/menus/index.vue
+++ b/docs/pages/menus/index.vue
@@ -86,28 +86,20 @@
         <li>Min width: 128px</li>
         <li>Menu elevation: 4dp</li>
         <li>
-          Background color: 
-          <DocsInternalLink href="/colors#palette.white" code>
-            tokens.surface
-          </DocsInternalLink>
+          Background color:
+          <DocsInternalLink code text="tokens.surface" href="/colors#palette.white" />
         </li>
         <li>
-          Option text color: 
-          <DocsInternalLink href="/colors#palette-grey-v_100" code>
-            tokens.text
-          </DocsInternalLink>
+          Option text color:
+          <DocsInternalLink code text="tokens.text" href="/colors#palette-grey-v_100" />
         </li>
         <li>
-          Option text hover color: 
-          <DocsInternalLink href="/colors#palette-grey-v_100" code>
-            palette.grey.v_100
-          </DocsInternalLink>
+          Option text hover color:
+          <DocsInternalLink code text="palette.grey.v_100" href="/colors#palette-grey-v_100" />
         </li>
         <li>
-          Iconography color: 
-          <DocsInternalLink href="/colors#palette-grey-v_900" code>
-            palette.grey.v_900
-          </DocsInternalLink>
+          Iconography color:
+          <DocsInternalLink code text="palette.grey.v_900" href="/colors#palette-grey-v_900" />
         </li>
       </ul>
       <h3>Dropdown menu</h3>

--- a/docs/pages/textfields/index.vue
+++ b/docs/pages/textfields/index.vue
@@ -180,34 +180,24 @@
         <li>Min width: 252px</li>
         <li>Corner radius: 2px</li>
         <li>
-          Fill color: 
-          <DocsInternalLink href="/colors#palette-grey-v_400" code>
-            palette.grey.v_400
-          </DocsInternalLink>, 0.25 opacity
+          Fill color:
+          <DocsInternalLink code text="palette.grey.v_400" href="/colors#palette-grey-v_400" />, 0.25 opacity
         </li>
         <li>
           Bottom stroke color:
-          <DocsInternalLink href="/colors#palette-grey-v_500" code>
-            palette.grey.v_500
-          </DocsInternalLink>
+          <DocsInternalLink code text="palette.grey.v_500" href="/colors#palette-grey-v_500" />
         </li>
         <li>
           Bottom stroke focused color:
-          <DocsInternalLink href="/colors#tokens.primary" code>
-            tokens.primary
-          </DocsInternalLink>
+          <DocsInternalLink code text="tokens.primary" href="/colors#tokens.primary" />
         </li>
         <li>
-          Label text color: 
-          <DocsInternalLink href="/colors#palette-grey-v_300" code>
-            palette.grey.v_300
-          </DocsInternalLink>
+          Label text color:
+          <DocsInternalLink code text="palette.grey.v_300" href="/colors#palette-grey-v_300" />
         </li>
         <li>
           Focused text color:
-          <DocsInternalLink href="/colors#tokens.primary" code>
-            tokens.text
-          </DocsInternalLink>
+          <DocsInternalLink code text="tokens.text" href="/colors#tokens.primary" />
         </li>
       </ul>
     </DocsPageSection>


### PR DESCRIPTION
This PR changes nearly all instances of internal and external links to use props instead of slots, from this form:

```html
Follow the <DocsExternalLink href="https://material.io/design">
  Material design guidelines
</DocsExternalLink>.
```

to this form

```html
Follow the <DocsExternalLink text="Material design guidelines" href="https://material.io/design" />.
```

This has two advantages:

A) the previous form causes undesirable underline behaviors:

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/94084633-c8090480-fdba-11ea-847f-6353df465a94.png)  | <img width="473" alt="image" src="https://user-images.githubusercontent.com/2367265/94084498-8aa47700-fdba-11ea-9170-013d03f17203.png"> |


B) The code is more concise.


Note while possibly desirable for consistency with `<a href="...">...</a>`, it is not possible to write this form:

```html
Follow the <DocsExternalLink href="https://material.io/design">Material design guidelines</DocsExternalLink>.
```

It appears that Vue-ESLint [always inserts additional whitespace](https://stackoverflow.com/questions/60286109/vue-cli-eslint-injects-additional-whitespace-into-multi-line-spans), and I can't determine any way of disabling this behavior.

