### PR TITLE
Adds menu offset guideline

### DIFF
--- a/docs/pages/menus/index.vue
+++ b/docs/pages/menus/index.vue
@@ -53,7 +53,7 @@
         <li>Menus appear above all other UI elements</li>
         <li>Menus appear directly below the element that generated it</li>
         <li>Menus do not move from their original location when scrolling through the page</li>
-        <li>Menus should never touch the edge of the browser screen</li>
+        <li>Menus should never touch the edge of the browser screen. Apply an offset of 8px.</li>
       </ul>
     </DocsPageSection>
 


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

This PR adds detail to the Menus page. If a menu will touch the edge of the browser's screen when opened, we should add an offset of 8px. 

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses https://github.com/learningequality/kolibri-design-system/issues/120
