### PR TITLE
Add `replace` prop to KRouterLink

### DIFF
--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -1,7 +1,7 @@
 <template>
 
   <!-- no extra whitespace inside link -->
-  <router-link :class="buttonClasses" :to="to" dir="auto">
+  <router-link :class="buttonClasses" :to="to" replace dir="auto">
     <KLabeledIcon :maxWidth="maxWidth" @mouseenter="hovering = true" @mouseleave="hovering = false">
       <KIcon
         v-if="icon"

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -1,7 +1,12 @@
 <template>
 
   <!-- no extra whitespace inside link -->
-  <router-link :class="buttonClasses" :to="to" replace dir="auto">
+  <router-link
+    :class="buttonClasses"
+    :to="to"
+    :replace="replace"
+    dir="auto"
+  >
     <KLabeledIcon :maxWidth="maxWidth" @mouseenter="hovering = true" @mouseleave="hovering = false">
       <KIcon
         v-if="icon"
@@ -52,6 +57,13 @@
        */
       icon: {
         type: String,
+        required: false,
+      },
+      /**
+       * If provided, calls window.history.replaceState() so navigation will not leave history record
+       */
+      replace: {
+        type: Boolean,
         required: false,
       },
       /**


### PR DESCRIPTION
## Summary
Added `replace` prop to `KRouterLink` by making `replace` accessible within `<router-link>` component.

Addresses #85 