### PR TITLE
Update documentation to not includedeleting KDS from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,7 @@ Large upgrades can result in a colossal git diff which makes reviewing changes o
 If you are working on the design system library code in this repo and want to see local updates reflected in other applications that are using this library, then you will need to do a few things.
 
 1. While in the root of your local `kolibri-design-system` repository, run `yarn link`.
-2. In the application where you intend to use `kolibri-design-system` remove the reference to `kolibri-design-system` from the `package.json` of that project.
-3. In the root of the application where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system` and then `yarn install`.
+2. In the root of the application where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system` and then `yarn install`.
 
 Now, when you run the application your changes in `kolibri-design-system` will be updated live where your app expects its dependency on `kolibri-design-system` to live.
 


### PR DESCRIPTION
## Description
Removes the step that instructs devs to delete the `package.json` reference to KDS when using `yarn link`

#### Issue addressed
Resolves [a problem discussed in Slack](https://learningequality.slack.com/archives/C0LE9NLCE/p1661252757986809?thread_ts=1661167701.303799&cid=C0LE9NLCE) where several team members had trouble with `yarn link` working correctly when deleting this from `package.json`.
