### PR TITLE
Fix invalid property type check

### DIFF
--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -11,9 +11,9 @@
   >
     <UiTooltip
       v-if="tooltip"
+      :zIndex="24"
       open-on="hover"
       position="bottom"
-      zIndex="24"
     >
       {{ tooltip }}
     </UiTooltip>


### PR DESCRIPTION
Fixes

```
Invalid prop: type check failed for prop "zIndex". Expected Number with value 24, got String with value "24".
```