### PR TITLE
Adding Tests

### DIFF
--- a/jest.conf.js
+++ b/jest.conf.js
@@ -1,0 +1,12 @@
+const baseConfig = require('kolibri-tools/jest.conf');
+
+module.exports = Object.assign(baseConfig, {
+  transformIgnorePatterns: [
+    '/node_modules/(?!(keen-ui|kolibri-tools)/).*/',
+  ],
+  collectCoverageFrom: [
+    'lib/**/*.{js|vue}',
+    '!**/node_modules/**',
+    'utils/*.{js|vue}',
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "dev": "npm-run-all --parallel _dev-only _lint-watch-fix _api-watch pregenerate",
     "generate": "yarn run pregenerate && nuxt generate",
+    "test": "yarn run test-jest --watch",
+    "test-jest": "kolibri-tools test --config ./jest.conf.js",
     "lint": "kolibri-tools lint --pattern '**/*.{js,vue,scss,less,css}' -i ,'**/node_modules/**','**/.nuxt/**','**/dist/**','**/lib/KIcon/precompiled-icons/**','**/lib/keen/**','**/docs/environment.js','**/docs/jsdocs.js'",
     "lint-fix": "yarn lint -w",
     "lint-watch": "yarn lint -m",

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -1,0 +1,5 @@
+describe("It smokes where there is fire", () => {
+  it("smokes", () => {
+    expect(true).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

- Adds some package.json scripts to call `kolibri-tools` and jest from it.
- Tried copying Kolibri's jest.conf.js file - the bits I figured we'd need.

Get this error when running (it finds the spec file before failing):

```
 FAIL  tests/smoke.spec.js
  ● Test suite failed to run

    /home/jacob/Code/LE/design-system/node_modules/kolibri-tools/jest.conf/setup.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import 'regenerator-runtime/runtime';
                                                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    SyntaxError: Unexpected string

      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:537:17)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:579:25)
          at Array.forEach (<anonymous>)
```

I'm blaming babel whether it deserves it or not.

NOTE: There is already a test command that calls `jest` bare - should we just use that? I'm not sure if pulling in from `kolibri-tools` is necessary and honestly only noticed the `yarn _test` command as I was writing this PR... :) 