### PR TITLE
Show proper keyboard focus ring in KDS examples in documentation

### DIFF
--- a/docs/plugins/load-lib-components.js
+++ b/docs/plugins/load-lib-components.js
@@ -5,6 +5,6 @@ import trackInputModality from '~~/lib/styles/trackInputModality';
 // `KThemePlugin` dependency needed for outline style when
 // navigating between KDS components with keyboard
 // See `KThemePlugin` `$coreOutline` and `globalThemeState.inputModality`
-trackInputModality({ disableDefaultFocusRing: false });
+trackInputModality({ disableFocusRingByDefault: false });
 
 Vue.use(KThemePlugin);

--- a/docs/plugins/load-lib-components.js
+++ b/docs/plugins/load-lib-components.js
@@ -1,4 +1,10 @@
 import Vue from 'vue';
 import KThemePlugin from '~~/lib/KThemePlugin';
+import trackInputModality from '~~/lib/styles/trackInputModality';
+
+// `KThemePlugin` dependency needed for outline style when
+// navigating between KDS components with keyboard
+// See `KThemePlugin` `$coreOutline` and `globalThemeState.inputModality`
+trackInputModality({ disableDefaultFocusRing: false });
 
 Vue.use(KThemePlugin);

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -10,7 +10,7 @@ import globalThemeState from './globalThemeState';
 
 const logging = logger.getLogger(__filename);
 
