### PR TITLE
Adds imperative verb guidance to modals and page headers

### DIFF
--- a/docs/pages/modals/index.vue
+++ b/docs/pages/modals/index.vue
@@ -27,7 +27,7 @@
         Title
       </h3>
       <p>
-        Keep this short, concise, and easy for the user to understand. Should not be structured as a sentence or question, and should not contain user-generated text.
+        Keep this short, concise, and easy for the user to understand. Titles should not be structured as a sentence or question, and should not contain user-generated text. Use verbs in the imperative form. Do not use verbs that end in "-ing"; doing so may give users the impression that a task is in progress when it is not.
       </p>
       <DocsDoNot>
         <template v-slot:do>

--- a/docs/pages/pageheader/index.vue
+++ b/docs/pages/pageheader/index.vue
@@ -33,6 +33,9 @@
         Page titles should correspond to <DocsInternalLink href="/appbars/#titles" text="app bar titles" />. If there are tabs in the app bar, the page title should be consistent with the current tab, although a word or two can be added on to the page title for clarity.
       </p>
       <img src="./page-header2.png">
+      <p>
+        Write any verbs that appear in page titles in the imperative form. Do not use verbs that end in "-ing"; doing so may give users the impression that a task is in progress when it is not.
+      </p>
     </DocsPageSection>
 
     <DocsPageSection title="Page titles and the browser" anchor="#browser">


### PR DESCRIPTION
## Description

I messed up my local git somehow... reposting [this PR](https://github.com/learningequality/kolibri-design-system/pull/176) here

Adds guidelines to not use verbs ending in "-ing" on page titles and modal titles because they give the false impression that a task is in progress. Added to Page headers and Modals pages

#### Issue Addressed
<!-- Only necessary if applicable -->

Addresses https://github.com/learningequality/kolibri-design-system/issues/92

### Before/After Screenshots

<!-- Insert images here if applicable -->

### Page headers

| Before  | After |
| ------------- | ------------- |
| <img width="736" alt="Screen Shot 2021-03-01 at 4 27 04 PM" src="https://user-images.githubusercontent.com/6668144/109577844-22fe0080-7aab-11eb-925c-8f6718c06a28.png"> | <img width="746" alt="Screen Shot 2021-03-01 at 4 26 02 PM" src="https://user-images.githubusercontent.com/6668144/109577861-2b563b80-7aab-11eb-98c6-e082b7a86809.png"> |

### Modals

| Before  | After |
| ------------- | ------------- |
| <img width="733" alt="Screen Shot 2021-03-01 at 4 27 11 PM" src="https://user-images.githubusercontent.com/6668144/109577906-46c14680-7aab-11eb-9bfc-2b246121521e.png"> | <img width="729" alt="Screen Shot 2021-03-01 at 4 26 34 PM" src="https://user-images.githubusercontent.com/6668144/109577925-504aae80-7aab-11eb-8fab-b42e9155990d.png"> |
