### PR TITLE
Better naming of the changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
-## Develop (version not yet known)
+## Develop (to become version 1.5.x)
 
 - [#351] - Wrap `KCheckbox` default slot's content in <label>
 - [#355] - Add `KSelect` to KDS


### PR DESCRIPTION
I'm updating the release process document where I want to mention that our changelog has two sections - one for `develop` branch and another for the current `release` branch so made a little improvement to naming of the `develop` section to make it clearer of which version `develop` updates will eventually be part of