### PR TITLE
KCheckbox: Wrap default's slot content in <label>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
+## Develop (version not yet known)
+- [#351] - Wrap `KCheckbox` default slot's content in <label>
+
+
 ## Version 1.4.x
 - [#185] - Handle arrow key navigation and improve focusOutline
 - [#338] - Allow for new 'nav' slot inline in the toolbar

--- a/docs/pages/kcheckbox.vue
+++ b/docs/pages/kcheckbox.vue
@@ -3,7 +3,7 @@
   <DocsPageTemplate apiDocs>
 
     <DocsPageSection title="Overview" anchor="#overview">
-      <p>These are checkbox components:</p>
+      <p>The checkbox is generally used to select one of two possible values in a form.</p>
       <DocsShow>
         <KCheckbox
           label="Some label"
@@ -14,20 +14,25 @@
           :checked="false"
         />
       </DocsShow>
-      <p>
-        The checkbox is generally used to select one of two possible values in a form. It should not be used to make real-time changes; for this situation, use a <DocsLibraryLink component="KSwitch" /> component instead.
-      </p>
-      <p>Layout:</p>
+    </DocsPageSection>
+
+    <DocsPageSection title="Layout" anchor="#layout">
       <ul>
         <li>Aligned with container margin</li>
         <li>When used in a group, vertically stacked</li>
         <li>Hierarchical nesting is avoided</li>
       </ul>
-      <p>Labels:</p>
+    </DocsPageSection>
+
+    <DocsPageSection title="Guidelines" anchor="#guidelines">
       <ul>
         <li>Labels should be short and concise</li>
-        <li>The checked state should represent an affirmative value</li>
+        <li>Checkbox should not be used to make real-time changes; for this situation, use a <DocsLibraryLink component="KSwitch" /> component instead</li>
       </ul>
+    </DocsPageSection>
+
+    <DocsPageSection title="States" anchor="#states">
+      <p>The checked state represents an affirmative value.</p>
       <p>
         Checkboxes can also have a "partially-checked" or "indeterminate" state used in cases where the value is neither true nor false, such as when a subset of a topic is selected:
       </p>
@@ -41,7 +46,6 @@
         A user cannot enter the indeterminate state by interacting directly with the checkbox; it only occurs due to external interactions.
       </p>
     </DocsPageSection>
-
   </DocsPageTemplate>
 
 </template>

--- a/docs/pages/kcheckbox.vue
+++ b/docs/pages/kcheckbox.vue
@@ -46,6 +46,54 @@
         A user cannot enter the indeterminate state by interacting directly with the checkbox; it only occurs due to external interactions.
       </p>
     </DocsPageSection>
+
+    <DocsPageSection title="Example: Label content" anchor="#example-labels">
+      Label content can be passed via the <code>label</code> property:
+
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="html">
+        &lt;KCheckbox label="First lesson" /&gt;
+      </DocsShowCode>
+      <!-- eslint-enable -->
+      <DocsShow>
+        <KCheckbox label="First lesson" />
+      </DocsShow>
+
+      In more complex situations, for example when another component is responsible for rendering the label, the default slot can be used:
+
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="html">
+        &lt;KCheckbox&gt;
+          &lt;KLabeledIcon icon="lesson" label="First lesson" /&gt;
+        &lt;/KCheckbox&gt;
+      </DocsShowCode>
+      <!-- eslint-enable -->
+      <DocsShow>
+        <KCheckbox>
+          <KLabeledIcon icon="lesson" label="First lesson" />
+        </KCheckbox>
+      </DocsShow>
+
+      <DocsDoNot>
+        <template #not>
+          <p>Don't wrap the default slot's content in <code>&lt;label&gt;</code>:</p>
+          <!-- eslint-disable -->
+          <!-- prevent prettier from changing indentation -->
+          <DocsShowCode language="html">
+            &lt;KCheckbox&gt;
+              &lt;label&gt;
+                &lt;KLabeledIcon icon="lesson" label="First lesson" /&gt;
+              &lt;/label&gt;
+            &lt;/KCheckbox&gt;
+          </DocsShowCode>
+          <!-- eslint-enable -->
+
+          <p>That would cause two nested <code>&lt;label&gt;</code> elements to be rendered as <code>KCheckbox</code> takes care of it already.</p>
+        </template>
+      </DocsDoNot>
+    </DocsPageSection>
   </DocsPageTemplate>
 
 </template>

--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -43,15 +43,17 @@
 
       </div>
 
-      <div
+      <label
         v-if="$slots.default"
+        :for="id"
         class="k-checkbox-label"
       >
+        <!-- @slot Optional slot as alternative to `label` prop. Its content will be rendered within `<label>`. -->
         <slot></slot>
         <div v-if="description" class="description">
           {{ description }}
         </div>
-      </div>
+      </label>
 
       <!-- In this case, we presume that there is a `label` prop given -->
       <label
@@ -91,7 +93,7 @@
         default: null,
       },
       /**
-       * Whether or not to show the label
+       * Whether or not to show the label provided via the `label` prop (doesn't apply to labels provided via the default slot)
        */
       showLabel: {
         type: Boolean,

--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -44,20 +44,6 @@
       </div>
 
       <label
-        v-if="$slots.default"
-        :for="id"
-        class="k-checkbox-label"
-      >
-        <!-- @slot Optional slot as alternative to `label` prop. Its content will be rendered within `<label>`. -->
-        <slot></slot>
-        <div v-if="description" class="description">
-          {{ description }}
-        </div>
-      </label>
-
-      <!-- In this case, we presume that there is a `label` prop given -->
-      <label
-        v-else
         dir="auto"
         class="k-checkbox-label"
         :for="id"
@@ -65,12 +51,17 @@
         :style="labelStyle"
         @click.prevent
       >
-        {{ label }}
+        <template v-if="$slots.default">
+          <!-- @slot Optional slot as alternative to `label` prop -->
+          <slot></slot>
+        </template>
+        <template v-else>
+          {{ label }}
+        </template>
         <div v-if="description" class="description">
           {{ description }}
         </div>
       </label>
-
     </div>
   </div>
 
@@ -93,7 +84,7 @@
         default: null,
       },
       /**
-       * Whether or not to show the label provided via the `label` prop (doesn't apply to labels provided via the default slot)
+       * Whether or not to show the label
        */
       showLabel: {
         type: Boolean,

--- a/lib/__tests__/KCheckbox.spec.js
+++ b/lib/__tests__/KCheckbox.spec.js
@@ -77,4 +77,15 @@ describe('KCheckbox component', () => {
       expect(wrapper.find('.disabled')).toBeTruthy();
     });
   });
+
+  it(`should render the default's slot content in <label>`, () => {
+    const wrapper = shallowMount(KCheckbox, {
+      slots: {
+        default: { template: '<span><span>Icon</span>Label</span>' },
+      },
+    });
+    const label = wrapper.find('label');
+    expect(label.exists()).toBeTruthy();
+    expect(label.html()).toContain('<span><span>Icon</span>Label</span>');
+  });
 });


### PR DESCRIPTION
## Description

- Previously, the default slot content was wrapped in `<div>`, making the checkbox inaccessible when label's content is provided via the default slot. This PR fixes it by replacing `<div>` with `<label>` (this also makes using the default slot consistent with using the `label` property)
- Organizes `KCheckbox` documentation page and adds some examples of how to use labels

#### Issue addressed

Addresses #347 

### Before/after screenshots

- No visual changes in products
- `KCheckbox` documentation
  - before: https://design-system.learningequality.org/kcheckbox/
  - after: https://deploy-preview-351--kolibri-design-system.netlify.app/kcheckbox/

## Steps to test

- Please follow the steps to test in Kolibri's corresponding PR https://github.com/learningequality/kolibri/pull/9648
- Read the updated documentation page and preview `KCheckboxes` used in examples (visually + markup)

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