-function setUpEventHandlers() {
+function setUpEventHandlers(disableDefaultFocusRing) {
   let hadKeyboardEvent = false;
   const keyboardModalityWhitelist = [
     'input:not([type])',
@@ -76,7 +76,9 @@ function setUpEventHandlers() {
     return triggers;
   };
 
-  disableFocusRingByDefault();
+  if (disableDefaultFocusRing) {
+    disableFocusRingByDefault();
+  }
 
   document.body.addEventListener(
     'keydown',
@@ -113,9 +115,18 @@ function setUpEventHandlers() {
   );
 }
 
-export default function trackInputModality() {
+/**
+ * Update `globalThemeState.inputModality` to true/false based on
+ * whether the user is currently navigating with the keyboard or not.
+ *
+ * @param {Boolean} [disableDefaultFocusRing=true] Set focus outline to none
+ *                                                 when not navigating with keyboard
+ */
+export default function trackInputModality({ disableDefaultFocusRing = true } = {}) {
   // skip for SSR
   if (typeof document !== 'undefined') {
-    document.addEventListener('DOMContentLoaded', setUpEventHandlers);
+    document.addEventListener('DOMContentLoaded', function() {
+      setUpEventHandlers(disableDefaultFocusRing);
+    });
   }
 }

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -7,7 +7,7 @@
 
 import globalThemeState from './globalThemeState';
 
-function setUpEventHandlers(disableDefaultFocusRing) {
+function setUpEventHandlers(disableFocusRingByDefault) {
   let hadKeyboardEvent = false;
   const keyboardModalityWhitelist = [
     'input:not([type])',
@@ -54,7 +54,7 @@ function setUpEventHandlers(disableDefaultFocusRing) {
     return triggers;
   };
 
-  if (disableDefaultFocusRing) {
+  if (disableFocusRingByDefault) {
     const css = 'body :focus { outline: none; }';
     const head = document.head || document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
@@ -110,14 +110,14 @@ function setUpEventHandlers(disableDefaultFocusRing) {
  * Update `globalThemeState.inputModality` to true/false based on
  * whether the user is currently navigating with the keyboard or not.
  *
- * @param {Boolean} [disableDefaultFocusRing=true] Set focus outline to none
+ * @param {Boolean} [disableFocusRingByDefault=true] Set focus outline to none
  *                                                 when not navigating with keyboard
  */
-export default function trackInputModality({ disableDefaultFocusRing = true } = {}) {
+export default function trackInputModality({ disableFocusRingByDefault = true } = {}) {
   // skip for SSR
   if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', function() {
-      setUpEventHandlers(disableDefaultFocusRing);
+      setUpEventHandlers(disableFocusRingByDefault);
     });
   }
 }

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -43,7 +43,18 @@ function setUpEventHandlers(disableDefaultFocusRing) {
     }
   })();
 
-  const disableFocusRingByDefault = function() {
+  const focusTriggersKeyboardModality = function(el) {
+    let triggers = false;
+
+    if (matcher) {
+      triggers =
+        matcher.call(el, keyboardModalityWhitelist) && matcher.call(el, ':not([readonly])');
+    }
+
+    return triggers;
+  };
+
+  if (disableDefaultFocusRing) {
     const css = 'body :focus { outline: none; }';
     const head = document.head || document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
@@ -58,21 +69,6 @@ function setUpEventHandlers(disableDefaultFocusRing) {
     }
 
     head.insertBefore(style, head.firstChild);
-  };
-
-  const focusTriggersKeyboardModality = function(el) {
-    let triggers = false;
-
-    if (matcher) {
-      triggers =
-        matcher.call(el, keyboardModalityWhitelist) && matcher.call(el, ':not([readonly])');
-    }
-
-    return triggers;
-  };
-
-  if (disableDefaultFocusRing) {
-    disableFocusRingByDefault();
   }
 
   document.body.addEventListener(

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -5,10 +5,7 @@
  * Version: 1.0.2
  */
 
-import logger from 'kolibri.lib.logging';
 import globalThemeState from './globalThemeState';
-
-const logging = logger.getLogger(__filename);
 
 function setUpEventHandlers(disableDefaultFocusRing) {
   let hadKeyboardEvent = false;
@@ -44,8 +41,6 @@ function setUpEventHandlers(disableDefaultFocusRing) {
     if (el.msMatchesSelector) {
       return el.msMatchesSelector;
     }
-
-    logging.error("Couldn't find any matchesSelector method on document.body.");
   })();
 
   const disableFocusRingByDefault = function() {

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -44,7 +44,7 @@ function setUpEventHandlers(disableDefaultFocusRing) {
   })();
 
   const disableFocusRingByDefault = function() {
-    const css = 'body:not([modality=keyboard]) :focus { outline: none; }';
+    const css = 'body :focus { outline: none; }';
     const head = document.head || document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
 


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

Track input modality on documentation pages because `KThemePlugin` used by KDS components in documentation examples needs this information to be able to decide if a keyboard focus ring should be displayed (input modality information is used only to inform KDS components, not the documentation pages themselves).

See commit messages for details.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #70

### After

![kds](https://user-images.githubusercontent.com/13509191/111793181-4efbed00-88c5-11eb-9ba3-f4fc9020f685.gif)

Because I made some updates to a code that is used in projects that import KDS, I also checked that there are no changes in Kolibri by linking the updated KDS package locally to Kolibri:

![kolibri](https://user-images.githubusercontent.com/13509191/111793463-971b0f80-88c5-11eb-8b31-01d5bd9e8ccc.gif)

<!-- Insert images here if applicable -->

## Steps to test

1. Use the keyboard to navigate documentation

## Implementation notes

### At a high level, how did you implement this?

<!-- Briefly describe how this works -->

I added a new option to the `trackInputModality` that allows us to not disable the default focus ring and then imported `trackInputModality` to documentation pages using this new setting so that there is a correct input modality saved in `KThemePlugin`'s `globalThemeState.inputModality` that is then used in KDS components in documentation examples.

An alternative approach to adding a new `disableDefaultFocusRing` parameter would be to remove style with ID `"disable-focus-ring"` as suggested in the documentation of [alice/modality](https://github.com/alice/modality), a library that's a template for our `trackInputModality` script:

> This is added in a <style> element with the ID "disable-focus-ring", to allow easy removal if different behavior is desired.

I consider configuration through a parameter easier.

### Does this introduce any tech-debt items?

<!-- List anything that will need to be addressed later -->

~~I still need to solve [a problem with logging](https://github.com/learningequality/kolibri-design-system/pull/200/files#r597740463) in this PR.~~

~~Other than that,~~ nothing that I am aware of related to this particular task. However, we might consider moving to [`:focus-visible` ](https://matthiasott.com/notes/focus-visible-is-here) and [`focus-visible` polyfill](https://github.com/WICG/focus-visible) instead of the solution based on alice/modality that has been deprecated in favor of the focus-visible polyfill. That would require updates of `KThemePlugin` and Kolibri testing.

## Reviewer guidance

<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

Please follow the steps to test

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?