### PR TITLE
Add documentation pages for KResponsiveWindow and KResponsiveElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 ## Version 1.4.x
 - [#185] - Handle arrow key navigation and improve focusOutline
 - [#338] - Allow for new 'nav' slot inline in the toolbar
+- [#362] - Add documentation pages for 'KResponsiveWindow' and 'KResponsiveElement'
+
+<!-- Referenced PRs -->
+[#185]: https://github.com/learningequality/kolibri-design-system/pull/185
+[#338]: https://github.com/learningequality/kolibri-design-system/pull/338
+[#362]: https://github.com/learningequality/kolibri-design-system/pull/362
 
 
 ## Version 1.3.1

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -75,3 +75,11 @@ html {
 *::after {
   box-sizing: inherit;
 }
+
+dt {
+  margin-top: 16px;
+}
+
+dd {
+  margin-left: 20px;
+}

--- a/docs/pages/kresponsiveelement.vue
+++ b/docs/pages/kresponsiveelement.vue
@@ -1,0 +1,62 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+
+    <DocsPageSection title="Overview" anchor="#overview">
+      <p>
+        Once added to a component it provides the following reactive component's size information:
+      </p>
+
+      <dl>
+        <dt><code>elementHeight</code></dt>
+        <dd>The component's element <code>$el</code> height in pixels (integer)</dd>
+
+        <dt><code>elementWidth</code></dt>
+        <dd>The component's element <code>$el</code> width in pixels  (integer)</dd>
+      </dl>
+
+    </DocsPageSection>
+
+    <DocsPageSection title="Usage" anchor="#usage">
+      <p>When compared to <DocsLibraryLink component="KResponsiveWindow" />, <code>KResponsiveElement</code> can be suitable when it's the available space determined by the layout which should influence reponsive behavior of a child component rather than relying on the overall window size.</p>
+
+      <h3>As mixin</h3>
+      <p>It can be imported as <code>KResponsiveElementMixin</code>. As with any other mixin, you need to register it in the script part of a component file:</p>
+
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="javascript">
+        import KResponsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
+
+        export default {
+          mixins: [KResponsiveElementMixin]
+        };
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <p>
+        Provided reactive properties can then be accessed on the component instance via <code>this</code>.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection title="Guidelines" anchor="#guidelines">
+      <ul>
+        <li>
+          Due to performance issues (<DocsExternalLink
+            text="Kolibri #8124"
+            href="https://github.com/learningequality/kolibri/issues/8124"
+          />), using <code>KResponsiveElement</code> in larger numbers on one page is currently discouraged
+        </li>
+      </ul>
+    </DocsPageSection>
+
+    <DocsPageSection title="Related" anchor="#related">
+      <ul>
+        <li>
+          See <DocsLibraryLink component="KResponsiveWindow" /> if you need the window's size reactive information rather than that of a component
+        </li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>

--- a/docs/pages/kresponsivewindow.vue
+++ b/docs/pages/kresponsivewindow.vue
@@ -1,0 +1,132 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+
+    <DocsPageSection title="Overview" anchor="#overview">
+      <p>
+        Once added to a component it provides the following reactive window's size information:
+      </p>
+
+      <dl>
+        <dt><code>windowIsSmall</code>, <code>windowIsMedium</code>, and <code>windowIsLarge</code></dt>
+        <dd>Returns <code>true</code> when the window width fits the small, medium, or large breakpoint respectively as defined in <DocsInternalLink text="Layout: Responsiveness" href="/layout#responsiveness" /> (boolean)</dd>
+
+        <dt><code>windowHeight</code></dt>
+        <dd>Returns the window height in pixels (integer)</dd>
+
+        <dt><code>windowWidth</code></dt>
+        <dd>Returns the window width in pixels (integer)</dd>
+
+        <dt><code>windowBreakpoint</code></dt>
+        <dd>Returns one of the more granular breakpoints defined as levels in <DocsInternalLink text="Layout: Responsiveness" href="/layout#responsiveness" /> (integer, 0-7)</dd>
+      </dl>
+    </DocsPageSection>
+
+    <DocsPageSection title="Usage" anchor="#usage">
+      <p>Provided reactive properties are typically used to dynamically drive the layout of components by adjusting inline styles, CSS classes, component visibility, or even swapping out one component for a completely different one.</p>
+
+      <h3>As mixin</h3>
+      <p>It can be imported as <code>KResponsiveWindowMixin</code>. As with any other mixin, you need to register it in the script part of a component file:</p>
+
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="javascript">
+        import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+
+        export default {
+          mixins: [KResponsiveWindowMixin]
+        };
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <p>
+        Provided reactive properties can then be accessed on the component instance via <code>this</code>.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection title="Example" anchor="#example">
+      <p>
+        Consider a Vue file with this in its template and script:
+      </p>
+      <!-- eslint-disable -->
+        <!-- prevent prettier from changing indentation -->
+        <DocsShowCode language="html">
+          &lt;div class="box" :style="boxStyle"&gt;
+            Box 1
+          &lt;/div&gt;
+          &lt;div class="box" :style="boxStyle"&gt;
+            Box 2
+          &lt;/div&gt;
+        </DocsShowCode>
+        <DocsShowCode language="javascript">
+          computed: {
+            boxStyle() {
+              if (this.windowIsLarge) {
+                return { display: 'inline-block' };
+              }
+              return { display: 'block' };
+            },
+          },
+        </DocsShowCode>
+        <!-- eslint-enable -->
+      <p>
+        This results in two boxes that stack vertically on small screens and otherwise display side-by-side:
+      </p>
+      <DocsShow>
+        <div>Breakpoint level: {{ windowBreakpoint }}</div>
+        <div>Window is large: {{ windowIsLarge }}</div>
+        <div>
+          <div class="box" :style="boxStyle">
+            Box 1
+          </div>
+          <div class="box" :style="boxStyle">
+            Box 2
+          </div>
+        </div>
+      </DocsShow>
+      <p>
+        Try adjusting your browser window size to see the example in action.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection title="Related" anchor="#related">
+      <ul>
+        <li>
+          <DocsInternalLink text="Layout: Responsiveness" href="/layout#responsiveness" /> has an overview of breakpoints
+        </li>
+        <li>
+          See <DocsLibraryLink component="KResponsiveElement" /> if you need a component's size reactive information rather than that of the window
+        </li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>
+
+
+<script>
+
+  import responsiveWindowMixin from '~~/lib/KResponsiveWindowMixin.js';
+
+  export default {
+    mixins: [responsiveWindowMixin],
+    computed: {
+      boxStyle() {
+        return { display: this.windowIsLarge ? 'inline-block' : 'block' };
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .box {
+    padding: 16px;
+    margin-top: 8px;
+    margin-right: 8px;
+    border: 1px solid gray;
+  }
+
+</style>

--- a/docs/pages/layout/index.vue
+++ b/docs/pages/layout/index.vue
@@ -69,63 +69,8 @@
         <li>Level 7: <code>&gt;= 1600px</code></li>
       </ul>
       <p>
-        Responsive layouts in the design system are built using reactive javascript state in Vue components rather than CSS media queries. This is done using the <code>KResponsiveWindowMixin</code> Vue mixin. Once added to a component it provides the following reactive window state information:
+        Responsive layouts in the design system are built using reactive JavaScript state in Vue components rather than CSS media queries. This is done using <DocsLibraryLink component="KResponsiveWindow" /> when reactive window's size information is needed or <DocsLibraryLink component="KResponsiveElement" /> when reactive component's size information is needed.
       </p>
-      <ul>
-        <li><code>windowIsSmall</code>: boolean</li>
-        <li><code>windowIsMedium</code>: boolean</li>
-        <li><code>windowIsLarge</code>: boolean</li>
-        <li><code>windowHeight</code>: integer height in pixels</li>
-        <li><code>windowWidth</code>: integer width in pixels</li>
-        <li><code>windowBreakpoint</code>: integer breakpoint level</li>
-      </ul>
-      <p>
-        These reactive properties are used to dynamically drive the layout of components by adjusting inline styles, CSS classes, component visibility, or even swapping out one component for a completely different one.
-      </p>
-      <p>
-        For example, consider a Vue file with this in its template and script:
-      </p>
-      <!-- eslint-disable -->
-      <!-- prevent prettier from changing indentation -->
-      <DocsShowCode language="html">
-        &lt;div class="box" :style="boxStyle"&gt;
-          Box 1
-        &lt;/div&gt;
-        &lt;div class="box" :style="boxStyle"&gt;
-          Box 2
-        &lt;/div&gt;
-      </DocsShowCode>
-      <DocsShowCode language="javascript">
-        computed: {
-          boxStyle() {
-            if (this.windowIsLarge) {
-              return { display: 'block' };
-            }
-            return { display: 'inline-block' };
-          },
-        },
-      </DocsShowCode>
-      <!-- eslint-enable -->
-      <p>
-        This results in two boxes that stack vertically on small screens and otherwise display side-by-side:
-      </p>
-      <DocsShow>
-        <div>Breakpoint level: {{ windowBreakpoint }}</div>
-        <div>Window is large: {{ windowIsLarge }}</div>
-        <div>
-          <div class="box" :style="boxStyle">
-            Box 1
-          </div>
-          <div class="box" :style="boxStyle">
-            Box 2
-          </div>
-        </div>
-      </DocsShow>
-      <p>
-        Try adjusting your browser window size to see the example in action.
-      </p>
-
-
     </DocsPageSection>
 
     <DocsPageSection title="Grid system" anchor="#grid-system">
@@ -265,30 +210,3 @@
 
 </template>
 
-
-<script>
-
-  import responsiveWindowMixin from '~~/lib/KResponsiveWindowMixin.js';
-
-  export default {
-    mixins: [responsiveWindowMixin],
-    computed: {
-      boxStyle() {
-        return { display: this.windowIsLarge ? 'inline-block' : 'block' };
-      },
-    },
-  };
-
-</script>
-
-
-<style lang="scss" scoped>
-
-  .box {
-    padding: 16px;
-    margin-top: 8px;
-    margin-right: 8px;
-    border: 1px solid gray;
-  }
-
-</style>

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -58,6 +58,7 @@ class Page {
 const buttonRelatedKeywords = ['button', 'link'];
 const textRelatedKeywords = ['text', 'area', 'field', 'box'];
 const layoutRelatedKeywords = ['grid', 'layout', 'container', 'page'];
+const responsiveComponentsRelatedKeywords = ['responsive', 'mixin', 'breakpoint'];
 
 export default [
   new Section({
@@ -300,6 +301,18 @@ export default [
         path: '/kbreadcrumbs',
         title: 'KBreadcrumbs',
         isCode: true,
+      }),
+      new Page({
+        path: '/kresponsivewindow',
+        title: 'KResponsiveWindow',
+        isCode: true,
+        keywords: [...responsiveComponentsRelatedKeywords, 'window'],
+      }),
+      new Page({
+        path: '/kresponsiveelement',
+        title: 'KResponsiveElement',
+        isCode: true,
+        keywords: [...responsiveComponentsRelatedKeywords, 'element'],
       }),
     ],
   }),


### PR DESCRIPTION
## Description

Updates library documentation:

- Updates _Layouts_ page: Some sections related to  `KResponsiveWindowMixin` were moved to its new page, and _Layouts_ page now only contains general breakpoints information with newly added references to the two new pages. 
- Adds two new pages:
  - _KResponsiveWindow_ page: To a large extent, existing documentation from the _Layouts_ page was used.
  - _KResponsiveElement_ page: I wrote down some basic information and usage but didn't create an example since it's quite simple, and also, currently, we rather discourage using it.

Two new pages were prepared with keeping https://github.com/learningequality/kolibri-design-system/issues/288 (allow mixins logic to be used via composition API) in mind. Therefore, pages are called _KResponsiveWindow_/_KResponsiveElement_ and not `KResponsiveWindowMixin`/`KResponsiveElementMixin` since in the near future we should be able to access this logic in an alternative way to mixins, via composables (`useKResponsiveWindow`, `useKResponsiveElement`). Relatedly, all information provided on new pages is presented in a way applicable to both existing mixins as well as to new composables to be implemented. Usage details specific to mixins can be found in the _Usage -> As mixins_ section of pages. This prepares the ground for a new sub-section, _Usage-> As composables_ to be added as part of https://github.com/learningequality/kolibri-design-system/issues/288.

#### Issue addressed

I mentioned performance troubles on _KResponsiveElement_ page so this also closes https://github.com/learningequality/kolibri-design-system/issues/237

## Steps to test

Read
- [ ] _Layout: Responsiveness_: https://deploy-preview-362--kolibri-design-system.netlify.app/layout/#responsiveness
- [ ] _KResponsiveElement_: https://deploy-preview-362--kolibri-design-system.netlify.app/kresponsiveelement/
- [ ] _KResponsiveWindow_: https://deploy-preview-362--kolibri-design-system.netlify.app/kresponsivewindow/

Is it easy to follow? Can you spot any typos, recommend grammar improvements?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
