### PR TITLE
Fix typo in buttons documentation

### DIFF
--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -102,7 +102,7 @@
       </p>
       <ul>
         <li>Right-aligned at the bottom of modal pop-ups</li>
-        <li>Left-aligned a the bottom of page forms</li>
+        <li>Left-aligned at the bottom of page forms</li>
         <li>Global actions related to full pages should be right-aligned and to the right of the page title on large screens, and left-aligned below the title on small screens. Use of <code>KGrid</code> is recommended</li>
       </ul>
       <p>


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

Update text in the ["Placement" section of buttons documentation](https://design-system.learningequality.org/buttons/#placement) (the second item of the list) from "Left-aligned **a** the bottom of page forms" to "Left-aligned **at** the bottom of page forms".
