### PR TITLE
KCheckbox description prop, simplified logic around slot vs label showing

### DIFF
--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -44,15 +44,18 @@
       </div>
 
       <div
-        v-if="!label && $slots.default"
+        v-if="$slots.default"
         class="k-checkbox-label"
       >
-        <!-- @slot Slot alternative to the `label` prop -->
         <slot></slot>
+        <div v-if="description" class="description"> 
+          {{ description }} 
+        </div>
       </div>
 
+      <!-- In this case, we presume that there is a `label` prop given -->
       <label
-        v-else-if="label && !$slots.default"
+        v-else
         dir="auto"
         class="k-checkbox-label"
         :for="id"
@@ -61,6 +64,9 @@
         @click.prevent
       >
         {{ label }}
+        <div v-if="description" class="description"> 
+          {{ description }} 
+        </div>
       </label>
 
     </div>
@@ -111,6 +117,14 @@
       disabled: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * Description - subtext to the label
+       */
+      description: {
+        type: String,
+        default: null,
+        required: false,
       },
     },
     data: () => ({
@@ -239,6 +253,11 @@
     top: 0;
     width: $checkbox-height;
     height: $checkbox-height;
+  }
+
+  .description {
+    font-size: 12px;
+    line-height: normal;
   }
 
 </style>


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

#### Issue addressed
<!-- Only necessary if applicable -->

Fixes #35 

I also thought that the `v-if-else` block there was weird because if I gave both a slot and a label it would show neither - so I picked one to be the override. 

Now if you give a slot and a label you'll see what is passed to the slot - if you don't give a slot it's expected you give a label.

### Before/after screenshots

<!-- Insert images here if applicable -->
| Before |
|---|
| ![screenshot-localhost_8000-2021 03 18-14_44_52](https://user-images.githubusercontent.com/6356129/111701778-86509800-87f8-11eb-8c23-a6e8d4853915.png) |

| After |
|---|
| ![screenshot-localhost_8000-2021 03 18-14_39_20](https://user-images.githubusercontent.com/6356129/111701679-67520600-87f8-11eb-8df7-15ab64e73a6b.png) |



## Steps to test

1. `yarn link kolibri-design-system` in your `kolibri` local repo
2. Checkout this PR in `kolibri-design-system` repo
3. Run Kolibri dev server
4. Find an instance of `KCheckbox` in the code and find it in the app itself
5. Add a `description` prop with a value.

### At a high level, how did you implement this?

<!-- Briefly describe how this works -->

Added the prop and updated the template to display it properly - basically stole the whole thing from `KRadioButton`.

### Does this introduce any tech-debt items?

<!-- List anything that will need to be addressed later -->

Nope.


## Reviewer guidance

<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments

<!-- Any additional notes you'd like to add -->
