### PR TITLE
allow KModal to take a precise width in pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
+## Version 1.2.0
+
+- [#281] - Allow `KModal` to take a `size` in pixels
+- [#278] - Adds timer icon
+
+<!-- Referenced PRs -->
+
+[#281]: https://github.com/learningequality/kolibri-design-system/pull/281
+[#278]: https://github.com/learningequality/kolibri-design-system/pull/278
+
+
 ## Version 1.1.0
 
 ### Added

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -15,7 +15,6 @@
         :tabindex="0"
         role="dialog"
         aria-labelledby="modal-title"
-        :class="size"
         :style="[ modalSizeStyles, { background: $themeTokens.surface } ]"
       >
 
@@ -98,6 +97,11 @@
   import debounce from 'lodash/debounce';
   import KResponsiveWindowMixin from './KResponsiveWindowMixin';
 
+  const SIZE_SM = 'small';
+  const SIZE_MD = 'medium';
+  const SIZE_LG = 'large';
+  const SIZE_STRINGS = [SIZE_SM, SIZE_MD, SIZE_LG];
+
   // check for Nuxt.js SSR
   const nuxtServerSideRendering = process && process.server;
 
@@ -144,16 +148,21 @@
         default: false,
       },
       /**
-       * How wide the modal should be.
-       * Small - 300 px.
-       * Medium - 450px.
-       * Large - 100%.
+       * Width of modal. For consistency use the strings `'small'`, `'medium'`, or `'large'`.
+       * For more precise control use an integer number of pixels.
        */
       size: {
-        type: String,
+        type: [String, Number],
         default: 'medium',
         validator(val) {
-          return ['small', 'medium', 'large'].includes(val);
+          if (typeof val === 'string') {
+            if (!SIZE_STRINGS.includes(val)) {
+              log.error(`'${val}' is not one of: ${SIZE_STRINGS}`);
+              return false;
+            }
+            return true;
+          }
+          return val > 0;
         },
       },
       /**
@@ -178,7 +187,14 @@
         return {
           'max-width': `${this.maxModalWidth - 32}px`,
           'max-height': `${this.windowHeight - 32}px`,
+          width: this.modalWidth,
         };
+      },
+      modalWidth() {
+        if (this.size === SIZE_SM) return '300px';
+        if (this.size === SIZE_MD) return '450px';
+        if (this.size === SIZE_LG) return '100%';
+        return `${this.size}px`;
       },
       maxModalWidth() {
         if (this.windowWidth < 1000) {
@@ -403,18 +419,6 @@
 
   .actions button:last-of-type {
     margin-left: 16px;
-  }
-
-  .small {
-    width: 300px;
-  }
-
-  .medium {
-    width: 450px;
-  }
-
-  .large {
-    width: 100%;
   }
 
 </style>


### PR DESCRIPTION
## Description

* Updates `KModal`'s `size` prop to take a precise width in pixels, in addition to existing `'small'`, `'medium'`, and `'large'` strings.
* Updates changelog, including reference to https://github.com/learningequality/kolibri-design-system/pull/278

#### Issue addressed

Helps address https://github.com/learningequality/kolibri/issues/8636

In this case, 'medium' was still too small but 'large' was too big.

### Before/after screenshots


| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/143077464-50e97354-741a-4843-958f-7733e43d4103.png) | ![image](https://user-images.githubusercontent.com/2367265/143077394-cf3d3fbb-8a5d-42c2-bd78-1237cc31343a.png) |
| ![image](https://user-images.githubusercontent.com/2367265/143077511-4aab4a68-65f0-4669-a9a8-aad16a5cc7ec.png) | ![image](https://user-images.githubusercontent.com/2367265/143077580-ce2170ad-25d1-49e9-a152-2644c6a6b740.png) |


## Steps to test

* Check that the new docstrings and logic make sense
* Testing PR in Kolibri: https://github.com/learningequality/kolibri/pull/8775

## (optional) Implementation notes

Because this change expands the API (hopefully without breaking anything) it should be released as a _minor_ (not major or patch) version bump.

### At a high level, how did you implement this?

Adds support for `size` to take a `Number`, interpreted as pixels, in addition to a `String`.

An alternative would have been to keep only strings as allowed, and instead require a unit. However this seemed to possibly introduce "too much" flexibility in the API, which we generally try to keep as constrained as possible while still allowing sufficient flexibility?

### Does this introduce any tech-debt items?

* By allowing arbitrary widths, there is a risk of encouraging UI inconsistency
* This change permanently interprets numbers as `px` values. If we ever wanted to allow another unit (e.g. `%`) we would need to update the strings to allow numbers with units.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [x] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [x] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
