### PR TITLE
Handle empty KButtonGroups

### DIFF
--- a/lib/buttons-and-links/KButtonGroup.vue
+++ b/lib/buttons-and-links/KButtonGroup.vue
@@ -11,7 +11,8 @@
     name: 'KButtonGroup',
     render(createElement) {
       var children = [];
-      this.$slots.default.forEach(element => {
+      // Add an existence catch in case nothing is passed into the slots.
+      (this.$slots.default || []).forEach(element => {
         if (element.tag) {
           children.push(createElement('span', { class: 'button-group-item' }, [element]));
         }


### PR DESCRIPTION
## Description
Catches an edge case when a KButtonGroup has no Buttons inside it.

## Steps to test

1. Create a KButtonGroup with nothing in it
2. Confirm it can render without errors.
3. Profit!

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
