### PR TITLE
Button docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ Layout:
 
 Links:
 
-* `<DocsAnchorTarget />` - for adding Anchor links to pages
+* `<DocsAnchorTarget />` - for creating anchor link targets
 * `<DocsExternalLink />` - links to an external website
-* `<DocsInternalLink />` - links within the design system
+* `<DocsInternalLink />` - links to pages within the design system
+* `<DocsLibraryLink />` - links to library components with `<code>` formatting
 
 Illustration:
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,15 @@ The documentation site is built using [NuxtJS](https://nuxtjs.org/) and [Vue](ht
 
 Clone this repository using [Git](https://help.github.com/en/github/getting-started-with-github/set-up-git), optionally [forking](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) it first if you plan to submit changes.
 
+First, change to the directory where you cloned the repo:
+
+```bash
+cd kolibri-design-system
+```
+
 Install the dependencies using `yarn`:
 
 ```bash
-cd design-system
 yarn install
 ```
 
@@ -208,18 +213,20 @@ If you are working on the design system library code in this repo and want to se
 
 Now, when you run the application your changes in `kolibri-design-system` will be updated live where your app expects its dependency on `kolibri-design-system` to live.
 
-For example, given that you have `~/kolibri` and `~/kolibri-design-system` folders with their respective local repositories.
+For example, given that you have `./kolibri` and `./kolibri-design-system` folders with their respective local repositories:
+
+First, remove the reference to `kolibri-design-system` from `./kolibri/core/package.json` which points at the online repo. Next,
 
 ```bash
-cd ~/kolibri-design-system
+# change to the KDS repo and add it to yarn's local package registry
+cd ./kolibri-design-system
 yarn link
-cd ~/kolibri
-```
 
-Remove the reference to `kolibri-design-system` from `kolibri/core/package.json`
-
-```bash
+# change to the Kolibri repo and link to the local package
+cd ../kolibri
 yarn link kolibri-design-system
+
+# run the Kolibri devserver
 yarn run devserver
 ```
 

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -12,9 +12,8 @@
 }
 
 code {
-  display: inline-block;
-  padding-right: 0.35em;
-  padding-left: 0.35em;
+  padding-right: 0.25em;
+  padding-left: 0.25em;
   font-family: 'Source Code Pro', monospace;
   font-weight: 400;
   white-space: nowrap;

--- a/docs/common/DocsFilter/utils.js
+++ b/docs/common/DocsFilter/utils.js
@@ -1,16 +1,18 @@
 import flow from 'lodash/flow';
-import words from 'lodash/words';
-import lowerCase from 'lodash/lowerCase';
+import toLower from 'lodash/toLower';
 import deburr from 'lodash/deburr';
 import every from 'lodash/every';
 import includes from 'lodash/includes';
 
 // normalize a term
-const cleanup = flow([lowerCase, deburr]);
+const cleanup = flow([toLower, deburr]);
 
 // given an input query string, return a list of search terms
 export function termList(filterText) {
-  return words(filterText).map(cleanup);
+  return filterText
+    .split(' ')
+    .map(cleanup)
+    .filter(val => val);
 }
 
 // given a list of search terms, decide whether to match some section or page

--- a/docs/common/DocsFilter/utils.spec.js
+++ b/docs/common/DocsFilter/utils.spec.js
@@ -1,0 +1,16 @@
+import { termList, matches } from './utils';
+
+test('termList', () => {
+  expect(termList('Term1 term2')).toEqual(['term1', 'term2']);
+  expect(termList('lowercase UPPERCASE')).toEqual(['lowercase', 'uppercase']);
+  expect(termList('  space     between')).toEqual(['space', 'between']);
+  expect(termList('  space     between')).toEqual(['space', 'between']);
+  expect(termList('ĜĚĔĶŜ ĝęėķś')).toEqual(['geeks', 'geeks']);
+});
+
+test('matches', () => {
+  expect(matches(termList('KButton'), 'KButton')).toEqual(true);
+  expect(matches(termList('KButton'), 'KCheckbox')).toEqual(false);
+
+  // TODO - add more complex variations
+});

--- a/docs/common/DocsGithubLink.vue
+++ b/docs/common/DocsGithubLink.vue
@@ -79,7 +79,7 @@
         if (this.pull)
           return `https://github.com/learningequality/kolibri-design-system/pull/${this.pull}`;
         if (this.issue)
-          return `https://github.com/learningequality/kolibri-design-system/issue/${this.issue}`;
+          return `https://github.com/learningequality/kolibri-design-system/issues/${this.issue}`;
         log.error(`No URL, PR, or issue provided`);
         return undefined;
       },

--- a/docs/common/DocsLibraryLink.vue
+++ b/docs/common/DocsLibraryLink.vue
@@ -1,0 +1,22 @@
+<template>
+
+  <a :href="'/' + page">
+    <code>{{ page }}</code>
+  </a>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'DocsLibraryLink',
+    props: {
+      page: {
+        type: String,
+        required: true,
+      },
+    },
+  };
+
+</script>

--- a/docs/common/DocsPageTemplate/SideNav/index.vue
+++ b/docs/common/DocsPageTemplate/SideNav/index.vue
@@ -53,9 +53,11 @@
           if (matches(this.terms, section.title)) {
             toc.push(section);
           }
