### PR TITLE
KTextbox with gray material background

### DIFF
--- a/lib/keen/UiTextbox.vue
+++ b/lib/keen/UiTextbox.vue
@@ -499,6 +499,7 @@
     width: 100%;
     padding: 4px 0 0 0;
     margin: 0;
+    background: #e9e9e9;
     border-radius: 4px 4px 0 0;
   }
 


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

[I did this](https://github.com/learningequality/kolibri-design-system/pull/139/commits/bf4fbd1fa57550ae12b39215d767e8eb41bed524#diff-687c5d9eca13195cf34fba3cf61e97418d9ac5f1ea6a43035523bcffd6dfd37cL502) in a follow-up commit and didn't realize it before merging. How and why this happened are beyond me.

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

Puts a gray background on KTextbox per Material guidance.

