### PR TITLE
Eliminate need to double-tab into dropdown

### DIFF
--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -1,29 +1,17 @@
 <template>
-
-  <div class="dib">
-    <!-- Added because the trigger could not be a vue element smh-->
-    <div
-      ref="buttonContainer"
-      class="button-container dib"
-    >
-      <slot name="button"></slot>
-      <KButton
-        v-if="!$slots.button"
-        ref="button"
-        :text="text"
-        :appearance="appearance"
-        :disabled="disabled"
-        :hasDropdown="true"
-        :primary="$attrs.primary"
-      />
-    </div>
-
-    <UiPopover
+  <KButton
+    ref="button"
+    :appearance="appearance"
+    :disabled="disabled"
+    :hasDropdown="true"
+    :primary="$attrs.primary"
+  >
+  <span>{{text}}</span>
+  <UiPopover
       v-if="!disabled"
       ref="popover"
       :z-index="12"
-      :trigger="$refs.buttonContainer"
-      :containFocus="false"
+      :containFocus="true"
       :dropdownPosition="position"
       @close="handleClose"
       @open="handleOpen"
@@ -31,10 +19,10 @@
       <UiMenu
         :options="options"
         @select="handleSelection"
+        :containFocus="containFocus"
       />
-    </UiPopover>
-
-  </div>
+    </UiPopover> 
+  </KButton>
 
 </template>
 


### PR DESCRIPTION
## Description

This PR prevents the loss of focus/double tab necessary to enter KDropdownModal

#### Issue Addressed
Fixes #136 
![tab-nav-after-2](https://user-images.githubusercontent.com/17235236/109316948-22027000-781a-11eb-98c1-fb09a05a9f6b.gif)

## Steps to Test

1. In Kolibri, on the channels page, use the tab key to navigate. You should be able to proceed from the main horizontal nav and move to the "Options" menu without a break/loss of focus.

## Comments

There is a [separate issue with `<KDropdownMenu />` not being keyboard navigable](https://github.com/learningequality/kolibri-design-system/issues/178) when the menu is open (meaning, there is no way to enter the menu). This PR does not resolve that. I've documented and assigned that issue to myself.


