### PR TITLE
KIconButton - Use "zIndex" property instead of "style" in UiTooltip

### DIFF
--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -13,7 +13,7 @@
       v-if="tooltip"
       open-on="hover"
       position="bottom"
-      style="z-index: 24;"
+      zIndex="24"
     >
       {{ tooltip }}
     </UiTooltip>


### PR DESCRIPTION
@nucleogenesis Please see https://github.com/learningequality/studio/pull/2280