### PR TITLE
Allow for new 'nav' slot inline in the toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
+## Version 1.4.x
+- [#185] - Handle arrow key navigation and improve focusOutline
+- [#338] - Allow for new 'nav' slot inline in the toolbar
+
+
 ## Version 1.3.1
 
 - [#309] - Add jest testing environment to KDS

--- a/lib/keen/UiToolbar.vue
+++ b/lib/keen/UiToolbar.vue
@@ -23,15 +23,15 @@
           </div>
         </slot>
       </div>
-    </div>
-
-    <div class="ui-toolbar__body" :class="{ 'has-brand-divider': hasBrandDivider }">
       <slot>
         <div v-if="title" class="ui-toolbar__title">
           {{ title }}
         </div>
       </slot>
+      <slot name="navigation" class="ui-toolbar__nav"></slot>
     </div>
+
+    
 
     <div class="ui-toolbar__right">
       <slot name="actions"></slot>
@@ -134,9 +134,12 @@
   .ui-toolbar {
     position: relative;
     display: flex;
+    align-content: center;
     align-items: center;
+    justify-content: space-between;
     height: $ui-toolbar-height;
     padding-left: rem(16px);
+    max-width: 100%;
     font-family: inherit;
     font-size: $ui-toolbar-font-size;
 
@@ -155,14 +158,20 @@
   }
 
   .ui-toolbar__left {
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
+    display: inline-flex;
   }
 
   .ui-toolbar__nav-icon {
     margin-right: rem(8px);
     margin-left: rem(-16px);
+  }
+
+  .ui-toolbar__nav {
+    margin-right: rem(8px);
+    margin-left: rem(-16px);
+    display: flex;
+    align-items: bottom;
+    margin-left: 16px;
   }
 
   .ui-toolbar__brand {
@@ -175,8 +184,6 @@
   }
 
   .ui-toolbar__body {
-    display: flex;
-    flex-grow: 1;
 
     &.has-brand-divider {
       padding-left: rem(24px);
@@ -186,8 +193,7 @@
   }
 
   .ui-toolbar__right {
-    flex-shrink: 0;
-    margin-left: auto;
+    display: inline-block;
   }
 
   .ui-toolbar__progress {


### PR DESCRIPTION
## Description
This PR updates the base UiToolbar layout to allow for inline navigation tabs

#### Issue addressed
Supports implemention of Kolibri # 9274

### Before/after screenshots
Example from kolibri update 


<img width="1431" alt="Screen Shot 2022-06-07 at 4 30 17 PM" src="https://user-images.githubusercontent.com/17235236/172625044-9a64567b-fcca-4444-9cad-80cf2cc44a87.png">

## Steps to test

Please see [corresponding Kolibri PR](https://github.com/learningequality/kolibri/pull/9496) 

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged
