### PR TITLE
Bump version 0.2.2-beta4 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "0.2.2-beta3",
+  "version": "0.2.2-beta4",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "license": "MIT",


### PR DESCRIPTION
Gets #122 in for improved Studio debugging (no more console spam).