### PR TITLE
add attrs/aria-label to navigation element within KBreadcrumbs

### DIFF
--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -4,7 +4,7 @@
     v-show="showSingleItem || crumbs.length > 1"
     :class="{ 'breadcrumbs-collapsed': collapsedCrumbs.length }"
   >
-    <nav class="breadcrumbs">
+    <nav class="breadcrumbs" v-bind="$attrs" :aria-label="$attrs.ariaLabel">
       <div
         v-show="collapsedCrumbs.length"
         class="breadcrumbs-dropdown-wrapper"

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -138,6 +138,7 @@
   export default {
     name: 'KBreadcrumbs',
     mixins: [KResponsiveElementMixin],
+    inheritAttrs: false,
     props: {
       /**
        * An array of objects, each with a `text` attribute (String) and a


### PR DESCRIPTION
## Description
Per conversation on Slack, I've added attributes binding and an aria-label option to `KBreadcrumbs` so that it is easier for us to use a label on the <nav> element, which is where it should be.

## Steps to test

1. See [corresponding kolibri PR](https://github.com/learningequality/kolibri/pull/9663) for testing. Successful implementation should have the aria label display on the breadcrumb elements

### Does this introduce any tech-debt items?
Is this clear enough? would props be better?

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
