### PR TITLE
Add `KCheckbox` tests

### DIFF
--- a/lib/__test__/KCheckbox.spec.js
+++ b/lib/__test__/KCheckbox.spec.js
@@ -1,0 +1,80 @@
+import { shallowMount } from '@vue/test-utils';
+import KCheckbox from '../KCheckbox';
+
+describe('KCheckbox component', () => {
+  it(`smoke test`, () => {
+    const wrapper = shallowMount(KCheckbox);
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  describe('props', () => {
+    it(`a label should appear with checkbox`, () => {
+      const wrapper = shallowMount(KCheckbox, {
+        propsData: {
+          label: 'test',
+        },
+      });
+      expect(wrapper.find('label').text()).toEqual('test');
+    });
+    it(`a checked checkbox icon should appear when checked is 'true'`, () => {
+      const wrapper = shallowMount(KCheckbox, {
+        propsData: {
+          label: 'checked',
+          checked: true,
+        },
+      });
+      expect(wrapper.find(`[icon="checked"]`).element).toBeTruthy();
+      expect(wrapper.find(`[icon="unchecked"]`).element).toBeFalsy();
+      expect(wrapper.find(`[icon="indeterminateCheck"]`).element).toBeFalsy();
+    });
+    it(`an unchecked checkbox icon should appear when checked is 'false'`, () => {
+      const wrapper = shallowMount(KCheckbox, {
+        propsData: {
+          label: 'unchecked',
+          checked: false,
+        },
+      });
+      expect(wrapper.find(`[icon="checked"]`).element).toBeFalsy();
+      expect(wrapper.find(`[icon="unchecked"]`).element).toBeTruthy();
+      expect(wrapper.find(`[icon="indeterminateCheck"]`).element).toBeFalsy();
+    });
+    it(`indeterminateCheck icon should show when indeterminate is 'true'`, () => {
+      const wrapper = shallowMount(KCheckbox, {
+        propsData: {
+          label: 'indeterminate',
+          indeterminate: true,
+        },
+      });
+      expect(wrapper.find(`[icon="checked"]`).element).toBeFalsy();
+      expect(wrapper.find(`[icon="unchecked"]`).element).toBeFalsy();
+      expect(wrapper.find(`[icon="indeterminateCheck"]`).element).toBeTruthy();
+    });
+    it(`'showLabel' should not show the label when 'false'`, () => {
+      const wrapper = shallowMount(KCheckbox, {
+        propsData: {
+          label: 'no label',
+          showLabel: false,
+        },
+      });
+      expect(wrapper.find('.visuallyhidden').exists()).toBeTruthy();
+    });
+    it(`a description is displayed when that prop is not null`, () => {
+      const wrapper = shallowMount(KCheckbox, {
+        propsData: {
+          label: 'description',
+          description: 'I am a description',
+        },
+      });
+      expect(wrapper.find('.description').text()).toEqual(wrapper.props().description);
+    });
+    it(`checkbox is in disabled state when disabled is 'true'`, () => {
+      const wrapper = shallowMount(KCheckbox, {
+        propsData: {
+          label: 'disabled',
+          disabled: true,
+        },
+      });
+      expect(wrapper.find('.disabled')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Adds tests for KCheckbox

#### Issue addressed
Addresses #307 

## Steps to test

1. Run `yarn run test` in the terminal

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->
- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
