### PR TITLE
persist nav state

### DIFF
--- a/docs/common/DocsPageTemplate/SideNav/index.vue
+++ b/docs/common/DocsPageTemplate/SideNav/index.vue
@@ -6,20 +6,22 @@
       class="sidenav"
       @scroll="throttleHandleScroll"
     >
-      <h1 class="header">
-        <file-svg src="./kolibri-logo.svg" class="logo" />
-        <span class="header-text">Design System</span>
-      </h1>
+      <template if="loaded">
+        <h1 class="header">
+          <file-svg src="./kolibri-logo.svg" class="logo" />
+          <span class="header-text">Design System</span>
+        </h1>
 
-      <DocsFilter v-model="filterText" />
+        <DocsFilter v-model="filterText" />
 
-      <div class="nav-links" if="loaded">
-        <NavSectionList
-          v-for="section in visibleTableOfContents"
-          :key="section.title"
-          :section="section"
-        />
-      </div>
+        <div class="nav-links">
+          <NavSectionList
+            v-for="section in visibleTableOfContents"
+            :key="section.title"
+            :section="section"
+          />
+        </div>
+      </template>
 
     </nav>
 

--- a/docs/common/DocsPageTemplate/SideNav/index.vue
+++ b/docs/common/DocsPageTemplate/SideNav/index.vue
@@ -9,7 +9,7 @@
 
       <DocsFilter v-model="filterText" />
 
-      <div class="nav-links">
+      <div class="nav-links" if="loaded">
         <NavSectionList
           v-for="section in visibleTableOfContents"
           :key="section.title"
@@ -40,6 +40,7 @@
     data() {
       return {
         filterText: '',
+        loaded: false,
       };
     },
     computed: {
@@ -65,6 +66,23 @@
         }
         return toc;
       },
+    },
+    watch: {
+      filterText(newValue) {
+        if (window) {
+          window.sessionStorage.setItem('nav-filter', newValue);
+        }
+      },
+    },
+    mounted() {
+      if (window) {
+        const val = window.sessionStorage.getItem('nav-filter');
+        if (val) {
+          this.filterText = val;
+        }
+      }
+      // don't show the nav until the filter is set
+      this.loaded = true;
     },
   };
 
@@ -100,7 +118,7 @@
     right: 16px;
     bottom: 0;
     left: 0;
-    height: 100px;
+    height: 64px;
     pointer-events: none;
     background-image: linear-gradient(to bottom, transparent, white);
   }

--- a/docs/common/DocsPageTemplate/SideNav/index.vue
+++ b/docs/common/DocsPageTemplate/SideNav/index.vue
@@ -1,7 +1,11 @@
 <template>
 
   <div class="nav-wrapper">
-    <nav class="sidenav">
+    <nav
+      ref="links"
+      class="sidenav"
+      @scroll="throttleHandleScroll"
+    >
       <h1 class="header">
         <file-svg src="./kolibri-logo.svg" class="logo" />
         <span class="header-text">Design System</span>
@@ -28,6 +32,7 @@
 
 <script>
 
+  import throttle from 'lodash/throttle';
   import NavSectionList from './NavSectionList';
   import { termList, matches } from '~/common/DocsFilter/utils';
   import tableOfContents from '~/tableOfContents.js';
@@ -76,13 +81,19 @@
     },
     mounted() {
       if (window) {
-        const val = window.sessionStorage.getItem('nav-filter');
-        if (val) {
-          this.filterText = val;
+        const filterText = window.sessionStorage.getItem('nav-filter');
+        if (filterText) {
+          this.filterText = filterText;
         }
+        this.$refs.links.scrollTop = window.sessionStorage.getItem('nav-scroll');
       }
-      // don't show the nav until the filter is set
+      // don't show the nav until the state is set
       this.loaded = true;
+    },
+    methods: {
+      throttleHandleScroll: throttle(function handleScroll() {
+        window.sessionStorage.setItem('nav-scroll', this.$refs.links.scrollTop);
+      }, 100),
     },
   };
 


### PR DESCRIPTION

## Description

Persist side nav bar scroll position and filter state using `Window.sessionStorage`, which should be per-tab.

#### Issue addressed

fixes https://github.com/learningequality/kolibri-design-system/issues/182

### Before/after screenshots

| before | after |
|--|--|
| ![2021-03-26 16 45 54](https://user-images.githubusercontent.com/2367265/112703127-13c46580-8e53-11eb-958c-ba494a8923a4.gif) | ![2021-03-26 17 05 20](https://user-images.githubusercontent.com/2367265/112703846-9ea65f80-8e55-11eb-9d9e-225fdedb5160.gif) |


## Steps to test

Experiment with navigation through the design system and see how it feels

## (optional) Implementation notes

### At a high level, how did you implement this?

* Persists changes to state
* Loads state on `mounted`

### Does this introduce any tech-debt items?

* Tries to keep the nav hidden until state has been loaded but doesn't always work as intended
* There's a brief flash during page load

## Reviewer guidance

<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments

<!-- Any additional notes you'd like to add -->
