### PR TITLE
Added minWidth to prevent squished/oval effect in KIconButton

### DIFF
--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -75,9 +75,10 @@
           ...this.sizeStyles,
           // Circle
           borderRadius: '50%',
-          // Remove mins & padding
+          // Added minWidth to prevent squished/oval effect
+          minWidth: '32px',
+          // Remove minHeight & padding
           minHeight: '0px',
-          minWidth: '0px',
           padding: '0',
           ':hover': hover,
         };


### PR DESCRIPTION
This PR re-adds a minWidth value, which prevents the "squished" effect that is seen in Studio with some browser window resizes, especially at small sizes (~600px) in the tree views