### PR TITLE
Set modality to keyboard only when TAB is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
+## Version 1.2.2
+
+- [#291] - When tracking input modality with `trackInputModality`, modality is set to keyboard only when the TAB key is pressed
+
+<!-- Referenced PRs -->
+
+[#291]: https://github.com/learningequality/kolibri-design-system/pull/291
+
 ## Version 1.2.1
 
 - [#279] - Fix vertical shifting of `KTextbox`

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -7,9 +7,11 @@
 
 import globalThemeState from './globalThemeState';
 
-function setUpEventHandlers(disableFocusRingByDefault) {
-  let hadKeyboardEvent = false;
+// only keys listed here will change modality to keyboard
+const KEYS_WHITELIST = ['Tab'];
 
+function setUpEventHandlers(disableFocusRingByDefault) {
+  let recentKeyboardEvent = null;
   let isHandlingKeyboardThrottle;
 
   if (disableFocusRingByDefault) {
@@ -31,15 +33,15 @@ function setUpEventHandlers(disableFocusRingByDefault) {
 
   document.body.addEventListener(
     'keydown',
-    () => {
-      hadKeyboardEvent = true;
+    event => {
+      recentKeyboardEvent = event;
 
       if (isHandlingKeyboardThrottle) {
         clearTimeout(isHandlingKeyboardThrottle);
       }
 
       isHandlingKeyboardThrottle = setTimeout(() => {
-        hadKeyboardEvent = false;
+        recentKeyboardEvent = null;
       }, 100);
     },
     true
@@ -48,7 +50,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
   document.body.addEventListener(
     'focus',
     () => {
-      if (hadKeyboardEvent) {
+      if (recentKeyboardEvent && KEYS_WHITELIST.includes(recentKeyboardEvent.key)) {
         globalThemeState.inputModality = 'keyboard';
       }
     },


### PR DESCRIPTION
## Description

Set modality to keyboard only when TAB key is pressed when tracking input modality.

#### Issue addressed

Fixes https://github.com/learningequality/kolibri/issues/8786

## Steps to test

Follow test instructions in https://github.com/learningequality/kolibri/pull/8971

## Implementation notes

### At a high level, how did you implement this?

I added a whitelist of keys that should change the modality to keyboard. Currently, only TAB key is in the whitelist. Any other keys don't change the modality to keyboard.

### Does this introduce any tech-debt items?

One thing to be cautious about is that many keys that used to change the input modality to keyboard won't change it anymore. I haven't noticed any problems so far. Can you think of any situations where we might need to display the focus ring for keyboard navigation when NOT using TAB/SHIFT+TAB?

> Can't think of any use case on the top of my head, but will do some searching and chime it if I find it!
> ~ @radinamatic

Development-wise, this limits ways that `trackInputModality` might be used in the future for purposes different than displaying focus rings since it won't inform us more generally about any usage of the keyboard anymore. An alternative solution could be to continue changing the input modality to keyboard on any key press and start reporting what key was pressed as the last one to `globalThemeState`. However, that would also require some more conditional logic around displaying focus rings. Since I'm not aware about any other ways that this script is useful for us other than for focus rings, I've decided to try the less complex solution first. I welcome any feedback on this decision.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
