### PR TITLE
Add anchor links to individual glossary terms

### DIFF
--- a/docs/pages/glossary/index.vue
+++ b/docs/pages/glossary/index.vue
@@ -27,7 +27,12 @@
         </thead>
         <tbody>
           <tr v-for="(term, i) in visibleTerms" :key="i">
-            <th>{{ term.term }}</th>
+            <th>
+              {{ term.term }}
+              <DocsAnchorTarget
+                :anchor="anchor(term)"
+              />
+            </th>
             <td><em>{{ term.note }}</em></td>
             <td>{{ term.description }}</td>
           </tr>
@@ -73,6 +78,18 @@
       },
       filterTerms() {
         return termList(this.filterText);
+      },
+    },
+    methods: {
+      anchor(term) {
+        // standarize url
+        return `#${term.term
+          .toLowerCase()
+          .split(' ')
+          .join('_')
+          .replace('(', '')
+          .replace(')', '')
+          .replace(',', '')}`;
       },
     },
   };


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
title: "Add anchor tags to glossary"
labels: 'docs, Q1 Milestone'
assignees: ''

---

<!-- Please remove any unused sections -->

## Description

Adds anchor links on the glossary page to each individual term 

#### Issue Addressed

Fixes #146 

### Before/After Screenshots

BEFORE
<img width="1411" alt="Screen Shot 2021-02-22 at 6 33 26 PM" src="https://user-images.githubusercontent.com/17235236/108784034-7668cf80-753c-11eb-8799-b60877d0cc02.png">

AFTER
<img width="1420" alt="Screen Shot 2021-02-22 at 6 32 42 PM" src="https://user-images.githubusercontent.com/17235236/108783979-5d601e80-753c-11eb-84d6-5e64b4f55e30.png">

## (Optional) Implementation Notes

### At a high level, how did you implement this?

Based on the Icons page, I similarly created a method to dynamically add anchor links based on the term, and used the `<DocsAnchorTarget/>` component to handle the styling.

## Checklist for the Reviewer

- [ ] Is the code clean and well-commented?
- [ ] Do the anchor links work as expected
