### PR TITLE
KButton Tests

### DIFF
--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -19,6 +19,7 @@
       v-if="icon"
       :icon="icon"
       :color="iconColor"
+      data-test="iconBefore"
       class="prop-icon"
     />
 
@@ -35,6 +36,7 @@
       v-if="iconAfter"
       :icon="iconAfter"
       :color="iconColor"
+      data-test="iconAfter"
       class="prop-icon"
     />
 
@@ -44,6 +46,7 @@
       icon="dropdown"
       class="dropdown-arrow"
       :style="arrowStyles"
+      data-test="dropdownIcon"
       style="width: 24px; height: 24px;"
     />
   </component>

--- a/lib/buttons-and-links/__tests__/KButton.spec.js
+++ b/lib/buttons-and-links/__tests__/KButton.spec.js
@@ -1,0 +1,67 @@
+import { shallowMount } from '@vue/test-utils';
+import KButton from '../KButton.vue';
+
+describe('KButton', () => {
+  describe('icon related props', () => {
+    it('should render an icon before the text with this.icon', () => {
+      const wrapper = shallowMount(KButton, {
+        propsData: {
+          icon: 'add',
+        },
+      });
+      expect(wrapper.find('[data-test="iconBefore"]').exists()).toBe(true);
+    });
+    it('should render an icon after the text with this.iconAfter', () => {
+      const wrapper = shallowMount(KButton, {
+        propsData: {
+          iconAfter: 'add',
+        },
+      });
+      expect(wrapper.find('[data-test="iconAfter"]').exists()).toBe(true);
+    });
+    it('should render a dropdown icon when hasDropdown is true', () => {
+      const wrapper = shallowMount(KButton, {
+        propsData: {
+          hasDropdown: true,
+        },
+      });
+      expect(wrapper.find('[data-test="dropdownIcon"]').exists()).toBe(true);
+    });
+  });
+
+  describe('text prop and slots', () => {
+    it('should render the text prop if nothing is in the default slot', () => {
+      const wrapper = shallowMount(KButton, {
+        propsData: {
+          text: 'test',
+        },
+      });
+      expect(wrapper.text()).toContain('test');
+    });
+
+    it('should render the slot and not the text prop when the slot has content', () => {
+      const wrapper = shallowMount(KButton, {
+        propsData: {
+          text: 'test',
+        },
+        slots: {
+          default: '<span>slot</span>',
+        },
+      });
+      expect(wrapper.text()).toContain('slot');
+      expect(wrapper.text()).not.toContain('test');
+    });
+  });
+
+  describe('event handling', () => {
+    it('should emit a click event when clicked', () => {
+      const wrapper = shallowMount(KButton, {
+        propsData: {
+          text: 'test',
+        },
+      });
+      wrapper.trigger('click');
+      expect(wrapper.emitted().click).toBeTruthy();
+    });
+  });
+});

--- a/lib/buttons-and-links/__tests__/KButton.spec.js
+++ b/lib/buttons-and-links/__tests__/KButton.spec.js
@@ -3,7 +3,7 @@ import KButton from '../KButton.vue';
 
 describe('KButton', () => {
   describe('icon related props', () => {
-    it('should render an icon before the text with this.icon', () => {
+    it('should render an icon before the text with the icon string passed to the `icon` prop', () => {
       const wrapper = shallowMount(KButton, {
         propsData: {
           icon: 'add',
@@ -11,10 +11,10 @@ describe('KButton', () => {
       });
       expect(wrapper.find('[data-test="iconBefore"]').exists()).toBe(true);
     });
-    it('should render an icon after the text with this.iconAfter', () => {
+    it('should render an icon after the text with the icon string pased to the `iconAfter` prop', () => {
       const wrapper = shallowMount(KButton, {
         propsData: {
-          iconAfter: 'add',
+          iconAfter: 'video',
         },
       });
       expect(wrapper.find('[data-test="iconAfter"]').exists()).toBe(true);


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Adds initial unit tests for some KButton behavior.

Does not test `buttonMixin` behavior as that should be tested separately. This impacts other components and having tests for buttonMixin might be a better next step than any other items in the `buttons-and-links` directory.

## Review

- What behavior in KButton that is not defined in the buttonMixin should I test that isn't covered here?

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #303 