### PR TITLE
Fix keyboard outline in Kolibri - no longer showing unless keyboard navigating

### DIFF
--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -55,7 +55,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
   };
 
   if (disableFocusRingByDefault) {
-    const css = 'body :focus { outline: none; }';
+    const css = 'body :focus:not([modality=keyboard]) { outline: none; }';
     const head = document.head || document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
 


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

#### Issue addressed
<!-- Only necessary if applicable -->

Fixes https://github.com/learningequality/kolibri/issues/7974


## Steps to test

*Kolibri*

- `yarn link` the design system (see [KDS Readme](https://github.com/learningequality/kolibri-design-system/) for help there)
- Run Kolibri and test that the outline comes up when you're keyboard navigating but does not come up when you're hovering with a mouse.

*KDS*

- `yarn dev` the KDS documentation (or just use the Preview link below at the GIthub Actions)
- Make sure that you see the keyboard navigation box when navigating by keyboard there.

## (optional) Implementation notes

[This commit is where the bug was introduced.](https://github.com/learningequality/kolibri-design-system/commit/e26893fcc6d970c11ca86b771cdc24658892c569) @MisRob undoing this fixes the issue - was there some other effect you expected to see when making this change?

### At a high level, how did you implement this?

[Reverts this commit.](https://github.com/learningequality/kolibri-design-system/commit/e26893fcc6d970c11ca86b771cdc24658892c569)