### PR TITLE
Updates to templates: Fix location of PR template and separate bug/enhancements

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement_template.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_template.md
@@ -1,0 +1,37 @@
+---
+name: Enhancement Request
+about: Suggest an idea!
+title: "[Title]: Brief description"
+labels: ''
+assignees: ''
+
+---
+
+<!-- Please remove any unused sections
+
+Instructions:
+- Title line template: [Title]: Brief description
+
+-->
+
+# Enhancement Request
+## Product
+<!-- Where could this enhancement be useful? (Kolibri, Studio, etc.) -->
+
+## Desired behavior
+<!-- Briefly describe the behavior you would like to see -->
+
+
+## Current behavior
+<!-- Briefly describe the current behavior; you may include screenshots, code, and notes -->
+
+
+## (Optional) The Value Add
+<!-- Explain why this should be added or changed in KDS and where it could be used -->
+
+
+## (Optional) Possible Tradeoffs
+<!-- Explain possible issues/costs that could arise - if any - from implementing this enhancement -->
+
+# Add labels
+Please choose the appropriate label(s) from our existing label list to ensure that your issue is properly categorized. This will help us to better understand and address your issue!

--- a/.github/ISSUE_TEMPLATE/enhancement_template.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_template.md
@@ -14,7 +14,6 @@ Instructions:
 
 -->
 
-# Enhancement Request
 ## Product
 <!-- Where could this enhancement be useful? (Kolibri, Studio, etc.) -->
 

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -14,7 +14,6 @@ Instructions:
 
 -->
 
-# Bug
 ## Product
 <!-- Where did you notice this bug? (Kolibri, Studio, Design System, etc.) -->
 

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,6 +1,6 @@
 ---
-name: ISSUE_TEMPLATE
-about: Create bug report or enhancement request
+name: Bug Report
+about: Create a bug report to help us improve
 title: "[Title]: Brief description"
 labels: ''
 assignees: ''
@@ -11,20 +11,19 @@ assignees: ''
 
 Instructions:
 - Title line template: [Title]: Brief description
-- Choose between "bug" or "enhancement request" below, fill it in, and delete the other section
 
 -->
 
 # Bug
 ## Product
-*Where did you notice this bug? (Kolibri, Studio, etc.)*
+<!-- Where did you notice this bug? (Kolibri, Studio, Design System, etc.) -->
 
 ## Expected behavior
-*Briefly describe the expected behavior*
+<!-- Briefly describe the expected behavior -->
 
 
 ## Actual behavior
-*Briefly describe the current behavior*
+<!-- Briefly describe the current behavior -->
 
 
 ## Steps to reproduce the issue
@@ -34,31 +33,8 @@ Instructions:
 
 
 ## Additional information
-* Screenshots or code?
-* Notes?
+<!-- Include screenshots, code, or notes to help us better understand the issue -->
 
 ## Environment
 - OS:
 - Browser version:
-
-# Enhancement Request
-## Product
-*Where could this enhancement be useful? (Kolibri, Studio, etc.)*
-
-## Desired behavior
-*Briefly describe the behavior you would like to see*
-
-
-## Current behavior
-*Briefly describe the current behavior; you may include screenshots, code, and notes*
-
-
-## (Optional) The Value Add
-*Explain why this should be added or changed in KDS and where it could be used*
-
-
-## (Optional) Possible Tradeoffs
-*Explain possible issues/costs that could arise - if any - from implementing this enhancement*
-
-# Add labels
-Please choose the appropriate label(s) from our existing label list to ensure that your issue is properly categorized. This will help us to better understand and address your issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,13 +40,14 @@ Addresses #*PR# HERE*
 <!-- List anything that will need to be addressed later -->
 
 
-## Checklist
+## Checklist for the Reviewer
 
-<!-- Delete anything that doesn't apply -->
+<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->
 
 - [ ] Is the code clean and well-commented?
 - [ ] Are there tests for this change?
 - [ ] Are all UI components LTR and RTL compliant (if applicable)?
+- [ ] _Add other things to check for here_
 
 ## Comments
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ---
-name: PULL_REQUEST
-about: Create pull request
+name: Pull Request
+about: Create a pull request
 title: "[TITLE]: Brief description of PR"
 labels: ''
 assignees: ''
@@ -13,13 +13,14 @@ assignees: ''
 
 <!-- What does this PR do? Briefly describe in 1-2 sentences* -->
 
-#### Issue Addressed (if applicable)
+#### Issue Addressed
+<!-- Only necessary if applicable -->
 
 Addresses #*PR# HERE*
 
-#### Before/After Screenshots (if applicable)
+### Before/After Screenshots
 
-<!-- Insert images here -->
+<!-- Insert images here if applicable -->
 
 
 ## Steps to Test

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ assignees: ''
 
 ## Description
 
-*What does this PR do? Briefly describe in 1-2 sentences*
+<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
 
 #### Issue Addressed (if applicable)
 
@@ -19,7 +19,7 @@ Addresses #*PR# HERE*
 
 #### Before/After Screenshots (if applicable)
 
-*Insert images here*
+<!-- Insert images here -->
 
 
 ## Steps to Test
@@ -32,16 +32,16 @@ Addresses #*PR# HERE*
 
 ### At a high level, how did you implement this?
 
-*Briefly describe how this works*
+<!-- Briefly describe how this works -->
 
 ### Does this introduce any tech-debt items?
 
-*List anything that will need to be addressed later*
+<!-- List anything that will need to be addressed later -->
 
 
 ## Checklist
 
-*Delete anything that doesn't apply*
+<!-- Delete anything that doesn't apply -->
 
 - [ ] Is the code clean and well-commented?
 - [ ] Are there tests for this change?
@@ -49,4 +49,4 @@ Addresses #*PR# HERE*
 
 ## Comments
 
-*Any additional notes you'd like to add*
+<!-- Any additional notes you'd like to add -->


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

1. Updates the location of the PR template. It was originally, erroneously housed in the `ISSUES_TEMPLATES` folder, so it was showing up as an issue template rather than a PR template.
2. Makes an adjustment so users can decide if the issue is a bug report or a feature request when they click on "New issue"


### Before/After Screenshots (if applicable)

<!-- Insert images here -->
Before
- Currently, opening an issue only gives us an option to add an "ISSUE_TEMPLATE" or a "PULL_REQUEST" (?!!)

![Screen Shot 2021-02-19 at 8 17 40 PM](https://user-images.githubusercontent.com/13563002/108583616-85a70d80-72ef-11eb-84d2-6319c2bd0c9c.png)

After:
1. We should still have two options, but they will be *Bug Report* and *Enhancement Request*
2. We should see a template when we open up a PR

## Checklist for Reviewer

<!-- Delete anything that doesn't apply -->

- [ ] Is the code clean and well-commented?
