### PR TITLE
update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "v0.2.2-beta-2",
+  "version": "v1.2.0",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "license": "MIT",


### PR DESCRIPTION

## Description

Updates version in preparation for new tagged release. This will enable us to pin Kolibri v0.15.x to tagged, stable releases rather than referencing git hashes.

cc @sairina @nucleogenesis @marcellamaki @MisRob 

