### PR TITLE
Fix missing mixin

### DIFF
--- a/docs/pages/layout/index.vue
+++ b/docs/pages/layout/index.vue
@@ -207,3 +207,13 @@
 
 </template>
 
+
+<script>
+
+  import responsiveWindowMixin from '~~/lib/KResponsiveWindowMixin.js';
+
+  export default {
+    mixins: [responsiveWindowMixin],
+  };
+
+</script>


### PR DESCRIPTION
## Description

This fixes `Property or method "windowIsLarge" is not defined on the instance but referenced during render` error that I caused recently when I was moving some parts of documentation from "Layout" page to another pages but didn't notice that I need to preserve the `KResponsiveWindowMixin` on the "Layout" page.

I didn't update the changelog as this is not user-facing but rather an internal docs bugfix.

Unfortunately, I merged the release branch to develop when this bug was still present on the release branch. As I will be offline soon, could someone please do it again once this PR is merged so that it is also fixed on the develop branch?

## Steps to test

- Preview "Layouts" page

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
