### PR TITLE
Fix default=false on boolean prop

### DIFF
--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -64,7 +64,7 @@
        */
       replace: {
         type: Boolean,
-        required: false,
+        default: false,
       },
       /**
        * If provided, shows a KIcon after the text


### PR DESCRIPTION
Updated `required=false` to `default=false` - [the issue that was not caught with the linter](https://github.com/learningequality/kolibri-design-system/pull/152#discussion_r575730153).