### PR TITLE
Wraps KRadioButton label text

### DIFF
--- a/docs/pages/kradiobutton.vue
+++ b/docs/pages/kradiobutton.vue
@@ -9,19 +9,25 @@
       <DocsShow>
         <KRadioButton
           v-model="exampleValue"
-          label="Option A"
+          label="Option A Lorem ipsum dolor"
           value="val-a"
         />
         <KRadioButton
           v-model="exampleValue"
-          label="Option B"
+          label="Option B  Lorem ipsum dolor"
           value="val-b"
         />
         <KRadioButton
           v-model="exampleValue"
-          label="Option C"
+          label="Option C  Lorem ipsum dolor"
           description="This one is special!"
           value="val-c"
+        />
+        <KRadioButton
+          v-model="exampleValue"
+          label="Truncated label. Adjusting your browser window size to see this in action."
+          value="val-d"
+          truncateLabel
         />
         <p>
           Current value: {{ exampleValue }}

--- a/docs/pages/kradiobutton.vue
+++ b/docs/pages/kradiobutton.vue
@@ -9,17 +9,17 @@
       <DocsShow>
         <KRadioButton
           v-model="exampleValue"
-          label="Option A Lorem ipsum dolor"
+          label="Option A"
           value="val-a"
         />
         <KRadioButton
           v-model="exampleValue"
-          label="Option B  Lorem ipsum dolor"
+          label="Option B"
           value="val-b"
         />
         <KRadioButton
           v-model="exampleValue"
-          label="Option C  Lorem ipsum dolor"
+          label="Option C"
           description="This one is special!"
           value="val-c"
         />


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This pr wraps the KRadioButton label instead of truncating it. Also, a new prop `truncateLabel` has been added to truncate the text explicitly. Finally, the `KRadioButton` has been streamlined to match `KCheckbox`'s API.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #349 #350

### Before/after screenshots
<!-- Insert images here if applicable -->
- No visual changes in products
- `KRadioButton` documentation
 - before: https://design-system.learningequality.org/kradiobutton/
 - after: https://deploy-preview-377--kolibri-design-system.netlify.app/kradiobutton/

## Steps to test

1. Step 1
2. Step 2
3. ...

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
- There are concerns about how the `value` and `v-model` props are used. Please see #379. There is need streamline this to improve developer experience

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [x] Are all UI components LTR and RTL compliant (if applicable)?

## Post-merge updates and tracking
<!-- After merging, unstable branches of Kolibri products (Learning Platform, Studio, and Data Portal) should be updated to point at the merge commit resulting from this PR. This process should be led by the submitter of the Design System PR in collaboration with other LE team members working on the other product repos. -->
- [x] Learning Platform update PR is submitted
- [ ] Learning Platform update PR is merged
- [ ] Studio update PR is submitted
- [ ] Studio update PR is merged
- [ ] Data Portal update PR is submitted
- [ ] Data Portal update PR is merged

## Comments
<!-- Any additional notes you'd like to add -->
