### PR TITLE
Exercise icon flipped in rtl

### DIFF
--- a/lib/KIcon/iconDefinitions.js
+++ b/lib/KIcon/iconDefinitions.js
@@ -87,7 +87,10 @@ const KolibriIcons = {
   audio: { icon: require('./precompiled-icons/material-icons/audiotrack/baseline.vue').default },
   channel: { icon: require('./precompiled-icons/material-icons/apps/baseline.vue').default },
   document: { icon: require('./precompiled-icons/material-icons/book/baseline.vue').default },
-  exercise: { icon: require('./precompiled-icons/material-icons/assignment/baseline.vue').default },
+  exercise: {
+    icon: require('./precompiled-icons/material-icons/assignment/baseline.vue').default,
+    rtlFlip: true,
+  },
   topic: { icon: require('./precompiled-icons/material-icons/folder/baseline.vue').default },
   video: {
     icon: require('./precompiled-icons/material-icons/ondemand_video/baseline.vue').default,


### PR DESCRIPTION
Updates the configuration file so that the Exercise icon flips when in RTL.

## Reviewer Guidance

- Checkout this branch locally
- Link it to your Kolibr
- Check that the icon flips in RTL

Fixes #301 