### PR TITLE
Update PR template for KDS release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -7,12 +7,7 @@ assignees: ''
 
 ---
 
-<!-- Please remove any unused sections
-
-Instructions:
-- Title line template: [Title]: Brief description
-
--->
+<!-- Please remove any unused sections -->
 
 ## Product
 <!-- Where did you notice this bug? (Kolibri, Studio, Design System, etc.) -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,6 @@ Addresses #*PR# HERE*
 - [ ] If there are any front-end changes, before/after screenshots are included
 - [ ] Critical and brittle code paths are covered by unit tests
 - [ ] The change has been added to the `changelog`
-- [ ] A separate PR has been submitted to point the `unstable` branch of the affected Kolibri product to the most recent version of KDS (see post-merge updates for details)
 
 ## Reviewer guidance
 <!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,9 @@ Addresses #*PR# HERE*
 - [ ] If there are any front-end changes, before/after screenshots are included
 - [ ] Critical and brittle code paths are covered by unit tests
 - [ ] The change has been added to the `changelog`
-- [ ] A PR has been submitted to point the Kolibri `develop` branch to the most recent version of KDS
+
+## Updating KDS in Kolibri
+- [ ] After this PR has been merged into KDS, a separate PR has been submitted to point the Kolibri `develop` branch to the most recent version of KDS
 
 ## Reviewer guidance
 <!-- Delete anything that doesn't apply so your reviewer knows what to check for -->
@@ -41,6 +43,7 @@ Addresses #*PR# HERE*
 - [ ] Is the code clean and well-commented?
 - [ ] Are there tests for this change?
 - [ ] Are all UI components LTR and RTL compliant (if applicable)?
+- [ ] Is the PR ready to be merged in KDS and is a PR ready to be submitted to Kolibri to point it to the most recent KDS hash?
 - [ ] _Add other things to check for here_
 
 ## Comments

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,9 +33,7 @@ Addresses #*PR# HERE*
 - [ ] If there are any front-end changes, before/after screenshots are included
 - [ ] Critical and brittle code paths are covered by unit tests
 - [ ] The change has been added to the `changelog`
-
-## Updating KDS in Kolibri
-- [ ] After this PR has been merged into KDS, a separate PR has been submitted to point the Kolibri `develop` branch to the most recent version of KDS
+- [ ] A separate PR has been submitted to point the `unstable` branch of the affected Kolibri product to the most recent version of KDS (see post-merge updates for details)
 
 ## Reviewer guidance
 <!-- Delete anything that doesn't apply so your reviewer knows what to check for -->
@@ -43,8 +41,16 @@ Addresses #*PR# HERE*
 - [ ] Is the code clean and well-commented?
 - [ ] Are there tests for this change?
 - [ ] Are all UI components LTR and RTL compliant (if applicable)?
-- [ ] Is the PR ready to be merged in KDS and is a PR ready to be submitted to Kolibri to point it to the most recent KDS hash?
 - [ ] _Add other things to check for here_
+
+## Post-merge updates and tracking
+<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
+- [ ] Learning Platform update PR is submitted
+- [ ] Learning Platform update PR is merged
+- [ ] Studio update PR is submitted
+- [ ] Studio update PR is merged
+- [ ] Data Portal update PR is submitted
+- [ ] Data Portal update PR is merged
 
 ## Comments
 <!-- Any additional notes you'd like to add -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 <!-- Please remove any unused sections -->
 
 ## Description
-
 <!-- What does this PR do? Briefly describe in 1-2 sentences* -->
 
 #### Issue addressed
@@ -10,7 +9,6 @@
 Addresses #*PR# HERE*
 
 ### Before/after screenshots
-
 <!-- Insert images here if applicable -->
 
 
@@ -23,16 +21,21 @@ Addresses #*PR# HERE*
 ## (optional) Implementation notes
 
 ### At a high level, how did you implement this?
-
 <!-- Briefly describe how this works -->
 
 ### Does this introduce any tech-debt items?
-
 <!-- List anything that will need to be addressed later -->
 
+## Testing checklist
+<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->
+
+- [ ] Contributor has fully tested the PR manually
+- [ ] If there are any front-end changes, before/after screenshots are included
+- [ ] Critical and brittle code paths are covered by unit tests
+- [ ] The change has been added to the `changelog`
+- [ ] A PR has been submitted to point the Kolibri `develop` branch to the most recent version of KDS
 
 ## Reviewer guidance
-
 <!-- Delete anything that doesn't apply so your reviewer knows what to check for -->
 
 - [ ] Is the code clean and well-commented?
@@ -41,5 +44,4 @@ Addresses #*PR# HERE*
 - [ ] _Add other things to check for here_
 
 ## Comments
-
 <!-- Any additional notes you'd like to add -->


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
Updates the PR template with a section for the PR-writer to add in the `changelog` and also to manually point the most recent version of KDS to the Kolibri `develop` branch.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #247


### Does this introduce any tech-debt items?

We will need to make sure that there is clear documentation about how to add to the `changelog` (this may be something we can add to the PR template in the future so that anyone can just access it). For now, we can just tell folks how to do it (internally). Same goes with how to point Kolibri to the right branch of KDS. 

## Reviewer guidance
- [ ] Is the code clean and well-commented?

## Comments

<!-- Any additional notes you'd like to add -->
Doesn't need to be said, but all feedback appreciated, of course.