### PR TITLE
A new documentation page and layout fixes for KBreadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
-## Version 1.2.2
+## Version 1.3.0
 
 - [#291] - When tracking input modality with `trackInputModality`, modality is set to keyboard only when the TAB key is pressed
+- [#292] - Add `KBreadcrumbs` page to the components documentation
+- [#292] - Optimize `KBreadcrumbs` to use all space available
+- [#292] - Fix `KBreadcrumbs` items vertical alignment
+- [#292] - Fix `KBreadcrumbs` items not collapsing when there are more instances on a page
 
 <!-- Referenced PRs -->
 
 [#291]: https://github.com/learningequality/kolibri-design-system/pull/291
+[#292]: https://github.com/learningequality/kolibri-design-system/pull/292
 
 ## Version 1.2.1
 

--- a/docs/pages/kbreadcrumbs.vue
+++ b/docs/pages/kbreadcrumbs.vue
@@ -1,0 +1,66 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+
+    <DocsPageSection title="Overview" anchor="#overview">
+      <div>
+        Breadcrumbs help understand the hierarchy among levels and a user's location in it. We often use breadcrumbs to aid navigation across channels, topic trees, and resources.
+
+        <DocsShow block>
+          <KBreadcrumbs
+            :items="[
+              { text: 'Global Digital Library', link: { path: '#' } },
+              { text: 'English', link: { path: '#' } },
+              { text: 'Level 2 ', link: { path: '#' } },
+            ]"
+          />
+        </DocsShow>
+      </div>
+
+      <div>
+        Breadcrumbs take the full width of their container. When there is not enough space available, items that can't be displayed will automatically collapse into the drop-down and visible items might also get truncated:
+
+        <DocsShow
+          block
+          :style="{ maxWidth: '500px' }"
+        >
+          <KBreadcrumbs
+            :items="[
+              { text: 'Global Digital Library', link: { path: '#' } },
+              { text: 'English', link: { path: '#' } },
+              { text: 'Level 2 ', link: { path: '#' } },
+              { text: 'Kaka and Munni: A Folktale from Punjab', link: { path: '#' } }
+            ]"
+          />
+        </DocsShow>
+      </div>
+
+      <div>
+        When there is only one item, it won't be displayed by default. If needed, you can set <code>showSingleItem</code> to <code>true</code> to show it:
+
+        <DocsShow block>
+          <KBreadcrumbs
+            :items="[
+              { text: 'Global Digital Library', link: { path: '#' } },
+            ]"
+            showSingleItem 
+          />
+        </DocsShow>
+      </div>
+    </DocsPageSection>
+
+    <DocsPageSection title="Placement" anchor="#placement">
+      <ul>
+        <li>Directly above the content to be navigated through</li>
+      </ul>
+    </DocsPageSection>
+
+    <DocsPageSection title="Guidelines" anchor="#guidelines">
+      <ul>
+        <li>It should include the current item</li>
+        <li>The current item can be repeated in a page header</li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>

--- a/docs/pages/kbreadcrumbs.vue
+++ b/docs/pages/kbreadcrumbs.vue
@@ -36,7 +36,7 @@
       </div>
 
       <div>
-        When there is only one item, it won't be displayed by default. If needed, you can set <code>showSingleItem</code> to <code>true</code> to show it:
+        When there is only one item, it won't be displayed by default. You can set <code>showSingleItem</code> to <code>true</code> to show it:
 
         <DocsShow block>
           <KBreadcrumbs
@@ -59,6 +59,7 @@
       <ul>
         <li>It should include the current item</li>
         <li>The current item can be repeated in a page header</li>
+        <li>Allow the single breadcrumb (<code>showSingleItem=true</code>) only when there isn't any other page header or label that shows what the current level is</li>
       </ul>
     </DocsPageSection>
   </DocsPageTemplate>

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -296,6 +296,11 @@ export default [
         isCode: true,
         keywords: textRelatedKeywords,
       }),
+      new Page({
+        path: '/kbreadcrumbs',
+        title: 'KBreadcrumbs',
+        isCode: true,
+      }),
     ],
   }),
 ];

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -187,7 +187,16 @@
     },
     mounted() {
       this.attachRefs();
-      this.$watch('parentWidth', this.throttleUpdateCrumbs);
+      // The throttled update function is defined here and not as a method on purpose
+      // since having it defined as a method on the options object would cause problems
+      // when there are more KBreadcrumbs instances rendered on one page.
+      // In such a scenario, all instances would share the same throttled function
+      // resulting in some instances not being updated when they should be.
+      // This is happening because of how the Vue component constructor and instances are built.
+      // Having it defined in the context of the `mounted` function ensures that each component
+      // instance will have its own throttled update function.
+      const throttledUpdateCrumbs = throttle(this.updateCrumbs, 100);
+      this.$watch('parentWidth', throttledUpdateCrumbs);
     },
     methods: {
       attachRefs() {
@@ -239,9 +248,6 @@
           }
         }
       },
