### PR TITLE
<KExternalLink> final fixes for icons and margins

### DIFF
--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -17,7 +17,7 @@
       <KIcon
         v-if="openInNewTab"
         icon="openNewTab"
-        :style="iconStyle"
+        style="top: 4px;"
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
     </slot>
@@ -80,16 +80,6 @@
           } else {
             styles['marginRight'] = '8px';
           }
-        }
-        return { ...styles };
-      },
-      /**
-       * Changes icon direction according to language of text of URL
-       */
-      iconStyle() {
-        let styles = { top: '4px' };
-        if (this.text === this.href) {
-          styles['transform'] = 'scaleX(1)';
         }
         return { ...styles };
       },

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -12,7 +12,23 @@
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >
+    <slot name="icon">
+      <KIcon
+        v-if="icon"
+        :icon="icon"
+        style="top: 4px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+    </slot>
     <span class="link-text" :style="spanStyle">{{ text }}</span>
+    <slot name="iconAfter">
+      <KIcon
+        v-if="iconAfter"
+        :icon="iconAfter"
+        style="top: 4px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+    </slot>
     <slot name="openInNewTab">
       <KIcon
         v-if="openInNewTab"
@@ -58,6 +74,20 @@
         type: Boolean,
         default: false,
       },
+      /**
+       * If provided, shows a KIcon in front of the text
+       */
+      icon: {
+        type: String,
+        required: false,
+      },
+      /**
+       * If provided, shows a KIcon after the text
+       */
+      iconAfter: {
+        type: String,
+        required: false,
+      },
     },
     data() {
       return {
@@ -66,25 +96,34 @@
     },
     computed: {
       /**
-       * If link opens in new tab, add 8px margin between the icon and the text
+       * If link opens in new tab or if icon is provided, add 8px margin between the icon and the text
        */
       spanStyle() {
         let styles = {};
-        if (this.openInNewTab) {
+        if (this.openInNewTab || this.icon) {
           if (this.isRtl) {
+            // If RTL-language, but English link, displays correct margins
             styles['marginRight'] = '8px';
+            // Checks to see if link for new tab is in same dir as page lang
             if (this.text !== this.href) {
               styles['marginRight'] = '0px';
               styles['marginLeft'] = '8px';
             }
           } else {
-            styles['marginRight'] = '8px';
+            if (this.text === this.href) {
+              styles['marginRight'] = '8px';
+            } else {
+              styles['marginLeft'] = '8px';
+            }
           }
+        }
+
+        if (this.iconAfter) {
+          styles['marginRight'] = '8px';
         }
         return { ...styles };
       },
     },
-    methods: {},
   };
 
 </script>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -87,16 +87,14 @@
        * Changes icon direction according to language of text of URL
        */
       iconStyle() {
-        let styles = { 'top': '4px' };
+        let styles = { top: '4px' };
         if (this.text === this.href) {
           styles['transform'] = 'scaleX(1)';
         }
         return { ...styles };
-      }
+      },
     },
-    methods: {
-
-    }
+    methods: {},
   };
 
 </script>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -79,7 +79,7 @@
               styles['marginLeft'] = '8px';
             }
           } else {
-            styles['marginLeft'] = '8px';
+            styles['marginRight'] = '8px';
           }
         }
         return { ...styles };

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -17,7 +17,7 @@
       <KIcon
         v-if="openInNewTab"
         icon="openNewTab"
-        style="top: 4px;"
+        :style="iconStyle"
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
     </slot>
@@ -72,7 +72,6 @@
         let styles = {};
         if (this.openInNewTab) {
           if (this.isRtl) {
-            // If RTL-language, but English link, displays correct margins
             styles['marginRight'] = '8px';
             if (this.text !== this.href) {
               styles['marginRight'] = '0px';
@@ -84,7 +83,20 @@
         }
         return { ...styles };
       },
+      /**
+       * Changes icon direction according to language of text of URL
+       */
+      iconStyle() {
+        let styles = { 'top': '4px' };
+        if (this.text === this.href) {
+          styles['transform'] = 'scaleX(1)';
+        }
+        return { ...styles };
+      }
     },
+    methods: {
+
+    }
   };
 
 </script>


### PR DESCRIPTION
@nucleogenesis - it's all fixed now! Here is a summary of what was updated:

### In either LTR or RTL languages, the direction of the icon matches the language of the text of the link
|English text in English|Arabic text in Arabic|
|--|--|
|![Screen Shot 2021-01-05 at 9 57 34 AM](https://user-images.githubusercontent.com/13563002/103700650-a262ce00-4f59-11eb-862a-40b1bc08be60.png)|![Screen Shot 2021-01-05 at 1 35 25 PM](https://user-images.githubusercontent.com/13563002/103701510-fd48f500-4f5a-11eb-8419-499d4a722ea0.png)|

|Now: English text in Arabic|(Previously: English text in RTL)|
|--|--|
|![Screen Shot 2021-01-05 at 1 06 08 PM](https://user-images.githubusercontent.com/13563002/103700631-9bd45680-4f59-11eb-9a07-e17db1b55e78.png)|![Screen Shot 2021-01-05 at 9 56 58 AM](https://user-images.githubusercontent.com/13563002/103700717-b73f6180-4f59-11eb-8669-7090b2ef7ef8.png)|

### If the user does not choose to open in a new tab, then the link has no left margin.
|No margins, no icon - English|No margins, no icon - Arabic|
|--|--|
|![Screen Shot 2021-01-05 at 9 53 19 AM](https://user-images.githubusercontent.com/13563002/103700874-f372c200-4f59-11eb-98cc-eb30626f79ac.png)|![Screen Shot 2021-01-05 at 9 53 48 AM](https://user-images.githubusercontent.com/13563002/103700876-f4a3ef00-4f59-11eb-80cd-9b2096b8ac2a.png)|

### If the user uses `openInNewTab`, icon appears correctly and has no left margin.
|No margins, with icon - English|No margins, with icon - Arabic|
|--|--|
|![Screen Shot 2021-01-05 at 9 51 56 AM](https://user-images.githubusercontent.com/13563002/103701073-3f256b80-4f5a-11eb-82ed-a4b845035138.png)|![Screen Shot 2021-01-05 at 9 52 28 AM](https://user-images.githubusercontent.com/13563002/103701081-3fbe0200-4f5a-11eb-99fe-0086babe41c1.png)|