### PR TITLE
Material background on KTextbox

### DIFF
--- a/lib/keen/UiTextbox.vue
+++ b/lib/keen/UiTextbox.vue
@@ -103,6 +103,12 @@
           </slot>
         </div>
 
+        <!-- Placeholder to keep the text height spacing in place even when
+          not showing any errors -->
+        <div v-else class="ui-textbox-feedback-text">
+          &nbsp;
+        </div>
+
         <div v-if="maxlength" class="ui-textbox-counter">
           {{ valueLength + '/' + maxlength }}
         </div>
@@ -433,7 +439,8 @@
         &.is-inline {
           color: $ui-input-label-color; // So the hover styles don't override it
           cursor: text;
-          transform: translateY($ui-input-label-top--inline) scale(1.1);
+          // 1em here is custom to keep text centered
+          transform: translateY(1em) scale(1.1);
         }
 
         &.is-floating {
@@ -490,8 +497,10 @@
     display: flex;
     flex-direction: column-reverse;
     width: 100%;
-    padding: 0;
+    padding: 4px 0 0 0;
     margin: 0;
+    background: #e9e9e9;
+    border-radius: 4px 4px 0 0;
   }
 
   .ui-textbox-icon-wrapper {
@@ -509,7 +518,7 @@
   }
 
   .ui-textbox-label-text {
-    margin-bottom: $ui-input-label-margin-bottom;
+    margin: 0 8px 0;
     font-size: $ui-input-label-font-size;
     line-height: $ui-input-label-line-height;
     color: $ui-input-label-color;
@@ -522,7 +531,7 @@
   .ui-textbox-textarea {
     display: block;
     width: 100%;
-    padding: 0;
+    padding: 0 0 0 8px;
     margin: 0;
     font-size: $ui-input-text-font-size;
     font-weight: normal;

--- a/lib/keen/UiTextbox.vue
+++ b/lib/keen/UiTextbox.vue
@@ -36,7 +36,7 @@
           :readonly="readonly"
           :required="required"
           :step="stepValue"
-          :style="isActive ? { borderBottomColor: $themeTokens.primary } : {}"
+          :style="isActive ? { borderBottomColor: $themeTokens.primaryDark } : {}"
           :tabindex="tabindex"
           :type="type"
           :value="value"
@@ -67,7 +67,7 @@
           :required="required"
 
           :rows="rows"
-          :style="isActive ? { borderBottomColor: $themeTokens.primary } : {}"
+          :style="isActive ? { borderBottomColor: $themeTokens.primaryDark } : {}"
 
           :tabindex="tabindex"
 
@@ -499,7 +499,6 @@
     width: 100%;
     padding: 4px 0 0 0;
     margin: 0;
-    background: #e9e9e9;
     border-radius: 4px 4px 0 0;
   }
 

--- a/lib/keen/UiTextbox.vue
+++ b/lib/keen/UiTextbox.vue
@@ -84,14 +84,14 @@
           v-if="label || $slots.default"
           class="ui-textbox-label-text"
           :class="labelClasses"
-          :style="isActive ? { color: $themeTokens.primary } : {}"
+          :style="isActive ? { color: $themeTokens.primaryDark } : {}"
         >
           <slot>{{ label }}</slot>
         </div>
       </label>
 
       <div v-if="hasFeedback || maxlength" class="ui-textbox-feedback">
-        <div v-if="showError" class="ui-textbox-feedback-text">
+        <div v-if="showError" class="ui-textbox-feedback-text" style="{ color: $themeTokens.error }">
           <slot name="error">
             {{ error }}
           </slot>

--- a/lib/styles/colorsDefault.js
+++ b/lib/styles/colorsDefault.js
@@ -20,7 +20,7 @@ export const defaultTokenMapping = {
   appBarFullscreenDark: 'black',
 
   // general semantic colors
-  error: 'palette.red.v_700',
+  error: 'palette.red.v_800',
   success: 'palette.green.v_700',
 
   // Kolibri-specific semantic colors


### PR DESCRIPTION
This is a draft for now - this should not be merged until KSelect is also available in KDS and has the same or similar styles applied.

Fixes #124
Fixes #167 

- Gray #e9e9e9 background on KTextbox
- CSS changes to align things roughly like the sample field https://material.io/components/text-fields
- Changed the value given to the `translate()` CSS function to ensure the label is centered (original value pushed the label to the baseline)
- Add a `&nbsp;` empty div fallback for the part of the DOM flow where the error/help message would show. A counter shows on the same horizontal line but is `position: absolute;` so when there is no help/error text, subsequent elements are closer to the previous one than they ought to be and they look squished. 

I took this first screenshot w/ a delay feature on my screenshot extension so I could properly focus the field to show that the theme colors work still.

![screenshot-localhost_8000-2020 12 02-13_55_14](https://user-images.githubusercontent.com/6356129/100936241-10712c80-34a6-11eb-9709-d7660340c8cd.png)

These are just a few more examples with error messages, text, no text.+

![screenshot-localhost_8000-2020 12 02-13_50_31](https://user-images.githubusercontent.com/6356129/100936040-c6884680-34a5-11eb-9389-3bec328ff4e1.png)
![screenshot-localhost_8000-2020 12 02-13_52_40](https://user-images.githubusercontent.com/6356129/100936041-c720dd00-34a5-11eb-9d90-e5c69463b49d.png)
![screenshot-localhost_8000-2020 12 02-13_52_59](https://user-images.githubusercontent.com/6356129/100936043-c7b97380-34a5-11eb-86cb-61124115470b.png)