-      throttleUpdateCrumbs: throttle(function updateCrumbs() {
-        this.updateCrumbs();
-      }, 100),
     },
   };
 

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -138,8 +138,8 @@
     mixins: [KResponsiveElementMixin],
     props: {
       /**
-       * An array of objects, each with a 'text' attribute (String) and a
-       * 'link' attribute (vue router link object). The 'link' attribute
+       * An array of objects, each with a `text` attribute (String) and a
+       * `link` attribute (vue router link object). The `link` attribute
        * of the last item in the array is optional and ignored.
        */
       items: {
@@ -156,7 +156,7 @@
       },
       /**
        * By default, the breadcrums will be hidden when the length of items is 1.
-       * When set to 'true', a breadcrumb will be shown even when there is only one.
+       * When set to `true`, a breadcrumb will be shown even when there is only one.
        */
       showSingleItem: {
         type: Boolean,

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -13,7 +13,6 @@
           size="small"
           :icon="showDropdown ? 'chevronUp' : 'chevronDown'"
           appearance="raised-button"
-          :style="{ verticalAlign: 'middle' }"
           @click="showDropdown = !showDropdown"
         />
         <div
@@ -68,7 +67,6 @@
             <span
               class="breadcrumbs-crumb-text"
               dir="auto"
-              style="text-decoration: none;"
             >
               {{ crumb.text }}
             </span>
@@ -267,10 +265,12 @@
   $crumb-max-width: 300px;
 
   .breadcrumbs {
+    height: 32px;
     margin-top: 8px;
     margin-bottom: 8px;
     font-size: 16px;
     font-weight: bold;
+    line-height: 32px;
     white-space: nowrap;
   }
 
@@ -279,22 +279,17 @@
     width: 100%;
     max-width: $crumb-max-width;
     overflow: hidden;
-    // this is overriden with inline styles on the last
-    // breadcrumb in the template
-    text-decoration: underline;
     text-overflow: ellipsis;
     white-space: nowrap;
-    vertical-align: middle;
+    vertical-align: bottom;
   }
 
   .breadcrumbs-dropdown-wrapper {
     display: inline-block;
-    vertical-align: middle;
 
     &::after {
       margin-right: 8px;
       margin-left: 8px;
-      vertical-align: middle;
       content: '›';
     }
   }
@@ -331,7 +326,6 @@
     padding: 0;
     margin: 0;
     white-space: nowrap;
-    vertical-align: middle;
     list-style: none;
 
     .breadcrumbs-collapsed & {
@@ -343,14 +337,12 @@
   .breadcrumbs-visible-item {
     display: inline-block;
     max-width: 100%;
-    vertical-align: middle;
   }
 
   .breadcrumbs-visible-item-notlast {
     &::after {
       margin-right: 8px;
       margin-left: 8px;
-      vertical-align: middle;
       content: '›';
     }
   }

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -113,7 +113,6 @@
 
 <script>
 
-  import ResizeSensor from 'css-element-queries/src/ResizeSensor';
   import filter from 'lodash/filter';
   import startsWith from 'lodash/startsWith';
   import throttle from 'lodash/throttle';
@@ -165,7 +164,7 @@
     data: () => ({
       // Array of crumb objects.
       // Each object contains:
-      // text, router-link 'to' object, vue ref, a resize sensor, and its collapsed state
+      // text, router-link 'to' object, vue ref, and its collapsed state
       crumbs: [],
       showDropdown: false,
     }),
@@ -180,36 +179,26 @@
     watch: {
       items(val) {
         this.crumbs = Array.from(val);
-        this.attachSensors();
+        this.attachRefs();
       },
     },
     created() {
       this.crumbs = Array.from(this.items);
     },
     mounted() {
-      this.attachSensors();
+      this.attachRefs();
       this.$watch('parentWidth', this.throttleUpdateCrumbs);
     },
-
-    beforeDestroy() {
-      this.detachSensors();
-    },
     methods: {
-      attachSensors() {
+      attachRefs() {
         this.$nextTick(() => {
           const crumbRefs = filter(this.$refs, (value, key) => startsWith(key, 'crumb'));
           this.crumbs = this.crumbs.map((crumb, index) => {
             const updatedCrumb = crumb;
             updatedCrumb.ref = crumbRefs[index];
-            updatedCrumb.sensor = new ResizeSensor(updatedCrumb.ref, this.throttleUpdateCrumbs);
             return updatedCrumb;
           });
           this.updateCrumbs();
-        });
-      },
-      detachSensors() {
-        this.crumbs.forEach(crumb => {
-          crumb.sensor.detach(this.throttleUpdateCrumbs);
         });
       },
       updateCrumbs() {


### PR DESCRIPTION
## Description

### (1) Adds a first version of `KBreadcrumbs` page to components documentation
### (2) Consolidates styles in regards to vertical alignment of breadcrumbs items

|  | Before | After |
| - | -------- | ------- |
| KDS docs | ![doc-breadcrumbs-vertical-align-before](https://user-images.githubusercontent.com/13509191/147820418-cf56c266-ccf5-4572-b3e8-f53ff7ce678d.png) | ![doc-breadcrumbs-vertical-align-after](https://user-images.githubusercontent.com/13509191/147820422-8b28038c-b18b-4f4b-a8c4-215a3de07248.png) |

### (3) Optimizes breadcrumbs to use all space available

|  | Before | After |
| - | -------- | ------- |
| KDS docs | ![doc-breadcrumbs-space-before](https://user-images.githubusercontent.com/13509191/147820491-3641679a-4fc7-4b90-9076-38ca0f355d79.png) | ![doc-breadcrumbs-space-after](https://user-images.githubusercontent.com/13509191/147820497-df8b4137-63ab-4cd1-b632-b21a44a81efd.png) |
| Kolibri | ![kolibri-breadcrumbs-before](https://user-images.githubusercontent.com/13509191/147820983-5ea39ef9-e4f5-4af3-a0ee-f1e7ecd2e4ad.png) | ![kolibri-breadcrumbs-after](https://user-images.githubusercontent.com/13509191/147821006-2cfc74df-c954-4711-82e7-28d77e0388d1.png) |

### (4) Consolidates throttling and resizing logic

Particularly in regards to having more breadcrumbs instances on one page like in KDS documentation. See commit messages and code comments for details. In the following recording, notice the second breadcrumbs not being properly collapsed because `updateCrumbs` never ran for this particular instance:

|  | Before | After |
| - | -------- | ------- |
| KDS docs | ![doc-breadcrumbs-throttle-before](https://user-images.githubusercontent.com/13509191/147820785-fde82fe6-6f65-4e79-a38f-da4c272cc2a1.gif) | ![doc-breadcrumbs-throttle-after](https://user-images.githubusercontent.com/13509191/147820788-e11c2cbe-e59a-4129-982b-52cbd0b46705.gif) |

#### Issue addressed

- Resolves [https://github.com/learningequality/kolibri-design-system/issues/284](https://github.com/learningequality/kolibri-design-system/issues/284)
- Resolves [https://github.com/learningequality/kolibri-design-system/issues/198](https://github.com/learningequality/kolibri-design-system/issues/198)
- Resolves [https://github.com/learningequality/kolibri/issues/6918](https://github.com/learningequality/kolibri/issues/6918)
- Resolves https://github.com/learningequality/kolibri-design-system/issues/129

## Steps to test

### The documentation page

Regarding text, this is just the very first draft that’s main purpose was to provide me with testing and development environment for new updates as @indirectlylit suggested:

> I realized that a simple alternative to Story Book integration is to simply expand the number of examples we embed in the `K*` pages. In this case for example I was able to update and test the changes without ever leaving the docs

Feel free to suggest any changes. @jtamiace I’d appreciate particularly your thoughts. Also, @jtamiace, I’d like to add some guidance to the new page on when to allow displaying a single breadcrumb item ([https://github.com/learningequality/kolibri-design-system/issues/129](https://github.com/learningequality/kolibri-design-system/issues/129)) on this opportunity. Do you have any suggestions?

### The library component

- [ ]  Check breadcrumbs while resizing window, collapsing of items and items alignment
- [ ]  Test breadcrumbs on [the new KDS documentation page](https://deploy-preview-292--kolibri-design-system.netlify.app/kbreadcrumbs/)
- [ ]  Test breadcrumbs in the corresponding Kolibri PR https://github.com/learningequality/kolibri/pull/8972
  - Confirm that [https://github.com/learningequality/kolibri/issues/6918](https://github.com/learningequality/kolibri/issues/6918) has been fixed
  - Check for breadcrumbs regressions in the whole app

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] The change has been added to the `changelog`

## Reviewer guidance

- [ ] Is the code clean and well-commented?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments

I’ll update the changelog and create a new release tag as soon as the first review of the documentation page and the component is done.