### PR TITLE
Kdropdown keyboard navigation

### DIFF
--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -98,12 +98,12 @@
       },
     },
     beforeDestroy() {
-      window.removeEventListener('keyup', this.handleKeyUp, true);
+      window.removeEventListener('keydown', this.handleArrowKeys, true);
     },
     methods: {
       handleOpen() {
         this.$nextTick(() => this.setFocus());
-        window.addEventListener('keyup', this.handleKeyUp, true);
+        window.addEventListener('keydown', this.handleArrowKeys, true);
       },
       setFocus() {
         this.$refs.menu.$el.querySelector('li').focus();
@@ -121,14 +121,23 @@
         }
         window.removeEventListener('keyup', this.handleKeyUp, true);
       },
-      handleKeyUp(event) {
-        if (event.shiftKey && event.keyCode == 9) {
-          const popover = this.$refs.popover.$el;
-          const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
-          if (popoverIsOpen && !popover.contains(document.activeElement)) {
-            this.closePopover();
-            this.focusOnButton();
-          }
+      handleArrowKeys(event) {
+        // identify the menu state and length 
+        const popover = this.$refs.popover.$el;
+        const menuElements = this.$refs.menu.$el.querySelector('div').children
+        const lastChild = menuElements[menuElements.length - 1]
+        const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
+        // set current element and its siblings
+        let focusedElement = document.activeElement;
+        let sibling = focusedElement.nextElementSibling;
+        let prevSibling = focusedElement.previousElementSibling;
+        // manage rotating through the options
+        if (event.keyCode == 38 && popoverIsOpen) {
+          event.preventDefault()
+          prevSibling ? this.$nextTick(() => prevSibling.focus()) : this.$nextTick(() => lastChild.focus())
+        } else if (event.keyCode == 40 && popoverIsOpen) {
+          event.preventDefault()
+          sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
         }
       },
       handleSelection(selection) {

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -122,10 +122,10 @@
         window.removeEventListener('keyup', this.handleKeyUp, true);
       },
       handleArrowKeys(event) {
-        // identify the menu state and length 
+        // identify the menu state and length
         const popover = this.$refs.popover.$el;
-        const menuElements = this.$refs.menu.$el.querySelector('div').children
-        const lastChild = menuElements[menuElements.length - 1]
+        const menuElements = this.$refs.menu.$el.querySelector('div').children;
+        const lastChild = menuElements[menuElements.length - 1];
         const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
         // set current element and its siblings
         let focusedElement = document.activeElement;
@@ -133,10 +133,12 @@
         let prevSibling = focusedElement.previousElementSibling;
         // manage rotating through the options
         if (event.keyCode == 38 && popoverIsOpen) {
-          event.preventDefault()
-          prevSibling ? this.$nextTick(() => prevSibling.focus()) : this.$nextTick(() => lastChild.focus())
+          event.preventDefault();
+          prevSibling
+            ? this.$nextTick(() => prevSibling.focus())
+            : this.$nextTick(() => lastChild.focus());
         } else if (event.keyCode == 40 && popoverIsOpen) {
-          event.preventDefault()
+          event.preventDefault();
           sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
         }
       },

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -18,6 +18,7 @@
       @open="handleOpen"
     >
       <UiMenu
+        ref="menu"
         :options="options"
         @select="handleSelection"
       />
@@ -101,7 +102,11 @@
     },
     methods: {
       handleOpen() {
+        this.$nextTick(() => this.setFocus());
         window.addEventListener('keyup', this.handleKeyUp, true);
+      },
+      setFocus() {
+        this.$refs.menu.$el.querySelector('li').focus();
       },
       handleClose() {
         const focusedElement = document.activeElement;
@@ -116,16 +121,16 @@
         }
         window.removeEventListener('keyup', this.handleKeyUp, true);
       },
-      handleKeyUp(event) {
-        if (event.shiftKey && event.keyCode == 9) {
-          const popover = this.$refs.popover.$el;
-          const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
-          if (popoverIsOpen && !popover.contains(document.activeElement)) {
-            this.closePopover();
-            this.focusOnButton();
-          }
-        }
-      },
+      // handleKeyUp(event) {
+      //   if (event.shiftKey && event.keyCode == 9) {
+      //     const popover = this.$refs.popover.$el;
+      //     const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
+      //     if (popoverIsOpen && !popover.contains(document.activeElement)) {
+      //       this.closePopover();
+      //       this.focusOnButton();
+      //     }
+      //   }
+      // },
       handleSelection(selection) {
         /**
          * Emitted when an option is selected

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -124,7 +124,7 @@
       handleOpenMenuNavigation(event) {
         // identify the menu state and length
         if (!this.$refs.popover && !this.$refs.popover.$el) {
-          return
+          return;
         }
         const popover = this.$refs.popover.$el;
         const menuElements = this.$refs.menu.$el.querySelector('div').children;
@@ -145,7 +145,7 @@
           sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
           // if a tab key, not an arrow key, close the popover and advance to next item in the tab index
         } else if (event.keyCode == 9 && popoverIsOpen) {
-          this.closePopover()
+          this.closePopover();
         }
       },
       handleSelection(selection) {

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -137,7 +137,6 @@
 
         // manage rotating through the options using arrow keys
         // UP arrow: .keyCode is depricated and should used only as a fallback
-        console.log(event.key);
         if ((event.key == 'ArrowUp' || event.keyCode == 38) && popoverIsOpen) {
           event.preventDefault();
           prevSibling

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -103,7 +103,7 @@
     methods: {
       handleOpen() {
         this.$nextTick(() => this.setFocus());
-        window.addEventListener('keydown', this.handleArrowKeys, true);
+        window.addEventListener('keydown', this.handleOpenMenuNavigation, true);
       },
       setFocus() {
         this.$refs.menu.$el.querySelector('li').focus();
@@ -121,8 +121,11 @@
         }
         window.removeEventListener('keyup', this.handleKeyUp, true);
       },
-      handleArrowKeys(event) {
+      handleOpenMenuNavigation(event) {
         // identify the menu state and length
+        if (!this.$refs.popover && !this.$refs.popover.$el) {
+          return
+        }
         const popover = this.$refs.popover.$el;
         const menuElements = this.$refs.menu.$el.querySelector('div').children;
         const lastChild = menuElements[menuElements.length - 1];
@@ -140,6 +143,9 @@
         } else if (event.keyCode == 40 && popoverIsOpen) {
           event.preventDefault();
           sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
+          // if a tab key, not an arrow key, close the popover and advance to next item in the tab index
+        } else if (event.keyCode == 9 && popoverIsOpen) {
+          this.closePopover()
         }
       },
       handleSelection(selection) {

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -121,16 +121,16 @@
         }
         window.removeEventListener('keyup', this.handleKeyUp, true);
       },
-      // handleKeyUp(event) {
-      //   if (event.shiftKey && event.keyCode == 9) {
-      //     const popover = this.$refs.popover.$el;
-      //     const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
-      //     if (popoverIsOpen && !popover.contains(document.activeElement)) {
-      //       this.closePopover();
-      //       this.focusOnButton();
-      //     }
-      //   }
-      // },
+      handleKeyUp(event) {
+        if (event.shiftKey && event.keyCode == 9) {
+          const popover = this.$refs.popover.$el;
+          const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
+          if (popoverIsOpen && !popover.contains(document.activeElement)) {
+            this.closePopover();
+            this.focusOnButton();
+          }
+        }
+      },
       handleSelection(selection) {
         /**
          * Emitted when an option is selected

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -98,7 +98,7 @@
       },
     },
     beforeDestroy() {
-      window.removeEventListener('keydown', this.handleArrowKeys, true);
+      window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
     },
     methods: {
       handleOpen() {
@@ -134,17 +134,21 @@
         let focusedElement = document.activeElement;
         let sibling = focusedElement.nextElementSibling;
         let prevSibling = focusedElement.previousElementSibling;
-        // manage rotating through the options
-        if (event.keyCode == 38 && popoverIsOpen) {
+
+        // manage rotating through the options using arrow keys
+        // UP arrow: .keyCode is depricated and should used only as a fallback
+        console.log(event.key);
+        if ((event.key == 'ArrowUp' || event.keyCode == 38) && popoverIsOpen) {
           event.preventDefault();
           prevSibling
             ? this.$nextTick(() => prevSibling.focus())
             : this.$nextTick(() => lastChild.focus());
-        } else if (event.keyCode == 40 && popoverIsOpen) {
+          // DOWN arrow
+        } else if ((event.key == 'ArrowDown' || event.keyCode == 40) && popoverIsOpen) {
           event.preventDefault();
           sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
-          // if a tab key, not an arrow key, close the popover and advance to next item in the tab index
-        } else if (event.keyCode == 9 && popoverIsOpen) {
+          // if a TAB key, not an arrow key, close the popover and advance to next item in the tab index
+        } else if ((event.key == 'Tab' || event.keyCode == 9) && popoverIsOpen) {
           this.closePopover();
         }
       },

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -27,6 +27,7 @@
       @keydown.enter.native="selectOption(option)"
 
       @keydown.esc.native.esc="closeMenu"
+      :style="[ activeOutline ]"
     >
       <slot name="option" :option="option"></slot>
     </UiMenuOption>
@@ -100,6 +101,9 @@
           'has-icons': this.hasIcons,
           'has-secondary-text': this.hasSecondaryText,
         };
+      },
+      activeOutline() {
+        return this.isActive ? this.$coreOutline : {};
       },
     },
 

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -104,9 +104,6 @@
       activeOutline() {
         return this.isActive ? this.$coreOutline : {};
       },
-      redirectFocus() {
-        console.log(document.activeElement)
-      },
     },
 
     methods: {

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -8,7 +8,6 @@
     lazy
 
     :class="classes"
-    :contain-focus="containFocus"
   >
     <UiMenuOption
       v-for="(option, index) in options"
@@ -105,6 +104,9 @@
       activeOutline() {
         return this.isActive ? this.$coreOutline : {};
       },
+      redirectFocus() {
+        console.log(document.activeElement)
+      },
     },
 
     methods: {
@@ -116,7 +118,6 @@
         this.$emit('select', option);
         this.closeMenu();
       },
-
       closeMenu() {
         this.$emit('close');
       },

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -9,6 +9,10 @@
     :href="isAnchor ? (disabled ? null : href) : null"
     :tabindex="(isDivider || isAnchor || disabled) ? null : '0'"
     :target="isAnchor ? (disabled ? null : target) : null"
+    @focus="onFocus"
+    @blur="onBlur"
+    :style="isActive ? this.activeStyles : {}"
+
   >
     <slot v-if="!isDivider">
       <div class="ui-menu-option-content">
@@ -68,6 +72,12 @@
       },
     },
 
+    data() {
+      return {
+        isActive: false,
+      };
+    },
+
     computed: {
       classes() {
         return {
@@ -84,7 +94,20 @@
       isAnchor() {
         return !this.isDivider && this.href !== undefined;
       },
+      activeStyles() {
+        return { ...this.$coreOutline, outlineOffset: '-2px' }
+      },
     },
+    methods: {
+      onFocus(e) {
+        this.isActive = true;
+        this.$emit('focus', e);
+      },
+      onBlur(e) {
+        this.isActive = false;
+        this.$emit('blur', e);
+      },
+    }
   };
 
 </script>
@@ -121,6 +144,11 @@
       outline: none;
 
       &:hover:not(.is-disabled),
+      body[modality='keyboard'] &:focus {
+        background-color: $ui-menu-item-hover-color;
+      }
+
+      &:focus:not(.is-disabled),
       body[modality='keyboard'] &:focus {
         background-color: $ui-menu-item-hover-color;
       }

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -9,10 +9,6 @@
     :href="isAnchor ? (disabled ? null : href) : null"
     :tabindex="(isDivider || isAnchor || disabled) ? null : '0'"
     :target="isAnchor ? (disabled ? null : target) : null"
-    @focus="onFocus"
-    @blur="onBlur"
-    :style="isActive ? this.activeStyles : {}"
-
   >
     <slot v-if="!isDivider">
       <div class="ui-menu-option-content">
@@ -72,12 +68,6 @@
       },
     },
 
-    data() {
-      return {
-        isActive: false,
-      };
-    },
-
     computed: {
       classes() {
         return {
@@ -94,20 +84,7 @@
       isAnchor() {
         return !this.isDivider && this.href !== undefined;
       },
-      activeStyles() {
-        return { ...this.$coreOutline, outlineOffset: '-2px' }
-      },
     },
-    methods: {
-      onFocus(e) {
-        this.isActive = true;
-        this.$emit('focus', e);
-      },
-      onBlur(e) {
-        this.isActive = false;
-        this.$emit('blur', e);
-      },
-    }
   };
 
 </script>

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -3,9 +3,12 @@
   <component
     :is="isAnchor ? 'a' : 'li'"
     class="ui-menu-option"
-
+    supports-modality=keyboard
+    @focus="isActive = true"
+    @blur="isActive = false"
     role="menu-item"
     :class="classes"
+    :style="activeStyle"
     :href="isAnchor ? (disabled ? null : href) : null"
     :tabindex="(isDivider || isAnchor || disabled) ? null : '0'"
     :target="isAnchor ? (disabled ? null : target) : null"
@@ -41,6 +44,8 @@
 <script>
 
   import UiIcon from './UiIcon.vue';
+  import globalThemeState from '../styles/globalThemeState';
+
 
   export default {
     name: 'UiMenuOption',
@@ -48,6 +53,10 @@
     components: {
       UiIcon,
     },
+
+    data:() => ({
+      isActive: false,
+    }),
 
     props: {
       type: String,
@@ -77,6 +86,9 @@
         };
       },
 
+      activeStyle() {
+        return this.isActive ? {...this.$coreOutline, outlineOffset: '-2px' } : {}
+      },
       isDivider() {
         return this.type === 'divider';
       },

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -9,9 +9,11 @@ import globalThemeState from './globalThemeState';
 
 function setUpEventHandlers(disableFocusRingByDefault) {
   let hadKeyboardEvent = false;
-  const keyboardModalityWhitelist = [
+  let hadClickEvent = false;
+  const keyboardModalityDefaultElements = [
     'input:not([type])',
     'input[type=text]',
+    'input[type=radio]',
     'input[type=checkbox]',
     'input[type=number]',
     'input[type=date]',
@@ -24,9 +26,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
   ].join(',');
 
   // add this to any element to allow keyboard navigation, regardless of focus event
-  const keyboardModalityOverride = [
-    '[supports-modality=keyboard]',
-  ];
+  const keyboardModalityOverride = ['[supports-modality=keyboard]'];
 
   let isHandlingKeyboardThrottle;
 
@@ -50,22 +50,21 @@ function setUpEventHandlers(disableFocusRingByDefault) {
     }
   })();
 
-  const focusTriggersKeyboardModality = function (el) {
+  const focusTriggersKeyboardModality = function(el) {
     let triggers = false;
 
     if (matcher) {
       triggers =
-        matcher.call(el, keyboardModalityWhitelist) && matcher.call(el, ':not([readonly])') 
+        matcher.call(el, keyboardModalityDefaultElements) && matcher.call(el, ':not([readonly])');
     }
     return triggers;
   };
 
-  const focusSetExplicitly = function (el) {
+  const focusSetExplicitly = function(el) {
     let triggers = false;
 
     if (matcher) {
-      triggers =
-        matcher.call(el, keyboardModalityOverride) && matcher.call(el, ':not([readonly])')
+      triggers = matcher.call(el, keyboardModalityOverride) && matcher.call(el, ':not([readonly])');
     }
     return triggers;
   };
@@ -91,6 +90,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
     'keydown',
     () => {
       hadKeyboardEvent = true;
+      hadClickEvent = false;
 
       if (isHandlingKeyboardThrottle) {
         clearTimeout(isHandlingKeyboardThrottle);
@@ -103,11 +103,18 @@ function setUpEventHandlers(disableFocusRingByDefault) {
     true
   );
 
+  document.body.addEventListener('mouseup', () => {
+    hadClickEvent = true;
+    hadKeyboardEvent = false;
+  });
+
   document.body.addEventListener(
     'focus',
     e => {
-      console.log(hadKeyboardEvent, e, e.target, focusTriggersKeyboardModality(e.target) )
-      if ((hadKeyboardEvent && focusTriggersKeyboardModality(e.target)) || focusSetExplicitly(e.target)) {
+      if (
+        (hadKeyboardEvent && focusTriggersKeyboardModality(e.target)) ||
+        (focusSetExplicitly(e.target) && !hadClickEvent)
+      ) {
         globalThemeState.inputModality = 'keyboard';
       }
     },
@@ -133,7 +140,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
 export default function trackInputModality({ disableFocusRingByDefault = true } = {}) {
   // skip for SSR
   if (typeof document !== 'undefined') {
-    document.addEventListener('DOMContentLoaded', function () {
+    document.addEventListener('DOMContentLoaded', function() {
       setUpEventHandlers(disableFocusRingByDefault);
     });
   }

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -7,15 +7,71 @@
 
 import globalThemeState from './globalThemeState';
 
-// only keys listed here will change modality to keyboard
-const KEYS_WHITELIST = ['Tab'];
-
 function setUpEventHandlers(disableFocusRingByDefault) {
-  let recentKeyboardEvent = null;
+  let hadKeyboardEvent = false;
+  const keyboardModalityWhitelist = [
+    'input:not([type])',
+    'input[type=text]',
+    'input[type=checkbox]',
+    'input[type=number]',
+    'input[type=date]',
+    'input[type=time]',
+    'input[type=datetime]',
+    'textarea',
+    '[role=textbox]',
+    'a',
+    'button',
+  ].join(',');
+
+  // add this to any element to allow keyboard navigation, regardless of focus event
+  const keyboardModalityOverride = [
+    '[supports-modality=keyboard]',
+  ];
+
   let isHandlingKeyboardThrottle;
 
+  const matcher = (() => {
+    const el = document.body;
+
+    if (el.matchesSelector) {
+      return el.matchesSelector;
+    }
+
+    if (el.webkitMatchesSelector) {
+      return el.webkitMatchesSelector;
+    }
+
+    if (el.mozMatchesSelector) {
+      return el.mozMatchesSelector;
+    }
+
+    if (el.msMatchesSelector) {
+      return el.msMatchesSelector;
+    }
+  })();
+
+  const focusTriggersKeyboardModality = function (el) {
+    let triggers = false;
+
+    if (matcher) {
+      triggers =
+        matcher.call(el, keyboardModalityWhitelist) && matcher.call(el, ':not([readonly])') 
+    }
+    return triggers;
+  };
+
+  const focusSetExplicitly = function (el) {
+    let triggers = false;
+
+    if (matcher) {
+      triggers =
+        matcher.call(el, keyboardModalityOverride) && matcher.call(el, ':not([readonly])')
+    }
+    return triggers;
+  };
+
   if (disableFocusRingByDefault) {
-    const css = 'body:not([modality=keyboard]) :focus { outline: none; }';
+    const css = 'body :focus:not([modality=keyboard]) { outline: none; }';
     const head = document.head || document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
 
@@ -33,15 +89,15 @@ function setUpEventHandlers(disableFocusRingByDefault) {
 
   document.body.addEventListener(
     'keydown',
-    event => {
-      recentKeyboardEvent = event;
+    () => {
+      hadKeyboardEvent = true;
 
       if (isHandlingKeyboardThrottle) {
         clearTimeout(isHandlingKeyboardThrottle);
       }
 
       isHandlingKeyboardThrottle = setTimeout(() => {
-        recentKeyboardEvent = null;
+        hadKeyboardEvent = false;
       }, 100);
     },
     true
@@ -49,8 +105,9 @@ function setUpEventHandlers(disableFocusRingByDefault) {
 
   document.body.addEventListener(
     'focus',
-    () => {
-      if (recentKeyboardEvent && KEYS_WHITELIST.includes(recentKeyboardEvent.key)) {
+    e => {
+      console.log(hadKeyboardEvent, e, e.target, focusTriggersKeyboardModality(e.target) )
+      if ((hadKeyboardEvent && focusTriggersKeyboardModality(e.target)) || focusSetExplicitly(e.target)) {
         globalThemeState.inputModality = 'keyboard';
       }
     },
@@ -76,7 +133,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
 export default function trackInputModality({ disableFocusRingByDefault = true } = {}) {
   // skip for SSR
   if (typeof document !== 'undefined') {
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
       setUpEventHandlers(disableFocusRingByDefault);
     });
   }

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -70,7 +70,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
   };
 
   if (disableFocusRingByDefault) {
-    const css = 'body :focus:not([modality=keyboard]) { outline: none; }';
+    const css = 'body:not([modality=keyboard]) :focus { outline: none; }';
     const head = document.head || document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
 
@@ -115,7 +115,12 @@ function setUpEventHandlers(disableFocusRingByDefault) {
         (hadKeyboardEvent && focusTriggersKeyboardModality(e.target)) ||
         (focusSetExplicitly(e.target) && !hadClickEvent)
       ) {
+        // both the JS state and the body attribute for keyboard modality
         globalThemeState.inputModality = 'keyboard';
+        document.body.setAttribute('modality', 'keyboard');
+      } else {
+        globalThemeState.inputModality = null;
+        document.body.setAttribute('modality', '');
       }
     },
     true

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -103,7 +103,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
     true
   );
 
-  document.body.addEventListener('mouseup', () => {
+  document.body.addEventListener('mousedown', () => {
     hadClickEvent = true;
     hadKeyboardEvent = false;
   });
@@ -130,6 +130,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
     'blur',
     () => {
       globalThemeState.inputModality = null;
+      document.body.setAttribute('modality', '');
     },
     true
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9060,7 +9060,7 @@ knuth-shuffle-seeded@^1.0.6:
 
 "kolibri-design-system@git://github.com/learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f":
   version "0.2.2-beta-2"
-  resolved "git://github.com/learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f"
+  resolved "https://github.com/learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Description

This PR adds tab navigability for KDropdownModal. Currently, a user cannot use keyboard navigation to enter into the dropdown.

#### Issue addressed

Fixes #178 

### Before/after screenshots

BEFORE

![tab-nav (1)](https://user-images.githubusercontent.com/17235236/110498172-17bb5e00-80c5-11eb-9f4f-44810e92922f.gif)

AFTER

![tab-nav-updated](https://user-images.githubusercontent.com/17235236/110498537-6bc64280-80c5-11eb-8d47-c6f0c0d9e352.gif)


## Steps to test

1. Use the tab key to navigate to a dropdown menu
2. Use the enter key to open the dropdown
3. The focus should be directed to the first item in the menu
4. Using the tab key should direct you down each item in the menu, and then a double-tab at the end should bring you back to the first element
5. Using escape key when you are inside the menu should close the menu, and bring the focus back to the dropdown menu button

## Comments 

Any feedback for general code improvement (and if I'm using some of the existing KDS patterns correctly) or about how this affects other components that I might not be thinking of would be very helpful.

Also, @jtamiace / @khangmach, I am not sure if there is already a design convention for the focus on menu items. I did review the existing docs but know they're a WIP and it's possible you have some work on this that I'm just unaware of. If you have design feedback or recommendations of how I can improve this, please let me know! So far, I just tried to adapt existing patterns and styles, but I'm sure there is room for improvement. 