-          // otherwise, check for matching pages
+          // otherwise, check for matching pages by title and keywords
           else {
-            const matchingPages = section.pages.filter(page => matches(this.terms, page.title));
+            const matchingPages = section.pages.filter(page =>
+              matches(this.terms, page.title + page.keywords.join(' '))
+            );
             if (matchingPages.length) {
               toc.push(section.clone({ pages: matchingPages }));
             }

--- a/docs/common/DocsPageTemplate/jsdocs/EventsTable.vue
+++ b/docs/common/DocsPageTemplate/jsdocs/EventsTable.vue
@@ -11,7 +11,10 @@
     </thead>
     <tbody>
       <tr v-for="(event, i) in api" :key="i">
-        <td><code>{{ event.name }}</code></td>
+        <td class="first-col">
+          <code>{{ event.name }}</code>
+          <DocsAnchorTarget :anchor="`#event:${event.name}`" />
+        </td>
         <td>
           <vue-simple-markdown v-if="event.description" :source="event.description" />
           <KEmptyPlaceholder v-else />

--- a/docs/common/DocsPageTemplate/jsdocs/MethodsTable.vue
+++ b/docs/common/DocsPageTemplate/jsdocs/MethodsTable.vue
@@ -11,7 +11,10 @@
     </thead>
     <tbody>
       <tr v-for="(method, i) in api" :key="i">
-        <td><code>{{ method.name }}</code></td>
+        <td class="first-col">
+          <code>{{ method.name }}</code>
+          <DocsAnchorTarget :anchor="`#method:${method.name}`" />
+        </td>
         <td>
           <vue-simple-markdown v-if="method.description" :source="method.description" />
           <KEmptyPlaceholder v-else />

--- a/docs/common/DocsPageTemplate/jsdocs/PropsTable.vue
+++ b/docs/common/DocsPageTemplate/jsdocs/PropsTable.vue
@@ -4,22 +4,25 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th>Type</th>
-        <th>Required</th>
-        <th>Default</th>
         <th class="stretch">
           Description
         </th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Required</th>
       </tr>
     </thead>
     <tbody>
       <tr v-for="(prop, i) in api" :key="i">
-        <td><code>{{ prop.name }}</code></td>
-        <td><code>{{ prop.type.name }}</code></td>
-        <td>
-          <KEmptyPlaceholder v-if="!prop.required" />
-          <code v-else>true</code>
+        <td class="first-col">
+          <code>{{ prop.name }}</code>
+          <DocsAnchorTarget :anchor="`#prop:${prop.name}`" />
         </td>
+        <td>
+          <vue-simple-markdown v-if="prop.description" :source="prop.description" />
+          <KEmptyPlaceholder v-else />
+        </td>
+        <td><code>{{ prop.type.name }}</code></td>
         <td>
           <code v-if="prop.defaultValue">
             {{ prop.defaultValue.value }}
@@ -27,8 +30,8 @@
           <KEmptyPlaceholder v-else />
         </td>
         <td>
-          <vue-simple-markdown v-if="prop.description" :source="prop.description" />
-          <KEmptyPlaceholder v-else />
+          <KEmptyPlaceholder v-if="!prop.required" />
+          <code v-else>true</code>
         </td>
       </tr>
     </tbody>

--- a/docs/common/DocsPageTemplate/jsdocs/PropsTable.vue
+++ b/docs/common/DocsPageTemplate/jsdocs/PropsTable.vue
@@ -17,9 +17,8 @@
         <td><code>{{ prop.name }}</code></td>
         <td><code>{{ prop.type.name }}</code></td>
         <td>
-          <code v-if="prop.required === true">true</code>
-          <code v-else-if="prop.required === false">false</code>
-          <KEmptyPlaceholder v-else />
+          <KEmptyPlaceholder v-if="!prop.required" />
+          <code v-else>true</code>
         </td>
         <td>
           <code v-if="prop.defaultValue">

--- a/docs/common/DocsPageTemplate/jsdocs/SlotsTable.vue
+++ b/docs/common/DocsPageTemplate/jsdocs/SlotsTable.vue
@@ -11,7 +11,10 @@
     </thead>
     <tbody>
       <tr v-for="(slot, i) in api" :key="i">
-        <td><code>{{ slot.name }}</code></td>
+        <td class="first-col">
+          <code>{{ slot.name }}</code>
+          <DocsAnchorTarget :anchor="`#slot:${slot.name}`" />
+        </td>
         <td>
           <vue-simple-markdown v-if="slot.description" :source="slot.description" />
           <KEmptyPlaceholder v-else />

--- a/docs/common/DocsPageTemplate/jsdocs/styles.scss
+++ b/docs/common/DocsPageTemplate/jsdocs/styles.scss
@@ -11,5 +11,10 @@ th {
 
 .stretch {
   width: 100%;
-  min-width: 150px;
+  min-width: 175px;
+}
+
+.first-col {
+  min-width: 175px;
+  white-space: nowrap;
 }

--- a/docs/pages/KButton.vue
+++ b/docs/pages/KButton.vue
@@ -13,21 +13,15 @@
         It can take on a number of visual styles, including buttons:
       </p>
       <DocsShow>
-        <p>
-          <KButtonGroup style="margin-bottom: 8px;">
-            <KButton text="Primary" :primary="true" appearance="raised-button" />
-            <KButton text="Secondary" :primary="false" appearance="raised-button" />
-          </KButtonGroup>
-        </p>
-        <p>
-          <KButtonGroup>
-            <KButton text="Primary" :primary="true" appearance="flat-button" />
-            <KButton text="Secondary" :primary="false" appearance="flat-button" />
-          </KButtonGroup>
-        </p>
+        <KButtonGroup>
+          <KButton text="Primary" :primary="true" appearance="raised-button" />
+          <KButton text="Secondary" :primary="false" appearance="raised-button" />
+          <KButton text="Primary" :primary="true" appearance="flat-button" />
+          <KButton text="Secondary" :primary="false" appearance="flat-button" />
+        </KButtonGroup>
       </DocsShow>
       <p>
-        and also links:
+        and links:
       </p>
       <DocsShow>
         <p>
@@ -37,16 +31,14 @@
           <KButton text="Link with icon before" appearance="basic-link" icon="person" />
         </p>
       </DocsShow>
-      <p>
-        See also:
-      </p>
+    </DocsPageSection>
+    <DocsPageSection title="Related components" anchor="#related">
       <ul>
         <li><DocsLibraryLink page="KButtonGroup" /></li>
         <li><DocsLibraryLink page="KExternalLink" /></li>
         <li><DocsLibraryLink page="KIconButton" /></li>
         <li><DocsLibraryLink page="KRouterLink" /></li>
       </ul>
-
     </DocsPageSection>
 
   </DocsPageTemplate>

--- a/docs/pages/KButton.vue
+++ b/docs/pages/KButton.vue
@@ -34,7 +34,7 @@
         </li>
         <li><DocsLibraryLink page="KExternalLink" /> and <DocsLibraryLink page="KRouterLink" /> are similar but handle events differently</li>
         <li>
-          <code>KIconButton</code> has a tooltip instead of a text label
+          <DocsLibraryLink page="KIconButton" /> has a tooltip instead of a text label
         </li>
         <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
       </ul>

--- a/docs/pages/KButton.vue
+++ b/docs/pages/KButton.vue
@@ -4,10 +4,7 @@
 
     <DocsPageSection title="Overview" anchor="#overview">
       <p>
-        For an overview of buttons and links in Kolibri, see the <DocsInternalLink text="Buttons and links" href="/buttons" /> page.
-      </p>
-      <p>
-        The <code>KButton</code> component creates a <code>&lt;button&gt;</code> tag and is appropriate for triggering javascript functions on-click.
+        Creates a <code>&lt;button&gt;</code> tag and is appropriate for triggering javascript functions on-click.
       </p>
       <p>
         It can take on a number of visual styles, including buttons:
@@ -15,9 +12,9 @@
       <DocsShow>
         <KButtonGroup>
           <KButton text="Primary" :primary="true" appearance="raised-button" />
+          <KButton text="Primary flat" :primary="true" appearance="flat-button" />
           <KButton text="Secondary" :primary="false" appearance="raised-button" />
-          <KButton text="Primary" :primary="true" appearance="flat-button" />
-          <KButton text="Secondary" :primary="false" appearance="flat-button" />
+          <KButton text="Secondary flat" :primary="false" appearance="flat-button" />
         </KButtonGroup>
       </DocsShow>
       <p>
@@ -32,12 +29,14 @@
         </p>
       </DocsShow>
     </DocsPageSection>
-    <DocsPageSection title="Related components" anchor="#related">
+    <DocsPageSection title="Related" anchor="#related">
       <ul>
-        <li><DocsLibraryLink page="KButtonGroup" /></li>
-        <li><DocsLibraryLink page="KExternalLink" /></li>
-        <li><DocsLibraryLink page="KIconButton" /></li>
-        <li><DocsLibraryLink page="KRouterLink" /></li>
+        <li>
+          <DocsInternalLink text="Buttons and links" href="/buttons" /> has an overview and usage guidance
+        </li>
+        <li><DocsLibraryLink page="KExternalLink" /> and <DocsLibraryLink page="KRouterLink" /> are similar but handle events differently</li>
+        <li><DocsLibraryLink page="KIconButton" /> has a tooltip instead of a text label</li>
+        <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
       </ul>
     </DocsPageSection>
 

--- a/docs/pages/KButton.vue
+++ b/docs/pages/KButton.vue
@@ -4,29 +4,27 @@
 
     <DocsPageSection title="Overview" anchor="#overview">
       <p>
-        Creates a <code>&lt;button&gt;</code> tag and is appropriate for triggering javascript functions on-click.
-      </p>
-      <p>
-        It can take on a number of visual styles, including buttons:
-      </p>
-      <DocsShow>
-        <KButtonGroup>
-          <KButton text="Primary" :primary="true" appearance="raised-button" />
-          <KButton text="Primary flat" :primary="true" appearance="flat-button" />
-          <KButton text="Secondary" :primary="false" appearance="raised-button" />
-          <KButton text="Secondary flat" :primary="false" appearance="flat-button" />
-        </KButtonGroup>
-      </DocsShow>
-      <p>
-        and links:
+        Creates a <code>&lt;button&gt;</code> tag and is appropriate for triggering javascript functions on-click. It can take on a number of visual styles, including both links and buttons.
       </p>
       <DocsShow>
         <p>
           <KButton text="Link" appearance="basic-link" />
         </p>
         <p>
-          <KButton text="Link with icon before" appearance="basic-link" icon="person" />
+          <KButton text="Link with icon" appearance="basic-link" icon="person" />
         </p>
+      </DocsShow>
+      <DocsShow>
+        <KButtonGroup>
+          <KButton text="Button" :primary="true" appearance="raised-button" />
+          <KButton text="Flat button" :primary="true" appearance="flat-button" />
+        </KButtonGroup>
+      </DocsShow>
+      <DocsShow>
+        <KButtonGroup>
+          <KButton text="Secondary button" :primary="false" appearance="raised-button" />
+          <KButton text="Secondary flat button" :primary="false" appearance="flat-button" />
+        </KButtonGroup>
       </DocsShow>
     </DocsPageSection>
     <DocsPageSection title="Related" anchor="#related">
@@ -35,7 +33,9 @@
           <DocsInternalLink text="Buttons and links" href="/buttons" /> has an overview and usage guidance
         </li>
         <li><DocsLibraryLink page="KExternalLink" /> and <DocsLibraryLink page="KRouterLink" /> are similar but handle events differently</li>
-        <li><DocsLibraryLink page="KIconButton" /> has a tooltip instead of a text label</li>
+        <li>
+          <code>KIconButton</code> has a tooltip instead of a text label
+        </li>
         <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
       </ul>
     </DocsPageSection>

--- a/docs/pages/KButton.vue
+++ b/docs/pages/KButton.vue
@@ -1,0 +1,54 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+
+    <DocsPageSection title="Overview" anchor="#overview">
+      <p>
+        For an overview of buttons and links in Kolibri, see the <DocsInternalLink text="Buttons and links" href="/buttons" /> page.
+      </p>
+      <p>
+        The <code>KButton</code> component creates a <code>&lt;button&gt;</code> tag and is appropriate for triggering javascript function on-click.
+      </p>
+      <p>
+        It can take on a number of visual styles, including buttons:
+      </p>
+      <DocsShow>
+        <p>
+          <KButtonGroup style="margin-bottom: 8px;">
+            <KButton text="Primary" :primary="true" appearance="raised-button" />
+            <KButton text="Secondary" :primary="false" appearance="raised-button" />
+          </KButtonGroup>
+        </p>
+        <p>
+          <KButtonGroup>
+            <KButton text="Primary" :primary="true" appearance="flat-button" />
+            <KButton text="Secondary" :primary="false" appearance="flat-button" />
+          </KButtonGroup>
+        </p>
+      </DocsShow>
+      <p>
+        and also links:
+      </p>
+      <DocsShow>
+        <p>
+          <KButton text="Link" appearance="basic-link" />
+        </p>
+        <p>
+          <KButton text="Link with icon before" appearance="basic-link" icon="person" />
+        </p>
+      </DocsShow>
+      <p>
+        See also:
+      </p>
+      <ul>
+        <li><DocsLibraryLink page="KButtonGroup" /></li>
+        <li><DocsLibraryLink page="KExternalLink" /></li>
+        <li><DocsLibraryLink page="KIconButton" /></li>
+        <li><DocsLibraryLink page="KInternalLink" /></li>
+      </ul>
+
+    </DocsPageSection>
+
+  </DocsPageTemplate>
+
+</template>

--- a/docs/pages/KButtonGroup.vue
+++ b/docs/pages/KButtonGroup.vue
@@ -24,7 +24,7 @@
         </KButtonGroup>
       </DocsShow>
       <p>
-        It is most often used with the <code>KButton</code>, <code>KRouterLink</code> and <code>KExternalLink</code> components.
+        It is most often used with the <DocsLibraryLink page="KButton" />, <DocsLibraryLink page="KRouterLink" /> and <DocsLibraryLink page="KExternalLink" /> components.
       </p>
     </DocsPageSection>
 

--- a/docs/pages/KButtonGroup.vue
+++ b/docs/pages/KButtonGroup.vue
@@ -3,7 +3,12 @@
   <DocsPageTemplate apiDocs>
 
     <DocsPageSection title="Overview" anchor="#overview">
-      <p>The <code>KButtonGroup</code> component is used to provide consistent, 8px spacing for buttons. For example:</p>
+      <p>
+        For an overview of buttons and links in Kolibri, see the <DocsInternalLink text="Buttons and links" href="/buttons" /> page.
+      </p>
+      <p>
+        The <code>KButtonGroup</code> component is used to provide consistent, 8px spacing for buttons. For example:
+      </p>
       <DocsShow>
         <KButtonGroup>
           <KButton

--- a/docs/pages/KButtonGroup.vue
+++ b/docs/pages/KButtonGroup.vue
@@ -1,0 +1,28 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+
+    <DocsPageSection title="Overview" anchor="#overview">
+      <p>The <code>KButtonGroup</code> component is used to provide consistent, 8px spacing for buttons. For example:</p>
+      <DocsShow>
+        <KButtonGroup>
+          <KButton
+            text="Button 1"
+          />
+          <KButton
+            text="Button 2"
+          />
+          <KButton
+            text="Primary button"
+            primary
+          />
+        </KButtonGroup>
+      </DocsShow>
+      <p>
+        It is most often used with the <code>KButton</code>, <code>KRouterLink</code> and <code>KExternalLink</code> components.
+      </p>
+    </DocsPageSection>
+
+  </DocsPageTemplate>
+
+</template>

--- a/docs/pages/KCheckbox.vue
+++ b/docs/pages/KCheckbox.vue
@@ -15,7 +15,7 @@
         />
       </DocsShow>
       <p>
-        The checkbox is generally used to select one of two possible values in a form. It should not be used to make real-time changes; for this situation, use a <code>KSwitch</code> component instead.
+        The checkbox is generally used to select one of two possible values in a form. It should not be used to make real-time changes; for this situation, use a <DocsLibraryLink page="KSwitch" /> component instead.
       </p>
       <p>Layout:</p>
       <ul>

--- a/docs/pages/KExternalLink.vue
+++ b/docs/pages/KExternalLink.vue
@@ -4,30 +4,7 @@
 
     <DocsPageSection title="Overview" anchor="#overview">
       <p>
-        For an overview of buttons and links in Kolibri, see the <DocsInternalLink text="Buttons and links" href="/buttons" /> page.
-      </p>
-      <p>
-        The <code>KExternalLink</code> component creates an <code>&lt;a&gt;</code> tag and is appropriate for links that use server-side routing.
-      </p>
-      <p>
-        It can take on a number of visual styles, including buttons:
-      </p>
-      <DocsShow>
-        <p>
-          <KButtonGroup style="margin-bottom: 8px;">
-            <KExternalLink text="Primary" :primary="true" appearance="raised-button" />
-            <KExternalLink text="Secondary" :primary="false" appearance="raised-button" />
-          </KButtonGroup>
-        </p>
-        <p>
-          <KButtonGroup>
-            <KExternalLink text="Primary" :primary="true" appearance="flat-button" />
-            <KExternalLink text="Secondary" :primary="false" appearance="flat-button" />
-          </KButtonGroup>
-        </p>
-      </DocsShow>
-      <p>
-        and also links:
+        Creates an <code>&lt;a&gt;</code> tag and is appropriate for links that use server-side routing.
       </p>
       <DocsShow>
         <p>
@@ -38,15 +15,28 @@
         </p>
       </DocsShow>
       <p>
-        See also:
+        and buttons:
       </p>
+      <DocsShow>
+        <KButtonGroup>
+          <KExternalLink text="Primary" :primary="true" appearance="raised-button" />
+          <KExternalLink text="Primary flat" :primary="true" appearance="flat-button" />
+          <KExternalLink text="Secondary" :primary="false" appearance="raised-button" />
+          <KExternalLink text="Secondary flat" :primary="false" appearance="flat-button" />
+        </KButtonGroup>
+      </DocsShow>
+    </DocsPageSection>
+    <DocsPageSection title="Related" anchor="#related">
       <ul>
-        <li><DocsLibraryLink page="KButton" /></li>
-        <li><DocsLibraryLink page="KButtonGroup" /></li>
-        <li><DocsLibraryLink page="KIconButton" /></li>
-        <li><DocsLibraryLink page="KRouterLink" /></li>
+        <li>
+          <DocsInternalLink text="Buttons and links" href="/buttons" /> has an overview and usage guidance
+        </li>
+        <li><DocsLibraryLink page="KButton" /> and <DocsLibraryLink page="KRouterLink" /> are similar but handle events differently</li>
+        <li>
+          <code>KIconButton</code> has a tooltip instead of a text label
+        </li>
+        <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
       </ul>
-
     </DocsPageSection>
 
   </DocsPageTemplate>

--- a/docs/pages/KExternalLink.vue
+++ b/docs/pages/KExternalLink.vue
@@ -7,7 +7,7 @@
         For an overview of buttons and links in Kolibri, see the <DocsInternalLink text="Buttons and links" href="/buttons" /> page.
       </p>
       <p>
-        The <code>KButton</code> component creates a <code>&lt;button&gt;</code> tag and is appropriate for triggering javascript functions on-click.
+        The <code>KExternalLink</code> component creates an <code>&lt;a&gt;</code> tag and is appropriate for links that use server-side routing.
       </p>
       <p>
         It can take on a number of visual styles, including buttons:
@@ -15,14 +15,14 @@
       <DocsShow>
         <p>
           <KButtonGroup style="margin-bottom: 8px;">
-            <KButton text="Primary" :primary="true" appearance="raised-button" />
-            <KButton text="Secondary" :primary="false" appearance="raised-button" />
+            <KExternalLink text="Primary" :primary="true" appearance="raised-button" />
+            <KExternalLink text="Secondary" :primary="false" appearance="raised-button" />
           </KButtonGroup>
         </p>
         <p>
           <KButtonGroup>
-            <KButton text="Primary" :primary="true" appearance="flat-button" />
-            <KButton text="Secondary" :primary="false" appearance="flat-button" />
+            <KExternalLink text="Primary" :primary="true" appearance="flat-button" />
+            <KExternalLink text="Secondary" :primary="false" appearance="flat-button" />
           </KButtonGroup>
         </p>
       </DocsShow>
@@ -31,18 +31,18 @@
       </p>
       <DocsShow>
         <p>
-          <KButton text="Link" appearance="basic-link" />
+          <KExternalLink text="Link" appearance="basic-link" />
         </p>
         <p>
-          <KButton text="Link with icon before" appearance="basic-link" icon="person" />
+          <KExternalLink text="Link with icon before" appearance="basic-link" icon="person" />
         </p>
       </DocsShow>
       <p>
         See also:
       </p>
       <ul>
+        <li><DocsLibraryLink page="KButton" /></li>
         <li><DocsLibraryLink page="KButtonGroup" /></li>
-        <li><DocsLibraryLink page="KExternalLink" /></li>
         <li><DocsLibraryLink page="KIconButton" /></li>
         <li><DocsLibraryLink page="KRouterLink" /></li>
       </ul>

--- a/docs/pages/KExternalLink.vue
+++ b/docs/pages/KExternalLink.vue
@@ -33,7 +33,7 @@
         </li>
         <li><DocsLibraryLink page="KButton" /> and <DocsLibraryLink page="KRouterLink" /> are similar but handle events differently</li>
         <li>
-          <code>KIconButton</code> has a tooltip instead of a text label
+          <DocsLibraryLink page="KIconButton" /> has a tooltip instead of a text label
         </li>
         <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
       </ul>

--- a/docs/pages/KIconButton.vue
+++ b/docs/pages/KIconButton.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+
+    <DocsPageSection title="Overview" anchor="#overview">
+      <p>
+        Use <DocsLibraryLink page="KIconButton" /> in situations where larger buttons with visible text would hinder the user experience. Use the flat secondary style unless the action should be highlighted.
+      </p>
+      <p>
+        A tooltip with the name of the action is required for an icon button.
+      </p>
+      <DocsShow>
+        <KButtonGroup>
+          <KIconButton tooltip="Add" icon="plus" :primary="true" appearance="raised-button" />
+          <KIconButton tooltip="Subtract" icon="minus" :primary="false" appearance="raised-button" />
+          <KIconButton tooltip="Add" text="Flat button" :primary="true" icon="plus" appearance="flat-button" />
+          <KIconButton tooltip="Subtract" text="Flat button" :primary="false" icon="minus" appearance="flat-button" />
+        </KButtonGroup>
+      </DocsShow>
+    </DocsPageSection>
+    <DocsPageSection title="Related" anchor="#related">
+      <ul>
+        <li>
+          <DocsInternalLink text="Buttons and links" href="/buttons" /> has an overview and usage guidance
+        </li>
+        <li><DocsLibraryLink page="KButton" />, <DocsLibraryLink page="KExternalLink" />, and <DocsLibraryLink page="KRouterLink" /> are all similar but handle events differently</li>
+        <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
+      </ul>
+    </DocsPageSection>
+
+  </DocsPageTemplate>
+
+</template>

--- a/docs/pages/KRouterLink.vue
+++ b/docs/pages/KRouterLink.vue
@@ -4,49 +4,39 @@
 
     <DocsPageSection title="Overview" anchor="#overview">
       <p>
-        For an overview of buttons and links in Kolibri, see the <DocsInternalLink text="Buttons and links" href="/buttons" /> page.
-      </p>
-      <p>
-        The <code>KRouterLink</code> component creates a <DocsExternalLink href="https://router.vuejs.org/api/#router-link" text="router-link" code /> element and is appropriate for triggering internal Vue router navigation on-click.
-      </p>
-      <p>
-        It can take on a number of visual styles, including buttons:
+        Creates a <DocsExternalLink href="https://router.vuejs.org/api/" text="Vue client-side router" /> link. It can take on a number of visual styles, including links:
       </p>
       <DocsShow>
         <p>
-          <KButtonGroup style="margin-bottom: 8px;">
-            <KRouterLink text="Primary" :primary="true" appearance="raised-button" />
-            <KRouterLink text="Secondary" :primary="false" appearance="raised-button" />
-          </KButtonGroup>
+          <KRouterLink :to="{}" text="Link" appearance="basic-link" />
         </p>
         <p>
-          <KButtonGroup>
-            <KRouterLink text="Primary" :primary="true" appearance="flat-button" />
-            <KRouterLink text="Secondary" :primary="false" appearance="flat-button" />
-          </KButtonGroup>
+          <KRouterLink :to="{}" text="Link with icon before" appearance="basic-link" icon="person" />
         </p>
       </DocsShow>
       <p>
-        and also links:
+        and buttons:
       </p>
       <DocsShow>
-        <p>
-          <KRouterLink text="Link" appearance="basic-link" />
-        </p>
-        <p>
-          <KRouterLink text="Link with icon before" appearance="basic-link" icon="person" />
-        </p>
+        <KButtonGroup>
+          <KRouterLink :to="{}" text="Primary" :primary="true" appearance="raised-button" />
+          <KRouterLink :to="{}" text="Primary flat" :primary="true" appearance="flat-button" />
+          <KRouterLink :to="{}" text="Secondary" :primary="false" appearance="raised-button" />
+          <KRouterLink :to="{}" text="Secondary flat" :primary="false" appearance="flat-button" />
+        </KButtonGroup>
       </DocsShow>
-      <p>
-        See also:
-      </p>
+    </DocsPageSection>
+    <DocsPageSection title="Related" anchor="#related">
       <ul>
-        <li><DocsLibraryLink page="KButton" /></li>
-        <li><DocsLibraryLink page="KButtonGroup" /></li>
-        <li><DocsLibraryLink page="KExternalLink" /></li>
-        <li><DocsLibraryLink page="KIconButton" /></li>
+        <li>
+          <DocsInternalLink text="Buttons and links" href="/buttons" /> has an overview and usage guidance
+        </li>
+        <li><DocsLibraryLink page="KButton" /> and <DocsLibraryLink page="KExternalLink" /> are similar but handle events differently</li>
+        <li>
+          <code>KIconButton</code> has a tooltip instead of a text label
+        </li>
+        <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
       </ul>
-
     </DocsPageSection>
 
   </DocsPageTemplate>

--- a/docs/pages/KRouterLink.vue
+++ b/docs/pages/KRouterLink.vue
@@ -33,7 +33,7 @@
         </li>
         <li><DocsLibraryLink page="KButton" /> and <DocsLibraryLink page="KExternalLink" /> are similar but handle events differently</li>
         <li>
-          <code>KIconButton</code> has a tooltip instead of a text label
+          <DocsLibraryLink page="KIconButton" /> has a tooltip instead of a text label
         </li>
         <li><DocsLibraryLink page="KButtonGroup" /> is used for button layout</li>
       </ul>

--- a/docs/pages/KRouterLink.vue
+++ b/docs/pages/KRouterLink.vue
@@ -7,7 +7,7 @@
         For an overview of buttons and links in Kolibri, see the <DocsInternalLink text="Buttons and links" href="/buttons" /> page.
       </p>
       <p>
-        The <code>KButton</code> component creates a <code>&lt;button&gt;</code> tag and is appropriate for triggering javascript functions on-click.
+        The <code>KRouterLink</code> component creates a <DocsExternalLink href="https://router.vuejs.org/api/#router-link" text="router-link" code /> element and is appropriate for triggering internal Vue router navigation on-click.
       </p>
       <p>
         It can take on a number of visual styles, including buttons:
@@ -15,14 +15,14 @@
       <DocsShow>
         <p>
           <KButtonGroup style="margin-bottom: 8px;">
-            <KButton text="Primary" :primary="true" appearance="raised-button" />
-            <KButton text="Secondary" :primary="false" appearance="raised-button" />
+            <KRouterLink text="Primary" :primary="true" appearance="raised-button" />
+            <KRouterLink text="Secondary" :primary="false" appearance="raised-button" />
           </KButtonGroup>
         </p>
         <p>
           <KButtonGroup>
-            <KButton text="Primary" :primary="true" appearance="flat-button" />
-            <KButton text="Secondary" :primary="false" appearance="flat-button" />
+            <KRouterLink text="Primary" :primary="true" appearance="flat-button" />
+            <KRouterLink text="Secondary" :primary="false" appearance="flat-button" />
           </KButtonGroup>
         </p>
       </DocsShow>
@@ -31,20 +31,20 @@
       </p>
       <DocsShow>
         <p>
-          <KButton text="Link" appearance="basic-link" />
+          <KRouterLink text="Link" appearance="basic-link" />
         </p>
         <p>
-          <KButton text="Link with icon before" appearance="basic-link" icon="person" />
+          <KRouterLink text="Link with icon before" appearance="basic-link" icon="person" />
         </p>
       </DocsShow>
       <p>
         See also:
       </p>
       <ul>
+        <li><DocsLibraryLink page="KButton" /></li>
         <li><DocsLibraryLink page="KButtonGroup" /></li>
         <li><DocsLibraryLink page="KExternalLink" /></li>
         <li><DocsLibraryLink page="KIconButton" /></li>
-        <li><DocsLibraryLink page="KRouterLink" /></li>
       </ul>
 
     </DocsPageSection>

--- a/docs/pages/KSwitch.vue
+++ b/docs/pages/KSwitch.vue
@@ -12,7 +12,7 @@
         A switch toggle is used to select and execute an action instantly, in real time. A switch is toggled successfully when the switch thumb slides to the other side of the track upon click or press.
       </p>
       <p>
-        For selections that require a confirmation to execute and are housed in a form, use <DocsInternalLink code text="KCheckbox" href="/KCheckbox" /> component instead.
+        For selections that require a confirmation to execute and are housed in a form, use <DocsLibraryLink page="KCheckbox" /> component instead.
       </p>
     </DocsPageSection>
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -106,7 +106,7 @@
         <li>Global actions related to full pages should be right-aligned and to the right of the page title on large screens, and left-aligned below the title on small screens. Use of <code>KGrid</code> is recommended</li>
       </ul>
       <p>
-        Use the <DocsLibraryLink page="KButtonGroup" /> component to add specing between adjacent buttons.
+        Use the <DocsLibraryLink page="KButtonGroup" /> component to add spacing between adjacent buttons.
       </p>
 
     </DocsPageSection>

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -20,19 +20,20 @@
       <p>As such, there are three components that all behave similarly, but are used for different purposes:</p>
       <ul>
         <li>
-          <code>KButton</code> is used to create <code>&lt;button&gt;</code> tags with
+          <DocsLibraryLink page="KButton" /> is used to create <code>&lt;button&gt;</code> tags with
           <code>@click</code> event handlers.
         </li>
         <li>
-          <code>KRouterLink</code> is used to create Vue router <code>&lt;router-link&gt;</code>
+          <DocsLibraryLink page="KRouterLink" /> is used to create Vue router <code>&lt;router-link&gt;</code>
           components with <code>:to</code> properties. These compile into <code>&lt;a&gt;</code>
           tags.
         </li>
         <li>
-          <code>KExternalLink</code> is used to create standard <code>&lt;a&gt;</code> tags with an
+          <DocsLibraryLink page="KExternalLink" /> is used to create standard <code>&lt;a&gt;</code> tags with an
           <code>href</code> attribute.
         </li>
       </ul>
+      <p>We also provide a <DocsLibraryLink page="KButtonGroup" /> wrapper component to set standardized spacing between groups of buttons.</p>
     </DocsPageSection>
 
     <DocsPageSection title="Visual styles" anchor="#visualstyles">

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -145,16 +145,42 @@
 
     <DocsPageSection title="Dropdowns" anchor="#dropdowns">
       <p>
-        There are variations of buttons which can open a dropdown menu:
+        Buttons can also have drop-down menus. Currently this is implemented using the poorly-named <code>KDropdownMenu</code> component, but this is subject to change.
       </p>
       <!-- TODO: implement 3 examples: primary button, primary flat button, and secondary icon button that function as dropdowns. See Google doc for example -->
       <DocsShow>
-        <KDropdownMenu style="margin-right: 8px;" text="Primary" :primary="true" :options="['Primary', 'Dropdown']" appearance="raised-button" />
-        <KDropdownMenu style="margin-right: 8px;" text="Secondary" :primary="false" :options="['Secondary', 'Dropdown']" appearance="raised-button" />
-        <KDropdownMenu text="Icon dropdown" :primary="false" :options="['Icon button', 'Flat button', 'Dropdown']" appearance="raised-button">
-          <KIconButton slot="button" tooltip="Dropdown options" icon="optionsHorizontal" appearance="flat-button" :primary="false" />
+        <KDropdownMenu
+          style="margin-right: 16px;"
+          text="Primary"
+          :primary="true"
+          :options="['Option 1', 'Option 2']"
+          appearance="raised-button"
+        />
+        <KDropdownMenu
+          style="margin-right: 16px;"
+          text="Secondary"
+          :primary="false"
+          :options="['Option 1', 'Option 2']"
+          appearance="raised-button"
+        />
+        <KDropdownMenu
+          text="Icon dropdown"
+          :primary="false"
+          :options="['Option 1', 'Option 2']"
+          appearance="raised-button"
+        >
+          <KIconButton
+            slot="button"
+            tooltip="Dropdown options"
+            icon="optionsHorizontal"
+            appearance="flat-button"
+            :primary="false"
+          />
         </KDropdownMenu>
       </DocsShow>
+      <p>
+        Caution: <code>KDropdownMenu</code> does not work with the <DocsLibraryLink page="KButtonGroup" /> component.
+      </p>
 
     </DocsPageSection>
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -46,7 +46,6 @@
         <KButtonGroup>
           <KButton text="Raised button" :primary="true" appearance="raised-button" />
           <KButton text="Flat button" :primary="true" appearance="flat-button" />
-          <KIconButton tooltip="A tooltip" text="Flat button" :primary="false" icon="plus" appearance="flat-button" />
           <KButton text="Basic link" :primary="true" appearance="basic-link" />
         </KButtonGroup>
       </DocsShow>
@@ -59,21 +58,19 @@
         <KButtonGroup style="margin-bottom: 8px;">
           <KButton text="Primary" :primary="true" appearance="raised-button" />
           <KButton text="Secondary" :primary="false" appearance="raised-button" />
-          <KIconButton tooltip="KIconButton" icon="plus" :primary="true" appearance="raised-button" />
         </KButtonGroup>
         <br>
         <KButtonGroup>
           <KButton text="Primary" :primary="true" appearance="flat-button" />
           <KButton text="Secondary" :primary="false" appearance="flat-button" />
-          <KIconButton tooltip="KIconButton" icon="plus" :primary="false" appearance="flat-button" />
         </KButtonGroup>
       </DocsShow>
 
       <p>
-        Note that we don't use a "secondary basic link" style.
+        Note that we don't have a "secondary basic link" style.
       </p>
       <p>
-        Buttons can also contain both text and an icon. Based on the need, the icon can come either before or after the text. This should be used sparingly - only when the icon significantly adds value to the meaning of the button.
+        Buttons can also contain an icon. Based on the need, the icon can come either before or after the text. Icons should be used sparingly when it adds significant value to the meaning of the button.
       </p>
 
       <DocsShow>
@@ -91,43 +88,43 @@
           Avoid ambiguity; be specific about the action that will be performed. For example,
           use 'Save' instead of 'OK'
         </li>
-        <li>Never use commas or other punctuation</li>
-        <li>For raised and flat buttons, always use all-caps text</li>
+        <li>Avoid commas and other punctuation</li>
       </ul>
     </DocsPageSection>
 
     <DocsPageSection title="Placement" anchor="#placement">
       <p>
-        We have some conventions regarding placement of 'raised button' and
-        'flat button' actions:
+        We have some conventions regarding placement of 'raised' and 'flat' buttons:
       </p>
       <ul>
-        <li>Right-aligned in modal pop-ups</li>
-        <li>Left-aligned in page forms</li>
-        <li>Global actions related to tables should be put above the table and right-aligned</li>
+        <li>Right-aligned at the bottom of modal pop-ups</li>
+        <li>Left-aligned a the bottom of page forms</li>
+        <li>Global actions related to full pages should be right-aligned and to the right of the page title on large screens, and left-aligned below the title on small screens. Use of <code>KGrid</code> is recommended</li>
       </ul>
+      <p>
+        Use the <DocsLibraryLink page="KButtonGroup" /> component to add specing between adjacent buttons.
+      </p>
 
     </DocsPageSection>
 
     <DocsPageSection title="Icon buttons" anchor="#icon_buttons">
       <p>
-        Use icon buttons for editors, or in situations where using text buttons would hinder the user experience.
-      </p>
-      <p>
-        Default to using flat secondary style for icon buttons.
-      </p>
-      <p>
-        Be sure to consider internationalization, translation, and cultural meaning in the use of icon buttons.
+        Use icon buttons for editors, or in situations where using text buttons would hinder the user experience. Use the flat secondary style by default.
       </p>
       <p>
         A tooltip with the name of the action is required for an icon button.
       </p>
       <DocsShow>
         <KButtonGroup>
+          <KIconButton tooltip="Add" icon="plus" :primary="true" appearance="raised-button" />
+          <KIconButton tooltip="Subtract" icon="minus" :primary="false" appearance="raised-button" />
           <KIconButton tooltip="Add" text="Flat button" :primary="true" icon="plus" appearance="flat-button" />
           <KIconButton tooltip="Subtract" text="Flat button" :primary="false" icon="minus" appearance="flat-button" />
         </KButtonGroup>
       </DocsShow>
+      <p>
+        Be sure to consider internationalization, translation, and cultural implications when choosing icons.
+      </p>
 
     </DocsPageSection>
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -145,7 +145,7 @@
 
     <DocsPageSection title="Dropdowns" anchor="#dropdowns">
       <p>
-        Buttons can also have drop-down menus. Currently this is implemented using the poorly-named <code>KDropdownMenu</code> component, but this is subject to change.
+        Buttons can also have drop-down menus. Currently this is implemented using the poorly-named <code>KDropdownMenu</code> component, but this is <DocsGithubLink text="subject to change" issue="164" />.
       </p>
       <!-- TODO: implement 3 examples: primary button, primary flat button, and secondary icon button that function as dropdowns. See Google doc for example -->
       <DocsShow>

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -24,7 +24,11 @@
           <DocsLibraryLink page="KExternalLink" /> is used to create standard <code>&lt;a&gt;</code> tags with an <code>href</code> attribute.
         </li>
       </ul>
-      <p>We also provide a <DocsLibraryLink page="KButtonGroup" /> wrapper component to set standardized spacing between groups of buttons.</p>
+      <p>We also provide:</p>
+      <ul>
+        <li>a <DocsLibraryLink page="KButtonGroup" /> wrapper component to set standardized spacing between groups of buttons.</li>
+        <li>a <DocsLibraryLink page="KIconButton" /> for smaller icon-and-tooltip buttons</li>
+      </ul>
     </DocsPageSection>
 
     <DocsPageSection title="Visual styles" anchor="#visualstyles">
@@ -109,7 +113,7 @@
 
     <DocsPageSection title="Icon buttons" anchor="#icon_buttons">
       <p>
-        Use icon buttons for editors, or in situations where using text buttons would hinder the user experience. Use the flat secondary style by default.
+        Use <DocsLibraryLink page="KIconButton" /> in situations where larger buttons with visible text would hinder the user experience. Use the flat secondary style unless the action should be highlighted.
       </p>
       <p>
         A tooltip with the name of the action is required for an icon button.

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -167,17 +167,6 @@
       <li>Text button padding: 8px 16px</li>
       <li>Icon button padding: 8px</li>
     </ul>
-    <DocsDoNot>
-      <template v-slot:not>
-        <ul>
-          <li>Use outlines for buttons</li>
-          <li>Use full-width buttons</li>
-          <li>Set arbitrary fixed widths</li>
-          <li>Change the border radius</li>
-          <li>Change the drop-shadow</li>
-        </ul>
-      </template>
-    </DocsDoNot>
 
   </DocsPageTemplate>
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -132,7 +132,7 @@
         Be sure to consider internationalization, translation, and cultural meaning in the use of icon buttons.
       </p>
       <p>
-        Always include a tooltip with the name of the action for icon buttons.
+        A tooltip with the name of the action is required for an icon button.
       </p>
       <DocsShow>
         <KButtonGroup>

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -4,33 +4,24 @@
 
     <DocsPageSection title="Overview" anchor="#overview">
       <p>
-        Buttons use the <code>&lt;button&gt;</code> HTML tag and trigger an action on the current
-        page. Links use the <code>&lt;a&gt;</code> HTML tag and navigate to a new URL.
+        Buttons use the <code>&lt;button&gt;</code> HTML tag and trigger an action on the current page. Links use the <code>&lt;a&gt;</code> HTML tag and navigate to a new URL.
       </p>
       <p>
-        Buttons and links are <em>not</em> visually distinguishable.
-        Buttons can visually look like classic links,
-        and links can visually look like classic buttons.
+        Buttons and links are <em>not</em> visually distinguishable. Buttons can visually look like classic links, and links can visually look like classic buttons.
       </p>
       <p>
-        When the user would expect to use navigation history, right-click to copy a URL,
-        or control-click to open a page in a new tab, then a link should be used.
-        Otherwise, a button should be used.
+        When the user would expect to use navigation history, right-click to copy a URL, or control-click to open a page in a new tab, then a link should be used. Otherwise, a button should be used.
       </p>
       <p>As such, there are three components that all behave similarly, but are used for different purposes:</p>
       <ul>
         <li>
-          <DocsLibraryLink page="KButton" /> is used to create <code>&lt;button&gt;</code> tags with
-          <code>@click</code> event handlers.
+          <DocsLibraryLink page="KButton" /> is used to create <code>&lt;button&gt;</code> tags with <code>@click</code> event handlers.
         </li>
         <li>
-          <DocsLibraryLink page="KRouterLink" /> is used to create Vue router <code>&lt;router-link&gt;</code>
-          components with <code>:to</code> properties. These compile into <code>&lt;a&gt;</code>
-          tags.
+          <DocsLibraryLink page="KRouterLink" /> is used to create Vue router <code>&lt;router-link&gt;</code> components with <code>:to</code> properties. These compile into <code>&lt;a&gt;</code> tags.
         </li>
         <li>
-          <DocsLibraryLink page="KExternalLink" /> is used to create standard <code>&lt;a&gt;</code> tags with an
-          <code>href</code> attribute.
+          <DocsLibraryLink page="KExternalLink" /> is used to create standard <code>&lt;a&gt;</code> tags with an <code>href</code> attribute.
         </li>
       </ul>
       <p>We also provide a <DocsLibraryLink page="KButtonGroup" /> wrapper component to set standardized spacing between groups of buttons.</p>
@@ -38,18 +29,17 @@
 
     <DocsPageSection title="Visual styles" anchor="#visualstyles">
       <p>
-        There are 3 main appearances of button and link components.
-        (Remember that a button component can visually look like a link,
-        and a link component can visually look like a button.)
-        Each appearance maps to a different level of
-        <DocsExternalLink href="https://en.wikipedia.org/wiki/Visual_hierarchy" text="visual hierarchy" />:
+        There are 3 main appearances of button and link components. (Remember that a button component can visually look like a link, and a link component can visually look like a button.) Each appearance maps to a different level of <DocsExternalLink href="https://en.wikipedia.org/wiki/Visual_hierarchy" text="visual hierarchy" />:
       </p>
       <ul>
-        <li><strong>Raised buttons:</strong> button-like appearance for more prominent actions</li>
-        <li><strong>Flat buttons:</strong> button-like appearance for less prominent actions</li>
         <li>
-          <strong>Basic links:</strong>
-          hyperlink-like appearance for deemphasized actions, or actions inline within text
+          <strong>Raised buttons:</strong> button-like appearance for more prominent actions
+        </li>
+        <li>
+          <strong>Flat buttons:</strong> button-like appearance for less prominent actions
+        </li>
+        <li>
+          <strong>Basic links:</strong> hyperlink-like appearance for deemphasized actions, or actions inline within text
         </li>
       </ul>
       <DocsShow>
@@ -62,9 +52,7 @@
       </DocsShow>
 
       <p>
-        Actions with a button-like appearance can also be <strong>primary</strong> or
-        <strong>secondary</strong>. There should only be one primary button visible at a time,
-        and it should be a common or default action.
+        Actions with a button-like appearance can also be <strong>primary</strong> or <strong>secondary</strong>. There should only be one primary button visible at a time, and it should be a common or default action.
       </p>
 
       <DocsShow>

--- a/docs/plugins/load-common-components.js
+++ b/docs/plugins/load-common-components.js
@@ -4,6 +4,7 @@ import VueSimpleMarkdown from 'vue-simple-markdown';
 import DocsExternalLink from '~/common/DocsExternalLink';
 import DocsGithubLink from '~/common/DocsGithubLink';
 import DocsInternalLink from '~/common/DocsInternalLink';
+import DocsLibraryLink from '~/common/DocsLibraryLink';
 import DocsAnchorTarget from '~/common/DocsAnchorTarget';
 import DocsPageSection from '~/common/DocsPageSection';
 import DocsPageTemplate from '~/common/DocsPageTemplate';
@@ -13,6 +14,7 @@ import DocsFilter from '~/common/DocsFilter';
 
 Vue.component('DocsPageTemplate', DocsPageTemplate);
 Vue.component('DocsPageSection', DocsPageSection);
+Vue.component('DocsLibraryLink', DocsLibraryLink);
 Vue.component('DocsInternalLink', DocsInternalLink);
 Vue.component('DocsAnchorTarget', DocsAnchorTarget);
 Vue.component('DocsExternalLink', DocsExternalLink);

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -41,17 +41,21 @@ class Page {
     title, // used in side nav, page header, and document title
     isCode = false, // if true, format using <code> tag
     disabled = false, // placeholder - don't link
+    keywords = [], // additional terms to match
   } = {}) {
     this.path = path;
     this.title = title;
     this.isCode = isCode;
     this.disabled = disabled;
+    this.keywords = keywords;
   }
 }
 
 /***********************************************/
 /*   Table of contents                         */
 /***********************************************/
