### PR TITLE
render function for handling vertical button wrap

### DIFF
--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -1,13 +1,3 @@
-<template>
-
-  <div class="button-group">
-    <!-- @slot Slot to wrap buttons and provide consistent spacing -->
-    <slot></slot>
-  </div>
-
-</template>
-
-
 <script>
 
   /**
@@ -19,6 +9,16 @@
 
   export default {
     name: 'KButtonGroup',
+    render(createElement) {
+      var children = [];
+      this.$slots.default.forEach(element => {
+        if (element.tag) {
+          children.push(createElement('span', { class: 'button-group-item' }, [element]));
+        }
+      });
+
+      return createElement('div', { class: 'button-group' }, children);
+    },
   };
 
 </script>
@@ -28,11 +28,17 @@
 
   .button-group {
     display: inline-block;
+    margin-bottom: -12px;
+  }
+
+  .button-group-item {
+    display: inline-block;
+    height: 48px;
   }
 
   /* KButton can produce <a> or <button> tags */
-  .button-group > a,
-  .button-group > button {
+  .button-group-item > a,
+  .button-group-item > button {
     margin-right: 8px;
     margin-left: 8px;
   }


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

adds vertical padding when buttons wrap to the next line. This is partly for example or future reference unless we decide to try and squeeze it in to 0.15

#### Issue addressed



fixes https://github.com/learningequality/kolibri-design-system/issues/84

refs:

* https://github.com/learningequality/kolibri/pull/8946#pullrequestreview-835383387
* https://learningequality.slack.com/archives/CB37UM23A/p1639690847424500



### Before/after screenshots

| before | after |
|--|--|
| ![2021-12-17 11 04 34](https://user-images.githubusercontent.com/2367265/146573462-4eb45c4b-98f2-4f38-a043-a75f4dc0ba67.gif) | ![2021-12-17 11 04 01](https://user-images.githubusercontent.com/2367265/146573473-e87d6d82-61b4-45fe-8411-065c36620a19.gif) |


## Steps to test

update kolibri with this change and check for regressions

## (optional) Implementation notes

### At a high level, how did you implement this?

* Adds a wrapper div to each element added in the lost using a render function
* Gives wrapper divs a fixed height, and sets a negative bottom margin to compensate for the last row

### Does this introduce any tech-debt items?

not that I can think of

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [x] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
