### PR TITLE
Fixes Safari text-wrapping in KLabeledIcon and KRouterLink

### DIFF
--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -65,9 +65,9 @@
     data() {
       return {
         noWhiteSpace: {
-          'white-space': 'nowrap'
+          'white-space': 'nowrap',
         },
-      }
+      };
     },
     computed: {
       labelEmpty() {

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -6,7 +6,7 @@
         <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" style="top: 2px;" />
       </slot>
     </span>
-    <span class="label" :style="labelStyle">
+    <span class="label" :style="[ labelStyle, noWhiteSpace ]">
       <!-- nest slot inside span to get alignment and flow correct for mixed RLT/LTR -->
       <span dir="auto" class="debug-warning">
         <!-- Use zero-width space when empty -->
@@ -62,6 +62,13 @@
         default: '100%',
       },
     },
+    data() {
+      return {
+        noWhiteSpace: {
+          'white-space': 'nowrap'
+        },
+      }
+    },
     computed: {
       labelEmpty() {
         if (this.label) {
@@ -109,8 +116,6 @@
   .labeled-icon-wrapper {
     position: relative;
     display: inline-block;
-    min-width: 100%;
-    // Fixes the text-wrapping in Safari
     max-width: 100%;
   }
 

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -6,7 +6,7 @@
         <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" style="top: 2px;" />
       </slot>
     </span>
-    <span class="label" :style="[ labelStyle, noWhiteSpace ]">
+    <span class="label" :style="[ labelStyle, { 'white-space': 'nowrap' } ]">
       <!-- nest slot inside span to get alignment and flow correct for mixed RLT/LTR -->
       <span dir="auto" class="debug-warning">
         <!-- Use zero-width space when empty -->
@@ -61,13 +61,6 @@
         type: String,
         default: '100%',
       },
-    },
-    data() {
-      return {
-        noWhiteSpace: {
-          'white-space': 'nowrap',
-        },
-      };
     },
     computed: {
       labelEmpty() {

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -6,7 +6,7 @@
         <KIcon v-if="icon" :icon="icon" :color="color || $themeTokens.text" style="top: 2px;" />
       </slot>
     </span>
-    <span class="label" :style="[ labelStyle, { 'white-space': 'nowrap' } ]">
+    <span class="label" :style="labelStyle">
       <!-- nest slot inside span to get alignment and flow correct for mixed RLT/LTR -->
       <span dir="auto" class="debug-warning">
         <!-- Use zero-width space when empty -->
@@ -108,8 +108,8 @@
 
   .labeled-icon-wrapper {
     position: relative;
-    display: block;
-    max-width: 100%;
+    display: inline-block;
+    width: 100%;
   }
 
   .icon {

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -108,7 +108,7 @@
 
   .labeled-icon-wrapper {
     position: relative;
-    display: inline-block;
+    display: block;
     max-width: 100%;
   }
 

--- a/lib/KLabeledIcon.vue
+++ b/lib/KLabeledIcon.vue
@@ -109,6 +109,8 @@
   .labeled-icon-wrapper {
     position: relative;
     display: inline-block;
+    min-width: 100%;
+    // Fixes the text-wrapping in Safari
     max-width: 100%;
   }
 

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -6,6 +6,7 @@
     :to="to"
     :replace="replace"
     dir="auto"
+    style="display: block;"
   >
     <KLabeledIcon
       :maxWidth="maxWidth"
@@ -20,7 +21,7 @@
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
 
-      <span class="link-text" style="white-space: nowrap;">{{ text }}</span>
+      <span class="link-text">{{ text }}</span>
 
       <KIcon
         v-if="iconAfter"

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -6,7 +6,6 @@
     :to="to"
     :replace="replace"
     dir="auto"
-    style="display: block;"
   >
     <KLabeledIcon
       :maxWidth="maxWidth"

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -20,7 +20,7 @@
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
       />
 
-      <span class="link-text">{{ text }}</span>
+      <span class="link-text" style="white-space: nowrap;">{{ text }}</span>
 
       <KIcon
         v-if="iconAfter"


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
Fixes the text-wrapping that occurs from webkit/Safari in `KLabeledIcon` and `KRouterLink`. PR in Kolibri addresses the specific issue that is found in the user dropdown menu for "Change language" option.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses learningequality/kolibri#7378

### Before/after screenshots
|`KLabeledIcon` fix for "Sign out"|
|--|
|![Screen Shot 2021-03-16 at 9 04 50 PM](https://user-images.githubusercontent.com/13563002/111537048-3a362280-8728-11eb-854e-8adfb2b73cd4.png)|

|`KRouterLink` Before|`KRouterLink` After|
|--|--|
|![Screen Shot 2021-03-16 at 9 05 57 PM](https://user-images.githubusercontent.com/13563002/111537053-3b674f80-8728-11eb-91dd-4f282d5c4ce0.png)|![Screen Shot 2021-03-16 at 9 06 14 PM](https://user-images.githubusercontent.com/13563002/111537054-3bffe600-8728-11eb-86fd-b1047b6c768d.png)|

|`KLabeledIcon` Before|`KLabeledIcon` After|
|--|--|
|![Screen Shot 2021-03-16 at 9 06 49 PM](https://user-images.githubusercontent.com/13563002/111537056-3c987c80-8728-11eb-9083-6cbf41767142.png)|![Screen Shot 2021-03-16 at 9 22 36 PM](https://user-images.githubusercontent.com/13563002/111537057-3c987c80-8728-11eb-81e8-1f8f3948fae4.png)|



## Steps to test (at least the features that were created)

1. Log in on Safari as admin or superadmin
2. Click on the user at the upper right hand to open the user menu dropdown - check to see if "Change language" is on one line.
3. Click on the hamburger menu on the left to open the sidenav - check to see if "Sign out" is on one line
4. Click on Coach
5. Click on a facility
6. Check to see if "All facilities" is on line line
7. Click on a class (preferably one with a long name!)
8. Check to see that "All classes" is on one line
9. Check to see that the class name is on one line
10. Repeat with other browsers (Chromium, Firefox, Chrome, etc.)

Please feel free to check other places where there are `KRouterLink`s or `KLabeledIcon`s

## (optional) Implementation notes

### At a high level, how did you implement this?

<!-- Briefly describe how this works -->
Added `whitespace: no-wrap` to both `KLabeledIcon` and `KRouterLink`

### Does this introduce any tech-debt items?

<!-- List anything that will need to be addressed later -->
Please check for regressions in other browsers!


## Reviewer guidance

<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Does this fix cause regressions in other browsers?
