### PR TITLE
updates to DocsShowCode component

### DIFF
--- a/docs/common/DocsShow.vue
+++ b/docs/common/DocsShow.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <div class="show" :style="{ display: block ? 'block' : 'inline-block' }">
+    <div class="show" :style="style">
       <slot></slot>
     </div>
   </div>
@@ -18,6 +18,18 @@
         type: Boolean,
         default: false,
       },
+      padding: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    computed: {
+      style() {
+        return {
+          display: this.block ? 'block' : 'inline-block',
+          padding: this.padding ? '8px 24px' : null,
+        };
+      },
     },
   };
 
@@ -27,7 +39,6 @@
 <style lang="scss" scoped>
 
   .show {
-    padding: 8px 24px;
     margin: 8px;
     border: 1px solid #dedede;
     border-radius: 4px;

--- a/docs/common/DocsShowCode.vue
+++ b/docs/common/DocsShowCode.vue
@@ -1,9 +1,9 @@
 <template>
 
-  <DocsShow :block="block">
-    <Prism :language="language">
+  <DocsShow :block="block" :padding="false">
+    <PrismComponent :language="language">
       <slot></slot>
-    </Prism>
+    </PrismComponent>
   </DocsShow>
 
 </template>
@@ -11,15 +11,15 @@
 
 <script>
 
-  import 'prismjs';
+  import Prism from 'prismjs';
   import 'prismjs/themes/prism.css';
   import 'prismjs/plugins/normalize-whitespace/prism-normalize-whitespace';
-  import Prism from 'vue-prism-component';
+  import PrismComponent from 'vue-prism-component';
 
   export default {
     name: 'DocsShowCode',
     components: {
-      Prism,
+      PrismComponent,
     },
     props: {
       // `display: block` takes up full width
@@ -31,6 +31,11 @@
         type: String,
         required: true,
       },
+    },
+    mounted() {
+      // Ensure prism-normalize-whitespace plugin is run
+      // ref: https://github.com/egoist/vue-prism-component/issues/10#issuecomment-988938865
+      Prism.highlightAll();
     },
   };
 
@@ -48,7 +53,7 @@
   }
 
   pre[class*='language-'] {
-    padding: 0;
+    padding: 8px 24px;
     margin: 0;
   }
 

--- a/docs/common/DocsShowCode/index.vue
+++ b/docs/common/DocsShowCode/index.vue
@@ -1,6 +1,7 @@
 <template>
 
   <DocsShow :block="block" :padding="false">
+    <!-- Note that slot contents are HTML-escaped using webpack-loader.js -->
     <PrismComponent :language="language">
       <slot></slot>
     </PrismComponent>

--- a/docs/common/DocsShowCode/webpack-loader.js
+++ b/docs/common/DocsShowCode/webpack-loader.js
@@ -1,0 +1,14 @@
+var TAG_PATTERN = new RegExp(`<DocsShowCode(.*?)>(.*?)</DocsShowCode>`, 'gms');
+
+function escape(unsafe) {
+  return (unsafe || '')
+    .replace(/&/gm, '&amp;')
+    .replace(/</gm, '&lt;')
+    .replace(/>/gm, '&gt;');
+}
+
+module.exports = function(content) {
+  return content.replace(TAG_PATTERN, function(_, attributes, innerText) {
+    return `<DocsShowCode${attributes}>${escape(innerText)}</DocsShowCode>`;
+  });
+};

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -53,7 +53,9 @@
       </p>
 
       <DocsShowCode language="html">
-        &lt;div :style="{ color: $themeTokens.error }"&gt;This is an error&lt;/div&gt;
+        <div :style="{ color: $themeTokens.error }">
+          This is an error
+        </div>
       </DocsShowCode>
 
       <p>
@@ -75,7 +77,7 @@
       </p>
 
       <DocsShowCode language="html">
-        &lt;input :class="$computedClass({ '::placeholder': { color: $themeTokens.annotation } })" /&gt;
+        <input :class="$computedClass({ '::placeholder': { color: $themeTokens.annotation } })">
       </DocsShowCode>
 
       <p>This is usually not necessary, and using <code>style</code> is preferred for simplicity when possible.</p>

--- a/docs/pages/layout/index.vue
+++ b/docs/pages/layout/index.vue
@@ -85,16 +85,16 @@
       <p>
         For example, consider a Vue file with this in its template and script:
       </p>
+      <DocsShowCode language="html">
+        <div class="box" :style="boxStyle">
+          Box 1
+        </div>
+        <div class="box" :style="boxStyle">
+          Box 2
+        </div>
+      </DocsShowCode>
       <!-- eslint-disable -->
       <!-- prevent prettier from changing indentation -->
