### PR TITLE
Don't try to load non-existent css files

### DIFF
--- a/lib/utils/pluginMediator.js
+++ b/lib/utils/pluginMediator.js
@@ -534,8 +534,9 @@ export default function pluginMediatorFactory({
               !url.includes(languageDirections.RTL) &&
               url.endsWith('css'))
         );
-        if (contentRendererModule.urlTags[cssUrl]) {
-          // This css file is already loaded and in the DOM, nothing to do.
+        if (!cssUrl || contentRendererModule.urlTags[cssUrl]) {
+          // There is no css file to try to load or
+          // this css file is already loaded and in the DOM, nothing to do.
           resolve();
         } else {
           // First unload the other direction CSS from the DOM


### PR DESCRIPTION
## Description
* Stops trying to load css files that don't exist
* This can happen in hot module replacement mode when CSS files are bundled into Javascript

## Steps to test

1. Run Kolibri with this patch on KDS, with `devserver-hot` and check that the EpubRenderer now properly loads.

## Reviewer guidance

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?

