### PR TITLE
Add navigateTo listener in KContentRenderer mixin for HTML5 hashi work

### DIFF
--- a/lib/content/mixin.js
+++ b/lib/content/mixin.js
@@ -8,7 +8,7 @@ const interactionEvents = [
   'updateProgress',
   'updateContentState',
   'startTracking',
-  'navigateto'
+  'navigateto',
 ];
 
 const fileFieldMap = {

--- a/lib/content/mixin.js
+++ b/lib/content/mixin.js
@@ -8,6 +8,7 @@ const interactionEvents = [
   'updateProgress',
   'updateContentState',
   'startTracking',
+  'navigateto'
 ];
 
 const fileFieldMap = {

--- a/lib/content/mixin.js
+++ b/lib/content/mixin.js
@@ -8,7 +8,7 @@ const interactionEvents = [
   'updateProgress',
   'updateContentState',
   'startTracking',
-  'navigateto',
+  'navigateTo',
 ];
 
 const fileFieldMap = {


### PR DESCRIPTION
## Description

Add navigateTo listener in KContentRenderer mixin for HTML5 hashi work.

## Steps to test

Please see this [kolibri PR for extensions to the navigateTo work](https://github.com/learningequality/kolibri/pull/8134).
