### PR TITLE
Update KDS to 0.2.2-beta-2 so that it gets picked up by yarn in other…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "0.2.2-beta5",
+  "version": "v0.2.2-beta-2",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "license": "MIT",


### PR DESCRIPTION
Need to update the number - create a tag - then update Kolibri's dependency to ensure that yarn pulls it and skips the cache. I forgot that the package.json version of the dependency (KDS in this case) is what yarn uses to determine whether or not to skip the cache.