### PR TITLE
Add missing template tags to KButton

### DIFF
--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -28,7 +28,7 @@
     <slot v-if="$slots.default"></slot>
 
     <template>
-    <span class="link-text" :style="textStyle">{{ text }}</span>
+      <span class="link-text" :style="textStyle">{{ text }}</span>
     </template>
 
     <!-- @slot Slot alternative to the `iconAfter` prop -->

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -27,7 +27,9 @@
 
     <slot v-if="$slots.default"></slot>
 
+    <template>
     <span class="link-text" :style="textStyle">{{ text }}</span>
+    </template>
 
     <!-- @slot Slot alternative to the `iconAfter` prop -->
     <slot name="iconAfter"></slot>


### PR DESCRIPTION
## Description
This replace the `<template />` tags which were needed in the `KButton` code in order for the refactored `KDropdownMenu` to work correctly. I think I accidentally dropped them during rebase.

#### Issue addressed

Addresses https://github.com/learningequality/kolibri/issues/9754

## Steps to test

Please see corresponding Kolibri PR to test in Kolibri

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [ ] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
