### PR TITLE
Remove download_url property

### DIFF
--- a/lib/content/mixin.js
+++ b/lib/content/mixin.js
@@ -45,9 +45,6 @@ const fileFieldMap = {
   thumbnail: {
     type: Boolean,
   },
-  download_url: {
-    type: String,
-  },
 };
 
 function fileValidator(file) {


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
Removes the `download_url` property from the file map in `mixin.js` for the `KContentRenderer` to mirror the changes in learningequality/kolibri#8005.

### Before/after screenshots
No screenshot needed, but the `fileValidator` method for `KContentRenderer` was returning a console error.

## Steps to test

1. Open an exercise in a Khan Academy lesson.
2. Open the console and check to see that there are no errors.

### Does this introduce any tech-debt items?

<!-- List anything that will need to be addressed later -->
No


## Reviewer guidance

<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?

## Comments

<!-- Any additional notes you'd like to add -->
