### PR TITLE
Clipboard icon should be outline not baseline

### DIFF
--- a/lib/KIcon/iconDefinitions.js
+++ b/lib/KIcon/iconDefinitions.js
@@ -154,7 +154,7 @@ const KolibriIcons = {
     icon: require('./precompiled-icons/material-icons/more_horiz/baseline.vue').default,
   },
   clipboard: {
-    icon: require('./precompiled-icons/material-icons/content_paste/baseline.vue').default,
+    icon: require('./precompiled-icons/material-icons/content_paste/outline.vue').default,
     rtlFlip: true,
   },
   copy: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "0.2.2-beta2",
+  "version": "0.2.2-beta3",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "license": "MIT",


### PR DESCRIPTION
Addresses: https://www.notion.so/learningequality/Copy-to-clipboard-icon-in-toolbar-should-be-outline-not-filled-5fcdf036bc51441697fc29b8cfcae257 because I put the wrong icon.

Also bumps the beta version in package.json to ensure Studio works from the correct code and doesn't use a cached version.