+
+const buttonRelatedItems = ['button', 'link'];
 
 export default [
   new Section({
@@ -286,6 +290,7 @@ export default [
         path: '/KCheckbox',
         title: 'KCheckbox',
         isCode: true,
+        keywords: ['button'],
       }),
       new Page({
         path: '/KCircularLoader',
@@ -360,18 +365,21 @@ export default [
         path: '/KSwitch',
         title: 'KSwitch',
         isCode: true,
+        keywords: ['button'],
       }),
       new Page({
         path: '/KButton',
         title: 'KButton',
         isCode: true,
         disabled: true,
+        keywords: buttonRelatedItems,
       }),
       new Page({
         path: '/KExternalLink',
         title: 'KExternalLink',
         isCode: true,
         disabled: true,
+        keywords: buttonRelatedItems,
       }),
       new Page({
         path: '/KRouterLink',

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -371,7 +371,6 @@ export default [
         path: '/KButton',
         title: 'KButton',
         isCode: true,
-        disabled: true,
         keywords: buttonRelatedItems,
       }),
       new Page({

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -356,6 +356,12 @@ export default [
         disabled: true,
       }),
       new Page({
+        path: '/KIconButton',
+        title: 'KIconButton',
+        isCode: true,
+        keywords: buttonRelatedItems,
+      }),
+      new Page({
         path: '/KLabeledIcon',
         title: 'KLabeledIcon',
         isCode: true,

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -377,14 +377,12 @@ export default [
         path: '/KExternalLink',
         title: 'KExternalLink',
         isCode: true,
-        disabled: true,
         keywords: buttonRelatedItems,
       }),
       new Page({
         path: '/KRouterLink',
         title: 'KRouterLink',
         isCode: true,
-        disabled: true,
         keywords: buttonRelatedItems,
       }),
       new Page({

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -386,6 +386,13 @@ export default [
         title: 'KRouterLink',
         isCode: true,
         disabled: true,
+        keywords: buttonRelatedItems,
+      }),
+      new Page({
+        path: '/KButtonGroup',
+        title: 'KButtonGroup',
+        isCode: true,
+        keywords: ['button'],
       }),
       new Page({
         path: '/KContentRenderer',

--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -47,7 +47,7 @@
         v-if="!label && $slots.default"
         class="k-checkbox-label"
       >
-        <!-- @slot Used as an alternative to the `label` prop -->
+        <!-- @slot Slot alternative to the `label` prop -->
         <slot></slot>
       </div>
 

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -20,7 +20,7 @@
       class="prop-icon"
     />
 
-    <!-- @slot Slot alternative to the `text` prop -->
+    <!-- @slot Pass sub-components into the button, which provides more flexibility than and takes precedence over the `text` prop -->
     <slot v-if="$slots.default"></slot>
 
     <template v-else>

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -11,7 +11,7 @@
     @click="handleClick"
     @keyup.enter.stop.prevent="handlePressEnter"
   >
-    <!-- icon may come by slot or by prop -->
+    <!-- @slot Slot alternative to the `icon` prop -->
     <slot name="icon"></slot>
     <KIcon
       v-if="icon"
@@ -20,13 +20,14 @@
       class="prop-icon"
     />
 
+    <!-- @slot Slot alternative to the `text` prop -->
     <slot v-if="$slots.default"></slot>
 
     <template v-else>
       <span class="link-text" :style="textStyle">{{ text }}</span>
     </template>
 
-    <!-- iconAfter may come by slot or by prop -->
+    <!-- @slot Slot alternative to the `iconAfter` prop -->
     <slot name="iconAfter"></slot>
     <KIcon
       v-if="iconAfter"
@@ -61,7 +62,7 @@
     mixins: [buttonMixin],
     props: {
       /**
-       * Button appearance: 'raised-button', 'flat-button', or 'basic-link'
+       * Button appearance: `'raised-button'`, `'flat-button'`, or `'basic-link'`
        */
       appearance: {
         type: String,
@@ -76,7 +77,7 @@
         default: false,
       },
       /**
-       * HTML button 'type' attribute (e.g. 'submit', 'reset')
+       * HTML button `type` attribute (e.g. `'submit'`, `'reset'`)
        */
       type: {
         type: String,
@@ -91,14 +92,14 @@
         default: false,
       },
       /**
-       * If provided, prepends a KIcon to the text in the button
+       * If provided, prepends a `KIcon` to the text in the button
        */
       icon: {
         type: String,
         default: null,
       },
       /**
-       * If provided, appends an KIcon to the text in the button.
+       * If provided, appends an `KIcon` to the text in the button
        */
       iconAfter: {
         type: String,
@@ -148,10 +149,10 @@
     },
     methods: {
       handleClick(event) {
+        this.blurWhenClicked();
         /**
          * Emitted when the button is triggered
          */
-        this.blurWhenClicked();
         this.$emit('click', event);
       },
       handlePressEnter(event) {

--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div class="button-group">
+    <!-- @slot Slot to wrap buttons and provide consistent spacing -->
     <slot></slot>
   </div>
 

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -12,6 +12,7 @@
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >
+    <!-- @slot Slot alternative to the `icon` prop -->
     <slot name="icon">
       <KIcon
         v-if="icon"
@@ -21,6 +22,7 @@
       />
     </slot>
     <span class="link-text" :style="spanStyle">{{ text }}</span>
+    <!-- @slot Slot alternative to the `iconAfter` prop -->
     <slot name="iconAfter">
       <KIcon
         v-if="iconAfter"
@@ -29,6 +31,7 @@
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
     </slot>
+    <!-- @slot unknown purpose -->
     <slot name="openInNewTab">
       <KIcon
         v-if="openInNewTab"

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -58,7 +58,7 @@
        */
       href: {
         type: String,
-        required: true,
+        default: null,
       },
       /**
        * Specifies that the file is meant to be downloaded, not displayed in a separate tab.

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -5,7 +5,7 @@
     :disabled="disabled"
     :appearance="appearance"
     :appearanceOverrides="appearanceOverrides"
-    :buttonType="buttonType"
+    :type="buttonType"
     :aria-label="ariaLabel"
     text=""
     v-on="$listeners"
@@ -33,35 +33,58 @@
     name: 'KIconButton',
     components: { UiTooltip },
     props: {
+      /**
+       * Button appearance: `'raised-button'` or `'flat-button'`
+       */
       appearance: {
         type: String,
         default: 'flat-button',
       },
+      /**
+       * Name of icon to display
+       */
       icon: {
         type: String,
         required: true,
       },
-      /* color: hex or rgb[a] color */
+      /**
+       * Optional hex or rgb[a] color for the button background
+       */
       color: {
         type: String,
         default: null,
       },
+      /**
+       * Whether or not button is disabled
+       */
       disabled: {
         type: Boolean,
         default: false,
       },
+      /**
+       * HTML button `type` attribute (e.g. `'submit'`, `'reset'`)
+       */
       buttonType: {
         type: String,
         default: 'button',
       },
+      /**
+       * Button size: `'mini'`, `'small'`, `'regular'`, or `'large'`
+       */
       size: {
         type: String,
-        default: null,
+        default: 'regular',
       },
+      /**
+       * `aria-label` attribute
+       */
       ariaLabel: {
         type: String,
         default: null,
       },
+      /**
+       * Tooltip label
+       */
       tooltip: {
         type: String,
         required: true,

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -7,6 +7,7 @@
     :appearanceOverrides="appearanceOverrides"
     :buttonType="buttonType"
     :aria-label="ariaLabel"
+    text=""
     v-on="$listeners"
   >
     <UiTooltip
@@ -63,7 +64,7 @@
       },
       tooltip: {
         type: String,
-        default: null,
+        required: true,
       },
     },
     computed: {

--- a/lib/buttons-and-links/buttonMixin.js
+++ b/lib/buttons-and-links/buttonMixin.js
@@ -18,7 +18,7 @@ export default {
      */
     text: {
       type: String,
-      required: false,
+      default: null,
     },
     /**
      * Button appearance: 'raised-button', 'flat-button', or 'basic-link'

--- a/lib/buttons-and-links/buttonMixin.js
+++ b/lib/buttons-and-links/buttonMixin.js
@@ -21,7 +21,7 @@ export default {
       default: null,
     },
     /**
-     * Button appearance: 'raised-button', 'flat-button', or 'basic-link'
+     * Button appearance: `'raised-button'`, `'flat-button'`, or `'basic-link'`
      */
     appearance: {
       type: String,
@@ -36,7 +36,7 @@ export default {
       default: () => ({}),
     },
     /**
-     * For 'raised-button' and 'flat-button' appearances: show as primary or secondary style
+     * Show as primary rather than secondary style (for `'raised-button'` and `'flat-button'` appearance)
      */
     primary: {
       type: Boolean,


### PR DESCRIPTION

# Component documentation

Adds documentation for library components:

* `KButton`
* `KRouterLink`
* `KExternalLink`
* `KButtonGroup`
* `KIconButton`



![2021-02-23 09 57 09](https://user-images.githubusercontent.com/2367265/108886437-d2276d00-75bd-11eb-8e4a-33b3abdbcec3.gif)


# Filter keywords

Adds a new 'keywords' property to the table of contents to allow filtering by related terms. For example:

```js
      new Page({
        path: '/KButton',
        title: 'KButton',
        isCode: true,
        keywords: ['button', 'link'],
      }),
```


![2021-02-23 09 49 24](https://user-images.githubusercontent.com/2367265/108885306-81634480-75bc-11eb-890f-34126df2f2af.gif)

# Cross-links to components

Adds a new `DocsLibraryLink` component to allow easy cross-linking. For example:

```vue
<DocsLibraryLink page="KExternalLink" /> is used to create standard <code>&lt;a&gt;</code> tags with an <code>href</code> attribute.
```

![2021-02-23 09 52 18](https://user-images.githubusercontent.com/2367265/108885735-00f11380-75bd-11eb-9a5a-cffdc20c120c.gif)

