### PR TITLE
Update KRouterLink icon w/out styling

### DIFF
--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -17,7 +17,7 @@
       <KIcon
         v-if="openInNewTab"
         icon="openNewTab"
-        :style="iconStyle"
+        style="top: 4px;"
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
     </slot>
@@ -80,16 +80,6 @@
           } else {
             styles['marginRight'] = '8px';
           }
-        }
-        return { ...styles };
-      },
-      /**
-       * Changes icon direction according to language of text of URL
-       */
-      iconStyle() {
-        let styles = { top: '4px' };
-        if (this.text === this.href) {
-          styles['transform'] = 'scaleX(1)';
         }
         return { ...styles };
       },

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -12,7 +12,23 @@
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >
+    <slot name="icon">
+      <KIcon
+        v-if="icon"
+        :icon="icon"
+        style="top: 4px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+    </slot>
     <span class="link-text" :style="spanStyle">{{ text }}</span>
+    <slot name="iconAfter">
+      <KIcon
+        v-if="iconAfter"
+        :icon="iconAfter"
+        style="top: 4px;"
+        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
+      />
+    </slot>
     <slot name="openInNewTab">
       <KIcon
         v-if="openInNewTab"
@@ -58,6 +74,20 @@
         type: Boolean,
         default: false,
       },
+      /**
+       * If provided, shows a KIcon in front of the text
+       */
+      icon: {
+        type: String,
+        required: false,
+      },
+      /**
+       * If provided, shows a KIcon after the text
+       */
+      iconAfter: {
+        type: String,
+        required: false,
+      },
     },
     data() {
       return {
@@ -66,25 +96,34 @@
     },
     computed: {
       /**
-       * If link opens in new tab, add 8px margin between the icon and the text
+       * If link opens in new tab or if icon is provided, add 8px margin between the icon and the text
        */
       spanStyle() {
         let styles = {};
-        if (this.openInNewTab) {
+        if (this.openInNewTab || this.icon) {
           if (this.isRtl) {
+            // If RTL-language, but English link, displays correct margins
             styles['marginRight'] = '8px';
+            // Checks to see if link for new tab is in same dir as page lang
             if (this.text !== this.href) {
               styles['marginRight'] = '0px';
               styles['marginLeft'] = '8px';
             }
           } else {
-            styles['marginRight'] = '8px';
+            if (this.text === this.href) {
+              styles['marginRight'] = '8px';
+            } else {
+              styles['marginLeft'] = '8px';
+            }
           }
+        }
+
+        if (this.iconAfter) {
+          styles['marginRight'] = '8px';
         }
         return { ...styles };
       },
     },
-    methods: {},
   };
 
 </script>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -87,16 +87,14 @@
        * Changes icon direction according to language of text of URL
        */
       iconStyle() {
-        let styles = { 'top': '4px' };
+        let styles = { top: '4px' };
         if (this.text === this.href) {
           styles['transform'] = 'scaleX(1)';
         }
         return { ...styles };
-      }
+      },
     },
-    methods: {
-
-    }
+    methods: {},
   };
 
 </script>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -79,7 +79,7 @@
               styles['marginLeft'] = '8px';
             }
           } else {
-            styles['marginLeft'] = '8px';
+            styles['marginRight'] = '8px';
           }
         }
         return { ...styles };

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -17,7 +17,7 @@
       <KIcon
         v-if="openInNewTab"
         icon="openNewTab"
-        style="top: 4px;"
+        :style="iconStyle"
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
     </slot>
@@ -72,7 +72,6 @@
         let styles = {};
         if (this.openInNewTab) {
           if (this.isRtl) {
-            // If RTL-language, but English link, displays correct margins
             styles['marginRight'] = '8px';
             if (this.text !== this.href) {
               styles['marginRight'] = '0px';
@@ -84,7 +83,20 @@
         }
         return { ...styles };
       },
+      /**
+       * Changes icon direction according to language of text of URL
+       */
+      iconStyle() {
+        let styles = { 'top': '4px' };
+        if (this.text === this.href) {
+          styles['transform'] = 'scaleX(1)';
+        }
+        return { ...styles };
+      }
     },
+    methods: {
+
+    }
   };
 
 </script>

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -2,27 +2,19 @@
 
   <!-- no extra whitespace inside link -->
   <router-link :class="buttonClasses" :to="to" dir="auto">
-    <KLabeledIcon :maxWidth="maxWidth" @mouseenter="hovering = true" @mouseleave="hovering = false">
-      <KIcon
-        v-if="icon"
-        slot="icon"
-        :icon="icon"
-        style="top: 0px; height: 24px; width: 24px;"
-        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
-      />
+    <KLabeledIcon
+      :maxWidth="maxWidth"
+      :icon="icon"
+      :iconAfter="iconAfter"
+      @mouseenter="hovering = true"
+      @mouseleave="hovering = false"
+    >
 
       <!-- Keep on the same line to avoid empty underlined spacing -->
       <slot name="text" :text="text">
         <span class="link-text">{{ text }}</span>
       </slot>
 
-      <KIcon
-        v-if="iconAfter"
-        slot="iconAfter"
-        :icon="iconAfter"
-        style="top: 0px; height: 24px; width: 24px;"
-        :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
-      />
     </KLabeledIcon>
   </router-link>
 


### PR DESCRIPTION
## Summary
Removed `KIcon` prop from `KRouterLink`, and instead, put the `icon` and `iconAfter` props in `KRouterLink`.

### Addresses
Issue #135 

### Screenshots After

|use of `icon`|use of `iconAfter`|
|--|--|
|![Screen Shot 2021-02-03 at 10 25 15 PM](https://user-images.githubusercontent.com/13563002/106858077-fb677400-6675-11eb-9508-62fa337508d9.png)|![Screen Shot 2021-02-03 at 11 11 14 PM](https://user-images.githubusercontent.com/13563002/106858079-fc000a80-6675-11eb-8818-45479aa4362e.png)|

### Screenshots Before
(when `KIcon` was inside `KRouterLink`):
![Screen Shot 2021-02-03 at 10 03 33 PM](https://user-images.githubusercontent.com/13563002/106858124-09b59000-6676-11eb-87d3-59cc3aef1cc6.png)

