### PR TITLE
[Kselect] Expose select event

### DIFF
--- a/lib/KSelect/KeenUiSelect.vue
+++ b/lib/KSelect/KeenUiSelect.vue
@@ -666,7 +666,7 @@
         }
 
         this.$emit('select', option, {
-          selected: this.multiple ? shouldSelect : true,
+          selected: this.isOptionSelected(option),
         });
 
         this.clearQuery();

--- a/lib/KSelect/KeenUiSelect.vue
+++ b/lib/KSelect/KeenUiSelect.vue
@@ -666,7 +666,7 @@
         }
 
         this.$emit('select', option, {
-          selected: this.isOptionSelected(option),
+          selected: !this.isOptionSelected(option),
         });
 
         this.clearQuery();

--- a/lib/KSelect/KeenUiSelectOption.vue
+++ b/lib/KSelect/KeenUiSelectOption.vue
@@ -123,8 +123,9 @@
   $ui-select-option-checkbox-color: rgba(black, 0.38) !default;
 
   .ui-select-option {
-    @include font-family-noto display: flex;
+    @include font-family-noto;
 
+    display: flex;
     align-items: center;
     font-size: $ui-dropdown-item-font-size;
     cursor: pointer;

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -19,6 +19,7 @@
     :placeholder="placeholder"
     @change="handleChange"
     @blur="$emit('blur')"
+    @select="handleSelect"
   >
     <template #display>
       <slot name="display"></slot>
@@ -173,6 +174,9 @@
     methods: {
       handleChange(newSelection) {
         this.selection = newSelection;
+      },
+      handleSelect(newSelection, options) {
+        this.$emit('select', newSelection, options);
       },
     },
   };


### PR DESCRIPTION
## Description

Expose `select` event provided by KeenUISelect.

#### Issue addressed

Addresses #342

## Steps to test

Use KSelect component and provide a `@select` event handler. The handler should execute on any select option and should receive the selectedOption, and an options object as first and second argument.

### At a high level, how did you implement this?

`KeenUISelect` emits an `select` event whenever an option is selected. So it just add a handler to the `KSelect` wrapper to emit the `select` event emitted by `KeenUISelect`.

## Implementation notes

The `options` argument emitted by the `select` event is just an object with just one boolean property `selected` that indicates whether the selected option was previous selected.

```JSX
<KSelect
  ...
  @select="onSelectHandler"
/>
...
onSelectHandler(newSelection, options) {
  console.log(newSelection); // New selected option
  console.log(options.selected); // True if the selected option was previously selected
}
```

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_
