### PR TITLE
Update kdropdown menu api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 ## Version 1.4.x
 - [#185] - Handle arrow key navigation and improve focusOutline
 - [#338] - Allow for new 'nav' slot inline in the toolbar
-
+- [#346] - Update KDropdownMenu API: `KDropdownMenu` no longer contains a button. `KDropdownMenu` can be used in `KButton` or `KIconButton` `slots`. Both `slots` and `text` can now be used in `KButton` - `slots` do not take precedence over `text`.
 
 ## Version 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,11 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 ## Develop (version not yet known)
 - [#351] - Wrap `KCheckbox` default slot's content in <label>
 - [#355] - Add `KSelect` to KDS
-
+- [#346] - Update KDropdownMenu API: `KDropdownMenu` no longer contains a button. `KDropdownMenu` can be used in `KButton` or `KIconButton` `slots`. Both `slots` and `text` can now be used in `KButton` - `slots` do not take precedence over `text`.
 
 ## Version 1.4.x
 - [#185] - Handle arrow key navigation and improve focusOutline
 - [#338] - Allow for new 'nav' slot inline in the toolbar
-- [#346] - Update KDropdownMenu API: `KDropdownMenu` no longer contains a button. `KDropdownMenu` can be used in `KButton` or `KIconButton` `slots`. Both `slots` and `text` can now be used in `KButton` - `slots` do not take precedence over `text`.
 
 ## Version 1.3.1
 

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -134,44 +134,48 @@
 
     <DocsPageSection title="Dropdowns" anchor="#dropdowns">
       <p>
-        Buttons can also have drop-down menus. Currently this is implemented using the poorly-named <code>KDropdownMenu</code> component, but this is <DocsGithubLink text="subject to change" issue="164" />.
+        Buttons can also have drop-down menus. 
       </p>
-      <!-- TODO: implement 3 examples: primary button, primary flat button, and secondary icon button that function as dropdowns. See Google doc for example -->
-      <DocsShow>
-        <KDropdownMenu
-          style="margin-right: 16px;"
-          text="Primary"
-          :primary="true"
-          :options="['Option 1', 'Option 2']"
-          appearance="raised-button"
-        />
-        <KDropdownMenu
-          style="margin-right: 16px;"
-          text="Secondary"
-          :primary="false"
-          :options="['Option 1', 'Option 2']"
-          appearance="raised-button"
-        />
-        <KDropdownMenu
-          text="Icon dropdown"
-          :primary="false"
-          :options="['Option 1', 'Option 2']"
-          appearance="raised-button"
-        >
-          <template #button>
-            <KIconButton
-              tooltip="Dropdown options"
-              icon="optionsHorizontal"
-              appearance="flat-button"
-              :primary="false"
-            />
-          </template>
-        </KDropdownMenu>
-      </DocsShow>
-      <p>
-        Caution: <code>KDropdownMenu</code> does not work with the <DocsLibraryLink component="KButtonGroup" /> component.
+      <p> 
+        The API for this has been updated, and now the <code>KDropdownMenu</code> component can be added using <code>template</code> with <code>#menu</code> to a <code>slot</code> in either a <code>KButton</code> or a <code>KIconButton</code>. 
+        Previously, the <code>KDropdownMenu</code> component was responsible for the button rendering as well as the menu, but now, it only manages the menu itself.
       </p>
 
+      <DocsShow>
+        <KButtonGroup>
+          <KButton
+            text="Options"
+            :primary="true"
+            iconAfter="chevronDown"
+          >
+            <KDropdownMenu
+              style="margin-right: 16px;"
+              text="Primary"
+              :primary="true"
+              :options="['Option 1', 'Option 2']"
+              appearance="raised-button"
+            />
+          </KButton>
+          <KIconButton
+            tooltip="Dropdown options"
+            icon="optionsHorizontal"
+            appearance="flat-button"
+            :primary="false"
+          >
+            <template #menu>
+              <KDropdownMenu
+                style="margin-right: 16px;"
+                text="Primary"
+                :primary="true"
+                :options="['Option 1', 'Option 2']"
+                appearance="raised-button"
+              />
+            </template>
+          </KIconButton>
+        </KButtonGroup>
+
+      </DocsShow>
+      <p>For more guidance, see the <code>KDropdownMenu</code> component.</p>
     </DocsPageSection>
 
     <DocsPageSection title="Visual specs" anchor="#specs" />
@@ -196,4 +200,5 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+</style>

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -198,7 +198,3 @@
   export default {};
 
 </script>
-
-
-<style lang="scss" scoped>
-</style>

--- a/docs/pages/kbutton.vue
+++ b/docs/pages/kbutton.vue
@@ -37,6 +37,7 @@
           <DocsLibraryLink component="KIconButton" /> has a tooltip instead of a text label
         </li>
         <li><DocsLibraryLink component="KButtonGroup" /> is used for button layout</li>
+        <li><DocsLibraryLink component="KDropdownMenu" /> and <DocsInternalLink text="Buttons and links" href="/buttons" /> have more detail about adding a menu of options to a button component</li>
       </ul>
     </DocsPageSection>
 

--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -4,10 +4,14 @@
     <DocsPageSection title="Overview" anchor="#overview">
 
       <p>
-        Implements a button with a dropdown set of options, based on <DocsExternalLink text="Keen's UI Menu" href="https://josephuspaye.github.io/Keen-UI/#/ui-menu" />. See these docs to understand the current implementation of the options object array.
+        Implements a dropdown set of options, based on <DocsExternalLink text="Keen's UI Menu" href="https://josephuspaye.github.io/Keen-UI/#/ui-menu" />. See these docs to understand the current implementation of the options object array.
       </p>
       <p>
-        Note that this component may be deprecated in the future: <DocsGithubLink issue="164" />
+        Notable possible for configuring the menu include: icons, text, secondary text, and dividers.
+      </p>
+      <p>
+        Prior to 09/2022, this component also managed the button associated with the dropdown menu, but the API has changed for a clearer division of responsibilities. 
+        Please see the <DocsInternalLink href="/buttons#dropdowns" text="Dropdown section of the Buttons and links page" /> on the buttons page for more details about how to use with a button, and a code example.
       </p>
     </DocsPageSection>
   </DocsPageTemplate>

--- a/docs/pages/kiconbutton.vue
+++ b/docs/pages/kiconbutton.vue
@@ -25,6 +25,7 @@
         </li>
         <li><DocsLibraryLink component="KButton" />, <DocsLibraryLink component="KExternalLink" />, and <DocsLibraryLink component="KRouterLink" /> are all similar but handle events differently</li>
         <li><DocsLibraryLink component="KButtonGroup" /> is used for button layout</li>
+        <li><DocsLibraryLink component="KDropdownMenu" /> and <DocsInternalLink text="Buttons and links" href="/buttons" /> have more detail about adding a menu of options to a button component</li>
       </ul>
     </DocsPageSection>
 

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -1,14 +1,15 @@
 <template>
-
-  <KButton
-    ref="button"
-    :appearance="appearance"
-    :disabled="disabled"
-    :hasDropdown="true"
-    :primary="$attrs.primary"
-  >
-    <span>{{ text }}</span>
-    <UiPopover
+    <!-- <KButton
+      v-if="!$slots.button"
+      ref="button"
+      :text="text"
+      :appearance="appearance"
+      :disabled="disabled"
+      :hasDropdown="true"
+      :primary="$attrs.primary"
+    >
+      <span>{{ text }}</span> -->
+      <UiPopover
       v-if="!disabled"
       ref="popover"
       :z-index="12"
@@ -17,156 +18,166 @@
       @close="handleClose"
       @open="handleOpen"
     >
-      <UiMenu
-        ref="menu"
-        :options="options"
-        @select="handleSelection"
-      />
+      <UiMenu ref="menu" :options="options" @select="handleSelection" :hasIcons="hasIcons" />
     </UiPopover>
-  </KButton>
-
+    <!-- </KButton>
+    <slot name="button"></slot>
+  </div> -->
 </template>
 
 
 <script>
+import UiPopover from './keen/UiPopover';
+import UiMenu from './keen/UiMenu';
+import { validator } from './buttons-and-links/appearances';
 
-  import UiPopover from './keen/UiPopover';
-  import UiMenu from './keen/UiMenu';
-  import { validator } from './buttons-and-links/appearances';
+/**
+ * The KDropdownMenu component is used to contain multiple actions
+ */
+export default {
+  name: 'KDropdownMenu',
+  components: {
+    UiPopover,
+    UiMenu,
+  },
+  props: {
+    /**
+     * Button label text
+     */
+    text: {
+      type: String,
+      required: false,
+    },
+    /**
+     * Button label icon
+     */
+    icon: {
+      type: String,
+      required: false,
+    },
+    /**
+     * An array of options objects, with one object per dropdown item
+     */
+    options: {
+      type: Array,
+      required: true,
+    },
+    /**
+     * Button appearance: `'raised-button'` or `'flat-button'`
+     */
+    appearance: {
+      type: String,
+      default: 'raised-button',
+      validator,
+    },
+    /**
+     * Whether or not the button is disabled
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Whether or not the options display an icon
+     */
+    hasIcons: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * The position of the dropdown relative to the button
+     */
+    position: {
+      type: String,
+      default: 'bottom right',
+      validator(val) {
+        return [
+          'bottom left',
+          'bottom center',
+          'bottom right',
+          'top left',
+          'top center',
+          'top right',
+          'left top',
+          'left middle',
+          'left bottom',
+          'right top',
+          'right middle',
+          'right bottom',
+        ].includes(val);
+      },
+    },
+  },
+  beforeDestroy() {
+    window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
+  },
+  methods: {
+    handleOpen() {
+      this.$nextTick(() => this.setFocus());
+      window.addEventListener('keydown', this.handleOpenMenuNavigation, true);
+    },
+    setFocus() {
+      this.$refs.menu.$el.querySelector('li').focus();
+    },
+    handleClose() {
+      const focusedElement = document.activeElement;
+      const popover = this.$refs.popover.$el;
+      if (
+        popover.contains(focusedElement) &&
+        (focusedElement.classList.contains('ui-popover') ||
+          focusedElement.classList.contains('ui-popover-focus-redirector') ||
+          focusedElement.classList.contains('ui-menu-option'))
+      ) {
+        this.focusOnButton();
+      }
+      window.removeEventListener('keyup', this.handleKeyUp, true);
+    },
+    handleOpenMenuNavigation(event) {
+      // identify the menu state and length
+      if (!this.$refs.popover && !this.$refs.popover.$el) {
+        return;
+      }
+      const popover = this.$refs.popover.$el;
+      const menuElements = this.$refs.menu.$el.querySelector('div').children;
+      const lastChild = menuElements[menuElements.length - 1];
+      const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
+      // set current element and its siblings
+      let focusedElement = document.activeElement;
+      let sibling = focusedElement.nextElementSibling;
+      let prevSibling = focusedElement.previousElementSibling;
 
-  /**
-   * The KDropdownMenu component is used to contain multiple actions
-   */
-  export default {
-    name: 'KDropdownMenu',
-    components: {
-      UiPopover,
-      UiMenu,
-    },
-    props: {
-      /**
-       * Button label text
-       */
-      text: {
-        type: String,
-        required: true,
-      },
-      /**
-       * An array of options objects, with one object per dropdown item
-       */
-      options: {
-        type: Array,
-        required: true,
-      },
-      /**
-       * Button appearance: `'raised-button'` or `'flat-button'`
-       */
-      appearance: {
-        type: String,
-        default: 'raised-button',
-        validator,
-      },
-      /**
-       * Whether or not the button is disabled
-       */
-      disabled: {
-        type: Boolean,
-        default: false,
-      },
-      /**
-       * The position of the dropdown relative to the button
-       */
-      position: {
-        type: String,
-        default: 'bottom right',
-        validator(val) {
-          return [
-            'bottom left',
-            'bottom center',
-            'bottom right',
-            'top left',
-            'top center',
-            'top right',
-            'left top',
-            'left middle',
-            'left bottom',
-            'right top',
-            'right middle',
-            'right bottom',
-          ].includes(val);
-        },
-      },
-    },
-    beforeDestroy() {
-      window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
-    },
-    methods: {
-      handleOpen() {
-        this.$nextTick(() => this.setFocus());
-        window.addEventListener('keydown', this.handleOpenMenuNavigation, true);
-      },
-      setFocus() {
-        this.$refs.menu.$el.querySelector('li').focus();
-      },
-      handleClose() {
-        const focusedElement = document.activeElement;
-        const popover = this.$refs.popover.$el;
-        if (
-          popover.contains(focusedElement) &&
-          (focusedElement.classList.contains('ui-popover') ||
-            focusedElement.classList.contains('ui-popover-focus-redirector') ||
-            focusedElement.classList.contains('ui-menu-option'))
-        ) {
-          this.focusOnButton();
-        }
-        window.removeEventListener('keyup', this.handleKeyUp, true);
-      },
-      handleOpenMenuNavigation(event) {
-        // identify the menu state and length
-        if (!this.$refs.popover && !this.$refs.popover.$el) {
-          return;
-        }
-        const popover = this.$refs.popover.$el;
-        const menuElements = this.$refs.menu.$el.querySelector('div').children;
-        const lastChild = menuElements[menuElements.length - 1];
-        const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
-        // set current element and its siblings
-        let focusedElement = document.activeElement;
-        let sibling = focusedElement.nextElementSibling;
-        let prevSibling = focusedElement.previousElementSibling;
-
-        // manage rotating through the options using arrow keys
-        // UP arrow: .keyCode is depricated and should used only as a fallback
-        if ((event.key == 'ArrowUp' || event.keyCode == 38) && popoverIsOpen) {
-          event.preventDefault();
-          prevSibling
-            ? this.$nextTick(() => prevSibling.focus())
-            : this.$nextTick(() => lastChild.focus());
-          // DOWN arrow
-        } else if ((event.key == 'ArrowDown' || event.keyCode == 40) && popoverIsOpen) {
-          event.preventDefault();
-          sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
-          // if a TAB key, not an arrow key, close the popover and advance to next item in the tab index
-        } else if ((event.key == 'Tab' || event.keyCode == 9) && popoverIsOpen) {
-          this.closePopover();
-        }
-      },
-      handleSelection(selection) {
-        /**
-         * Emitted when an option is selected
-         */
-        this.$emit('select', selection);
+      // manage rotating through the options using arrow keys
+      // UP arrow: .keyCode is depricated and should used only as a fallback
+      if ((event.key == 'ArrowUp' || event.keyCode == 38) && popoverIsOpen) {
+        event.preventDefault();
+        prevSibling
+          ? this.$nextTick(() => prevSibling.focus())
+          : this.$nextTick(() => lastChild.focus());
+        // DOWN arrow
+      } else if ((event.key == 'ArrowDown' || event.keyCode == 40) && popoverIsOpen) {
+        event.preventDefault();
+        sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
+        // if a TAB key, not an arrow key, close the popover and advance to next item in the tab index
+      } else if ((event.key == 'Tab' || event.keyCode == 9) && popoverIsOpen) {
         this.closePopover();
-      },
-      closePopover() {
-        this.$refs.popover.close();
-      },
-      focusOnButton() {
-        if (this.$refs.button) {
-          this.$refs.button.$el.focus();
-        }
-      },
+      }
     },
-  };
-
+    handleSelection(selection) {
+      console.log('handling selection', selection);
+      /**
+       * Emitted when an option is selected
+       */
+      this.$emit('select', selection);
+      this.closePopover();
+    },
+    closePopover() {
+      this.$refs.popover.close();
+    },
+    focusOnButton() {
+      if (this.$refs.button) {
+        this.$refs.button.$el.focus();
+      }
+    },
+  },
+};
 </script>

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -1,28 +1,20 @@
 <template>
-    <!-- <KButton
-      v-if="!$slots.button"
-      ref="button"
-      :text="text"
-      :appearance="appearance"
-      :disabled="disabled"
-      :hasDropdown="true"
-      :primary="$attrs.primary"
-    >
-      <span>{{ text }}</span> -->
-      <UiPopover
-      v-if="!disabled"
-      ref="popover"
-      :z-index="12"
-      :containFocus="true"
-      :dropdownPosition="position"
-      @close="handleClose"
-      @open="handleOpen"
-    >
-      <UiMenu ref="menu" :options="options" @select="handleSelection" :hasIcons="hasIcons" />
-    </UiPopover>
-    <!-- </KButton>
-    <slot name="button"></slot>
-  </div> -->
+  <UiPopover
+    v-if="!disabled"
+    ref="popover"
+    :z-index="12"
+    :containFocus="true"
+    :dropdownPosition="position"
+    @close="handleClose"
+    @open="handleOpen"
+  >
+    <UiMenu 
+      ref="menu" 
+      :options="options" 
+      @select="handleSelection" 
+      :hasIcons="hasIcons" 
+    />
+  </UiPopover>
 </template>
 
 
@@ -42,40 +34,11 @@ export default {
   },
   props: {
     /**
-     * Button label text
-     */
-    text: {
-      type: String,
-      required: false,
-    },
-    /**
-     * Button label icon
-     */
-    icon: {
-      type: String,
-      required: false,
-    },
-    /**
      * An array of options objects, with one object per dropdown item
      */
     options: {
       type: Array,
       required: true,
-    },
-    /**
-     * Button appearance: `'raised-button'` or `'flat-button'`
-     */
-    appearance: {
-      type: String,
-      default: 'raised-button',
-      validator,
-    },
-    /**
-     * Whether or not the button is disabled
-     */
-    disabled: {
-      type: Boolean,
-      default: false,
     },
     /**
      * Whether or not the options display an icon

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -1,4 +1,5 @@
 <template>
+
   <UiPopover
     v-if="!disabled"
     ref="popover"
@@ -11,135 +12,138 @@
     <UiMenu 
       ref="menu" 
       :options="options" 
-      @select="handleSelection" 
       :hasIcons="hasIcons" 
+      @select="handleSelection" 
     />
   </UiPopover>
+
 </template>
 
 
 <script>
-import UiPopover from './keen/UiPopover';
-import UiMenu from './keen/UiMenu';
 
-/**
- * The KDropdownMenu component is used to contain multiple actions
- */
-export default {
-  name: 'KDropdownMenu',
-  components: {
-    UiPopover,
-    UiMenu,
-  },
-  props: {
-    /**
-     * An array of options objects, with one object per dropdown item
-     */
-    options: {
-      type: Array,
-      required: true,
+  import UiPopover from './keen/UiPopover';
+  import UiMenu from './keen/UiMenu';
+
+  /**
+   * The KDropdownMenu component is used to contain multiple actions
+   */
+  export default {
+    name: 'KDropdownMenu',
+    components: {
+      UiPopover,
+      UiMenu,
     },
-    /**
-     * Whether or not the options display an icon
-     */
-    hasIcons: {
-      type: Boolean,
-      default: false,
-    },
-    /**
-     * The position of the dropdown relative to the button
-     */
-    position: {
-      type: String,
-      default: 'bottom right',
-      validator(val) {
-        return [
-          'bottom left',
-          'bottom center',
-          'bottom right',
-          'top left',
-          'top center',
-          'top right',
-          'left top',
-          'left middle',
-          'left bottom',
-          'right top',
-          'right middle',
-          'right bottom',
-        ].includes(val);
+    props: {
+      /**
+       * An array of options objects, with one object per dropdown item
+       */
+      options: {
+        type: Array,
+        required: true,
+      },
+      /**
+       * Whether or not the options display an icon
+       */
+      hasIcons: {
+        type: Boolean,
+        default: false,
+      },
+      /**
+       * The position of the dropdown relative to the button
+       */
+      position: {
+        type: String,
+        default: 'bottom right',
+        validator(val) {
+          return [
+            'bottom left',
+            'bottom center',
+            'bottom right',
+            'top left',
+            'top center',
+            'top right',
+            'left top',
+            'left middle',
+            'left bottom',
+            'right top',
+            'right middle',
+            'right bottom',
+          ].includes(val);
+        },
       },
     },
-  },
-  beforeDestroy() {
-    window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
-  },
-  methods: {
-    handleOpen() {
-      this.$nextTick(() => this.setFocus());
-      window.addEventListener('keydown', this.handleOpenMenuNavigation, true);
+    beforeDestroy() {
+      window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
     },
-    setFocus() {
-      this.$refs.menu.$el.querySelector('li').focus();
-    },
-    handleClose() {
-      const focusedElement = document.activeElement;
-      const popover = this.$refs.popover.$el;
-      if (
-        popover.contains(focusedElement) &&
-        (focusedElement.classList.contains('ui-popover') ||
-          focusedElement.classList.contains('ui-popover-focus-redirector') ||
-          focusedElement.classList.contains('ui-menu-option'))
-      ) {
-        this.focusOnButton();
-      }
-      window.removeEventListener('keyup', this.handleKeyUp, true);
-    },
-    handleOpenMenuNavigation(event) {
-      // identify the menu state and length
-      if (!this.$refs.popover && !this.$refs.popover.$el) {
-        return;
-      }
-      const popover = this.$refs.popover.$el;
-      const menuElements = this.$refs.menu.$el.querySelector('div').children;
-      const lastChild = menuElements[menuElements.length - 1];
-      const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
-      // set current element and its siblings
-      let focusedElement = document.activeElement;
-      let sibling = focusedElement.nextElementSibling;
-      let prevSibling = focusedElement.previousElementSibling;
+    methods: {
+      handleOpen() {
+        this.$nextTick(() => this.setFocus());
+        window.addEventListener('keydown', this.handleOpenMenuNavigation, true);
+      },
+      setFocus() {
+        this.$refs.menu.$el.querySelector('li').focus();
+      },
+      handleClose() {
+        const focusedElement = document.activeElement;
+        const popover = this.$refs.popover.$el;
+        if (
+          popover.contains(focusedElement) &&
+          (focusedElement.classList.contains('ui-popover') ||
+            focusedElement.classList.contains('ui-popover-focus-redirector') ||
+            focusedElement.classList.contains('ui-menu-option'))
+        ) {
+          this.focusOnButton();
+        }
+        window.removeEventListener('keyup', this.handleKeyUp, true);
+      },
+      handleOpenMenuNavigation(event) {
+        // identify the menu state and length
+        if (!this.$refs.popover && !this.$refs.popover.$el) {
+          return;
+        }
+        const popover = this.$refs.popover.$el;
+        const menuElements = this.$refs.menu.$el.querySelector('div').children;
+        const lastChild = menuElements[menuElements.length - 1];
+        const popoverIsOpen = popover.clientWidth > 0 && popover.clientHeight > 0;
+        // set current element and its siblings
+        let focusedElement = document.activeElement;
+        let sibling = focusedElement.nextElementSibling;
+        let prevSibling = focusedElement.previousElementSibling;
 
-      // manage rotating through the options using arrow keys
-      // UP arrow: .keyCode is depricated and should used only as a fallback
-      if ((event.key == 'ArrowUp' || event.keyCode == 38) && popoverIsOpen) {
-        event.preventDefault();
-        prevSibling
-          ? this.$nextTick(() => prevSibling.focus())
-          : this.$nextTick(() => lastChild.focus());
-        // DOWN arrow
-      } else if ((event.key == 'ArrowDown' || event.keyCode == 40) && popoverIsOpen) {
-        event.preventDefault();
-        sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
-        // if a TAB key, not an arrow key, close the popover and advance to next item in the tab index
-      } else if ((event.key == 'Tab' || event.keyCode == 9) && popoverIsOpen) {
+        // manage rotating through the options using arrow keys
+        // UP arrow: .keyCode is depricated and should used only as a fallback
+        if ((event.key == 'ArrowUp' || event.keyCode == 38) && popoverIsOpen) {
+          event.preventDefault();
+          prevSibling
+            ? this.$nextTick(() => prevSibling.focus())
+            : this.$nextTick(() => lastChild.focus());
+          // DOWN arrow
+        } else if ((event.key == 'ArrowDown' || event.keyCode == 40) && popoverIsOpen) {
+          event.preventDefault();
+          sibling ? this.$nextTick(() => sibling.focus()) : this.$nextTick(() => this.setFocus());
+          // if a TAB key, not an arrow key, close the popover and advance to next item in the tab index
+        } else if ((event.key == 'Tab' || event.keyCode == 9) && popoverIsOpen) {
+          this.closePopover();
+        }
+      },
+      handleSelection(selection) {
+        console.log('handling selection', selection);
+        /**
+         * Emitted when an option is selected
+         */
+        this.$emit('select', selection);
         this.closePopover();
-      }
+      },
+      closePopover() {
+        this.$refs.popover.close();
+      },
+      focusOnButton() {
+        if (this.$refs.button) {
+          this.$refs.button.$el.focus();
+        }
+      },
     },
-    handleSelection(selection) {
-      console.log('handling selection', selection);
-      /**
-       * Emitted when an option is selected
-       */
-      this.$emit('select', selection);
-      this.closePopover();
-    },
-    closePopover() {
-      this.$refs.popover.close();
-    },
-    focusOnButton() {
-      if (this.$refs.button) {
-        this.$refs.button.$el.focus();
-      }
-    },
-  },
-};
+  };
+
 </script>

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -21,7 +21,6 @@
 <script>
 import UiPopover from './keen/UiPopover';
 import UiMenu from './keen/UiMenu';
-import { validator } from './buttons-and-links/appearances';
 
 /**
  * The KDropdownMenu component is used to contain multiple actions

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -128,7 +128,6 @@
         }
       },
       handleSelection(selection) {
-        console.log('handling selection', selection);
         /**
          * Emitted when an option is selected
          */

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -23,7 +23,8 @@
       class="prop-icon"
     />
     <slot name="menu"></slot>
-    <!-- @slot Pass sub-components into the button, which provides more flexibility than and takes precedence over the `text` prop -->
+    <!-- @slot Pass sub-components into the button, which provides more flexibility -->
+    <!-- @slot no longer takes prescendence over text. Both slot and text can now be used -->
     <slot v-if="$slots.default"></slot>
 
     <template>

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -22,11 +22,11 @@
       data-test="iconBefore"
       class="prop-icon"
     />
-
+    <slot name="menu"></slot>
     <!-- @slot Pass sub-components into the button, which provides more flexibility than and takes precedence over the `text` prop -->
     <slot v-if="$slots.default"></slot>
 
-    <template v-else>
+    <template>
       <span class="link-text" :style="textStyle">{{ text }}</span>
     </template>
 

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -22,9 +22,9 @@
       data-test="iconBefore"
       class="prop-icon"
     />
+    <!-- @slot Pass sub-components into the button, typically `KDropdownMenu` -->
     <slot name="menu"></slot>
-    <!-- @slot Pass sub-components into the button, which provides more flexibility -->
-    <!-- @slot no longer takes prescendence over text. Both slot and text can now be used -->
+    <!-- @slot Slot alternative to the `text` prop -->
     <slot v-if="$slots.default"></slot>
 
     <template>

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -92,7 +92,7 @@
         default: null, // https://github.com/learningequality/kolibri-design-system/issues/168
       },
       /**
-       * Tooltip position, passes to existing 'UiTooltip' prop for position
+       * Tooltip position: `'top', 'right', 'bottom', 'left'`
        */
       tooltipPosition: {
         type: String,

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -21,6 +21,7 @@
     </UiTooltip>
     <!-- UiIconButton used flexbox - 7px is the magic centering number -->
     <KIcon :icon="icon" :color="color" :style="iconStyles" />
+    <!-- @slot Pass sub-components into the button, typically `KDropdownMenu` -->
     <slot name="menu"></slot>
   </KButton>
 

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -20,6 +20,7 @@
     </UiTooltip>
     <!-- UiIconButton used flexbox - 7px is the magic centering number -->
     <KIcon :icon="icon" :color="color" :style="iconStyles" />
+    <slot name="menu"></slot>
   </KButton>
 
 </template>

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -10,11 +10,12 @@
     text=""
     v-on="$listeners"
   >
+    <!-- if no "position" is passed as a prop, defaults to bottom, as previously -->
     <UiTooltip
       v-if="tooltip"
       :zIndex="24"
       open-on="hover"
-      position="bottom"
+      :position="tooltipPosition" 
     >
       {{ tooltip }}
     </UiTooltip>
@@ -89,6 +90,13 @@
       tooltip: {
         type: String,
         default: null, // https://github.com/learningequality/kolibri-design-system/issues/168
+      },
+      /**
+       * Tooltip position, passes to existing 'UiTooltip' prop for position
+       */
+      tooltipPosition: {
+        type: String,
+        default: 'bottom',
       },
     },
     computed: {

--- a/lib/buttons-and-links/__tests__/KButton.spec.js
+++ b/lib/buttons-and-links/__tests__/KButton.spec.js
@@ -39,7 +39,7 @@ describe('KButton', () => {
       expect(wrapper.text()).toContain('test');
     });
 
-    it('should render the slot and not the text prop when the slot has content', () => {
+    it('should render the slot when the slot has content', () => {
       const wrapper = shallowMount(KButton, {
         propsData: {
           text: 'test',
@@ -49,7 +49,7 @@ describe('KButton', () => {
         },
       });
       expect(wrapper.text()).toContain('slot');
-      expect(wrapper.text()).not.toContain('test');
+      expect(wrapper.text()).toContain('test');
     });
   });
 

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -24,10 +24,10 @@
         <div class="ui-menu-option-text">
           {{ label }}
         </div>
-<!--
+
         <div v-if="secondaryText" class="ui-menu-option-secondary-text">
           {{ secondaryText }}
-        </div> -->
+        </div>
       </div>
     </slot>
 

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -15,24 +15,19 @@
   >
     <slot v-if="!isDivider">
       <div class="ui-menu-option-content">
-        <UiIcon
+        <KIcon
+        class="k-icon"
           v-if="icon"
-
-          class="ui-menu-option-icon"
-          :icon-set="iconProps.iconSet"
           :icon="icon"
-          :remove-text="iconProps.removeText"
-
-          :use-svg="iconProps.useSvg"
         />
-
+ 
         <div class="ui-menu-option-text">
           {{ label }}
         </div>
-
+<!--
         <div v-if="secondaryText" class="ui-menu-option-secondary-text">
           {{ secondaryText }}
-        </div>
+        </div> -->
       </div>
     </slot>
 
@@ -178,6 +173,11 @@
     margin-left: rem(4px);
     font-size: rem(13px);
     color: $hint-text-color;
+  }
+
+  .k-icon {
+    top: 0px !important;
+    margin: 0px 8px;
   }
 
 </style>


### PR DESCRIPTION
## Description
This PR changes the KDropdownMenu API by addressing the issue that KDropdownMenu also contained a button. Now, KDropdownMenu is _only_ the popover elements

#### Issue addressed
Addresses #164
Does a better job fixing #136 (which caused a regression with my last fix). 
Fix the regression where the [additional options for the button (previously in a `<slot/>` in KDropdownMenu is no longer working](https://kolibri-design-system.netlify.app/buttons/#dropdowns), as you can see in the documentation

### Before/after screenshots
There are no visual changes to the UI (I hope!)

## Steps to test
I will open a corresponding kolibri PR that points to this commit next week with instructions for testing.

## (optional) Implementation notes

### At a high level, how did you implement this?
The makes `KDropdownMenu` a slot for `KButton` (or `KIconButton`) rather than responsible for also creating the button.

### Does this introduce any tech-debt items?
 Doing this would require some (fairly straightforward) remediation following a KDS version bump in Kolibri (11 instances of component are used) and KDP (5 instances of component). None in Studio.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
