### PR TITLE
enable loaders page

### DIFF
--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -154,6 +154,10 @@ export default [
         title: 'Text fields',
         keywords: textRelatedKeywords,
       }),
+      new Page({
+        path: '/loaders',
+        title: 'Loaders',
+      }),
     ],
   }),
   new Section({


### PR DESCRIPTION

## Description

Enabled 'loading' page which was written but missing

### Before/after screenshots


| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/139323828-55be776c-0df0-44ff-94a5-0caebe522f98.png) | ![image](https://user-images.githubusercontent.com/2367265/139323709-8d547278-47a4-4932-8c9c-30e088f3e3e2.png) |


## Steps to test

check `/loaders` URL



## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
