### PR TITLE
Add boolean prop, 'openInNewTab' to KExternalLink

### DIFF
--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -5,6 +5,8 @@
     :class="buttonClasses"
     :href="href"
     :download="download"
+    :openInNewTab="openInNewTab"
+    :target="openInNewTab ? '_blank' : false"
     dir="auto"
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
@@ -68,6 +70,13 @@
        */
       iconAfter: {
         type: String,
+        required: false,
+      },
+      /**
+       * If provided, opens link in new tab
+       */
+      openInNewTab: {
+        type: Boolean,
         required: false,
       },
     },

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -77,7 +77,7 @@
        */
       openInNewTab: {
         type: Boolean,
-        required: false,
+        default: false,
       },
     },
     data() {


### PR DESCRIPTION
**Summary:**
- Added boolean prop `openInNewTab` to `KExternalLink`
- Added `:target` to anchor tag in `<template>` to open up new tab if `openInNewTab` is given `true`

Fixes #94 

**Testing:**
- Tested with Chrome on MacOSX, but not yet with other versions of Kolibri.
![Screen-Recording-2020-11-30-at-7 28 34-PM](https://user-images.githubusercontent.com/13563002/100694128-392ce100-3343-11eb-86e0-497edebe3d5b.gif)
