### PR TITLE
Add focus outline to password type inputs when navigating using keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 - [#185] - Handle arrow key navigation and improve focusOutline
 - [#338] - Allow for new 'nav' slot inline in the toolbar
 - [#362] - Add documentation pages for 'KResponsiveWindow' and 'KResponsiveElement'
+- [#364] - Fixes 'Missing focus ring around password inputs' while navigating with keyboard.
 
 <!-- Referenced PRs -->
 [#185]: https://github.com/learningequality/kolibri-design-system/pull/185
 [#338]: https://github.com/learningequality/kolibri-design-system/pull/338
 [#362]: https://github.com/learningequality/kolibri-design-system/pull/362
-
+[#364]: https://github.com/learningequality/kolibri-design-system/pull/364
 
 ## Version 1.3.1
 

--- a/lib/styles/trackInputModality.js
+++ b/lib/styles/trackInputModality.js
@@ -19,6 +19,7 @@ function setUpEventHandlers(disableFocusRingByDefault) {
     'input[type=date]',
     'input[type=time]',
     'input[type=datetime]',
+    'input[type=password]',
     'textarea',
     '[role=textbox]',
     'a',


### PR DESCRIPTION
## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
Focus inputs of type "password" when navigating using the keyboard.

#### Issue addressed
<!-- Only necessary if applicable -->
Fixes issue #9563 from Kolibri repo - "Missing focus ring around password inputs".

### Before/after screenshots
<!-- Insert images here if applicable -->
Before:
![Screenshot from 2022-09-21 07-44-31](https://user-images.githubusercontent.com/12814577/191507132-fa0fa93a-36f4-44b7-be16-68430e0616db.png)

After:
![Screenshot from 2022-09-21 07-44-06](https://user-images.githubusercontent.com/12814577/191507171-b258fdec-e626-4c65-99dd-077c89594b2c.png)

## Steps to test

1. Link this updated Kolibri-design-system to the Kolibri repo
2. Start a devserver for the Lolibri repo
3. Create a new account in Kolibri
4. Tab through the inputs using the keyboard and note that an outline is applied to the password inputs

### At a high level, how did you implement this?
Added a new type of input (password) to the list of keyboard modality default elements.

### Does this introduce any tech-debt items?
No

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Are there tests for this change? (not sure if this applies)
- [ ] Are all UI components LTR and RTL compliant (if applicable)?

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
Unsure how to handle the post-merge updates