-      <DocsShowCode language="html">
-        &lt;div class="box" :style="boxStyle"&gt;
-          Box 1
-        &lt;/div&gt;
-        &lt;div class="box" :style="boxStyle"&gt;
-          Box 2
-        &lt;/div&gt;
-      </DocsShowCode>
       <DocsShowCode language="javascript">
         computed: {
           boxStyle() {
@@ -195,19 +195,16 @@
       <p>
         For example, a common pattern in Kolibri is to have a button right-aligned at the top of a page alongside the header on large windows, but on medium and small windows to move the button underneath the header and left-align it. To do this with the responsive grid:
       </p>
-      <!-- eslint-disable -->
-      <!-- prevent prettier from changing indentation -->
       <DocsShowCode language="html">
-        &lt;KGrid&gt;
-          &lt;KGridItem :layout12="{ span: 9 }"&gt;
-            &lt;h2&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit&lt;/h2&gt;
-          &lt;/KGridItem&gt;
-          &lt;KGridItem :layout12="{ span: 3, alignment: 'right' }"&gt;
-            &lt;KButton text="Button" primary/&gt;
-          &lt;/KGridItem&gt;
-        &lt;/KGrid&gt;
+        <KGrid>
+          <KGridItem :layout12="{ span: 9 }">
+            <h2>Lorem ipsum dolor sit amet, consectetur adipiscing elit</h2>
+          </KGridItem>
+          <KGridItem :layout12="{ span: 3, alignment: 'right' }">
+            <KButton text="Button" primary />
+          </KGridItem>
+        </KGrid>
       </DocsShowCode>
-      <!-- eslint-enable -->
 
       <p>
         Each grid item is described by layout objects which can contain a column <code>span</code> and default text <code>alignment</code>. When no additional layout information is provided, the <code>span</code> defaults to the total number of columns (i.e. full-width), and <code>alignment</code> defaults to <code>'right'</code>.

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -28,7 +28,9 @@
         Use these by importing the design system's <code>definitions.scss</code> file. For example, this HTML and SCSS in a Vue template:
       </p>
       <DocsShowCode language="html">
-        &lt;div class="box"&gt;Hello!&lt;/div&gt;
+        <div class="box">
+          Hello!
+        </div>
       </DocsShowCode>
       <!-- eslint-disable -->
       <!-- prevent prettier from changing indentation -->

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -19,6 +19,7 @@ export default {
   srcDir: './docs/',
   plugins: ['~/plugins/load-common-components.js', '~/plugins/load-lib-components.js'],
   css: ['normalize.css/normalize.css', '~/assets/main.scss'],
+  modulesDir: ['node_modules', 'docs'], // allow custom DocsShowCode loader to be found
   build: {
     extractCSS: true,
     optimization: {
@@ -40,6 +41,12 @@ export default {
         test: /\.vue$/,
         enforce: 'pre',
         loader: 'svg-icon-inline-loader',
+        exclude: /node_modules/,
+      });
+      // handles escaping HTML inside <DocsShowCode> slots
+      config.module.rules.push({
+        test: /\.vue$/,
+        loader: 'common/DocsShowCode/webpack-loader.js',
         exclude: /node_modules/,
       });
       // used for glossary


### PR DESCRIPTION

## Description

Improves `DocsShowCode` component layout:

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/188290801-47e2fced-2744-4cb7-836f-ac433ff32eb3.png) | ![image](https://user-images.githubusercontent.com/2367265/188290807-7ed3dccb-bf94-4690-ab66-269aa7971050.png) |


Allows example HTML and Vue code to be inserted verbatim, without escape sequences or `eslint-disable` directives:

```diff
-      <!-- eslint-disable -->
-      <!-- prevent prettier from changing indentation -->
      <DocsShowCode language="html">
-        &lt;KGrid&gt;
-          &lt;KGridItem :layout12="{ span: 9 }"&gt;
-            &lt;h2&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit&lt;/h2&gt;
-          &lt;/KGridItem&gt;
-          &lt;KGridItem :layout12="{ span: 3, alignment: 'right' }"&gt;
-            &lt;KButton text="Button" primary/&gt;
-          &lt;/KGridItem&gt;
-        &lt;/KGrid&gt;
+        <KGrid>
+          <KGridItem :layout12="{ span: 9 }">
+            <h2>Lorem ipsum dolor sit amet, consectetur adipiscing elit</h2>
+          </KGridItem>
+          <KGridItem :layout12="{ span: 3, alignment: 'right' }">
+            <KButton text="Button" primary />
+          </KGridItem>
+        </KGrid>
      </DocsShowCode>
-      <!-- eslint-enable -->
```

## (optional) Implementation notes

### At a high level, how did you implement this?

* Adds a hack to resolve an issue related to the Vue component wrapper library around Prism which was preventing the `prism-normalize-whitespace` plugin from loading in some cases. Same issue as https://github.com/egoist/vue-prism-component/issues/10#issuecomment-988938865
* Adds a new webpack loader which changes `<` and `>` to `&lt;` and `&gt;`. Same concept as https://github.com/Etheryte/vue-raw-pre


### Does this introduce any tech-debt items?

This doesn't resolve the need to wrap javascript and CSS code sample blocks with `eslint-disable`/`eslint-enable`, because otherwise the code formatter treats them as HTML text nodes and flattens indentation. This might be fixable with a custom eslint plugin rule which can tell eslint/prettier to treat contents of `DocsShowCode` differently.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
