### PR TITLE
Report KDS public icons diff after precompilation and add more information about icons upgrade to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,21 @@ Note that we currently use the deprecated Nuxt.js `mode: universal` flag, and sh
 
 ### SVG Icons
 
-Icons are drawn from https://github.com/material-icons/material-icons and then converted to Vue components. This is currently pinned by the `yarn.lock`. If we upgrade it, we need to regenerate the Vue components by running:
+There are three sources of icons:
+
+- [Google Material Design Icons](https://github.com/material-icons/material-icons) (a version pinned in [yarn.lock](yarn.lock))
+- [Material Design Icons](https://github.com/Templarian/MaterialDesign-SVG) (a version pinned in [yarn.lock](yarn.lock))
+- [Custom Learning Equality icons](custom-icons)
+
+Icons from them are then converted to Vue components by our custom precompilation script. After updating any of these sources, we need to regenerate the Vue components by running:
 
 ```bash
 yarn run precompile-svgs
 ```
+
+We don't expose all icons in our KDS public API. Only icons defined in [the icons definitions file](lib/KIcon/iconDefinitions.js) are exposed, and we use our custom aliases for them.
+
+#### reStructuredText replacement strings
 
 We also output a set of reStructuredText replacement strings into the file `docs/rstIconReplacements.txt` which can be used in
 user docs based on Sphinx. To update this file, run
@@ -202,6 +212,18 @@ user docs based on Sphinx. To update this file, run
 ```bash
 yarn run pregenerate
 ```
+#### Example: Upgrading Google Material Design Icons
+
+It is advised to commit changes at each step to make reviewing files other than those in *precompiled-icons/* easier, especially in case of large updates.
+
+1. Run `yarn upgrade @material-icons/svg`
+2. Run `yarn run precompile-svgs`
+3. Review updates of all public icons defined in [the icons definitions file](lib/KIcon/iconDefinitions.js)
+
+Large upgrades can result in a colossal git diff which makes reviewing changes of selected public icons in detail difficult. To make such upgrades smoother, in addition to visually reviewing [icons in KDS documentation](https://design-system.learningequality.org/icons/#icons), you can use a report that is printed in a terminal as soon as the precompilation process ends. It contains all exposed icons aliases together with information about whether an icon has been updated or no. If it's been updated, git diff will be printed.
+
+4. Run `yarn run pregenerate`
+5. Write down notes to the changelog about any public updates like visual changes of icons, updates of their aliases, and updates of reStructuredText replacement strings
 
 ### Development in parallel with other applications
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ There are three sources of icons:
 - [Material Design Icons](https://github.com/Templarian/MaterialDesign-SVG) (a version pinned in [yarn.lock](yarn.lock))
 - [Custom Learning Equality icons](custom-icons)
 
-Icons from them are then converted to Vue components by our custom precompilation script. After updating any of these sources, we need to regenerate the Vue components by running:
+Icons from these sources are then converted to Vue components by our custom precompilation script. After updating any of these sources, we need to regenerate the Vue components by running:
 
 ```bash
 yarn run precompile-svgs

--- a/lib/KIcon/iconDefinitions.js
+++ b/lib/KIcon/iconDefinitions.js
@@ -17,8 +17,9 @@ import { themeTokens } from '../styles/theme';
  * - defaultColor: A color for the icon. If not defined, icons are `themeTokens.text` colored
  *
  * NOTE: this file is currently processed using regex by utils/pregenerate.js in order to
- * extract information for use in user docs. Before refactoring, please take that brittle
- * dependency into consideration.
+ * extract information for use in user docs. It is also processed
+ * by utils/precompileSvgs/precompilationDiff.js.
+ * Before refactoring, please take those brittle dependencies into consideration.
  */
 
 const KolibriIcons = {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint-watch": "yarn lint -m",
     "pregenerate": "node utils/pregenerate.js",
     "_dev-only": "nuxt --port 4000",
-    "precompile-svgs": "rm -rf lib/KIcon/precompiled-icons && node utils/precompileSvgs.js",
+    "precompile-svgs": "rm -rf lib/KIcon/precompiled-icons && node utils/precompileSvgs/index.js",
     "_lint-watch-fix": "yarn lint -w -m",
     "_test": "jest",
     "_api-watch": "chokidar \"**/lib/**\" -c \"node utils/extractApi.js\""

--- a/utils/extractRstIcons.js
+++ b/utils/extractRstIcons.js
@@ -18,7 +18,7 @@ const consola = require('consola');
   changes to the implementation of iconDefinitions.js and KIcon might break this.
 
   A slightly preferable implementation might be to extract this information during the
-  precompileSvgs.js process, importing iconDefinitions.js directly, and parsing the
+  precompileSvgs/index.js process, importing iconDefinitions.js directly, and parsing the
   information as real javascript. However this would require webpack tooling which
   is – at present – unavailable to this pre-processing script. We also might want to
   consider a different source of truth besides iconDefinitions.js, but this was deemed

--- a/utils/precompileSvgs/index.js
+++ b/utils/precompileSvgs/index.js
@@ -11,6 +11,8 @@ const SVGO = require('svgo');
 
 var svgo = new SVGO(); // You use this one.
 
+const precompilationDiff = require('./precompilationDiff.js');
+
 // Some attrs used during SVG optimization
 const a11yAttrs = `role="presentation" focusable="false"`;
 const viewBox = `viewBox="0 0 24 24"`;
@@ -153,3 +155,7 @@ class LibPrecompiler {
 config.forEach(c => {
   new LibPrecompiler(c.iconLibPath, c.namespace).process();
 });
+
+consola.success('Precompilation has been successful');
+consola.info(`Updates of KDS public icons: \n`);
+precompilationDiff.print();

--- a/utils/precompileSvgs/precompilationDiff.js
+++ b/utils/precompileSvgs/precompilationDiff.js
@@ -28,7 +28,7 @@ function print() {
       const iconAlias = iconDefinitionMatch[1];
       const iconPath = path.resolve(path.join('./lib/KIcon/', iconDefinitionMatch[2]));
 
-      exec('git diff ' + iconPath, (error, stdout, stderr) => {
+      exec('git diff --color=always ' + iconPath, (error, stdout, stderr) => {
         if (error) {
           consola.error(error.message);
           return;

--- a/utils/precompileSvgs/precompilationDiff.js
+++ b/utils/precompileSvgs/precompilationDiff.js
@@ -1,0 +1,53 @@
+/**
+ * Print gif diff of publicly exposed Vue icons
+ * (defined in 'lib/KIcon/precompiled-icons/iconDefinitions.js')
+ * to allow for easier before/after precompilation preview
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
+const consola = require('consola');
+
+const ICONS_DEFINITIONS_PATH = './lib/KIcon/iconDefinitions.js';
+
+// Within the main icon definitions object, match all individual definition objects:
+// `someIconName: { icon: require('./some/icon/path'), ...}`
+// (taken from extractRstIcons.js)
+const ICON_DEFINITION_PATTERN = /\n {2}(\w+): {.*?\s+icon:\s+require\('(.+?)'\).*?},/gs;
+
+function print() {
+  fs.readFile(ICONS_DEFINITIONS_PATH, 'utf8', (error, iconsDefinitions) => {
+    if (error) {
+      consola.error(`Can't open icons definitions file: "${ICONS_DEFINITIONS_PATH}"`);
+      return;
+    }
+
+    let iconDefinitionMatch;
+    while ((iconDefinitionMatch = ICON_DEFINITION_PATTERN.exec(iconsDefinitions)) !== null) {
+      const iconAlias = iconDefinitionMatch[1];
+      const iconPath = path.resolve(path.join('./lib/KIcon/', iconDefinitionMatch[2]));
+
+      exec('git diff ' + iconPath, (error, stdout, stderr) => {
+        if (error) {
+          consola.error(error.message);
+          return;
+        }
+        if (stderr) {
+          consola.error(stderr);
+          return;
+        }
+        consola.info(`Icon name: ${iconAlias}`);
+        if (stdout.length === 0) {
+          consola.info('No updates \n');
+        } else {
+          consola.info('Icon has been updated');
+          consola.info('Git diff:');
+          consola.info(`${stdout}\n`);
+        }
+      });
+    }
+  });
+}
+
+exports.print = print;


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

This PR adds more information about the icons upgrades process to documentation and also adds a utility for printing differences in public KDS icons after running the precompilation script to help with tracking updates.

### Screenshots

<!-- Insert images here if applicable -->

Precompilation diff displayed in my terminal after upgrading Google Material Icons and running `yarn run precompile-svgs`:

![Screenshot from 2021-07-01 16-12-03](https://user-images.githubusercontent.com/13509191/124140220-95e2ac80-da88-11eb-9165-413445a9a18e.png)

## Steps to test

Please read the documentation updates and then follow **Example: Upgrading Google Material Design Icons** to check the before/after icons precompilation diff reporting for yourself.

### Does this introduce any tech-debt items?

We now have even more logic built around parsing [iconsDefinitions.js file](https://github.com/learningequality/kolibri-design-system/blob/v0.2.x/lib/KIcon/iconDefinitions.js) with regexes (see [this commentary](https://github.com/learningequality/kolibri-design-system/blob/v0.2.x/utils/extractRstIcons.js#L16) to understand how we currently work with getting information from iconsDefinitions.js)

## Reviewer guidance

<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_
