### PR TITLE
fix add event type in removeEventListener in useKWindowDimension

### DIFF
--- a/lib/useKWindowDimensions.js
+++ b/lib/useKWindowDimensions.js
@@ -59,7 +59,7 @@ function addWindowListener(eventHandler) {
  */
 function removeWindowListener(eventHandler) {
   if (!isUseKWindowDimensionsActiveElsewhere()) {
-    window.removeEventListener(eventHandler);
+    window.removeEventListener('resize', eventHandler);
 
     //Allow addition of a listener
     isListenerAdded.value = false;


### PR DESCRIPTION
## Description
Incorrect arguments to removeEventListener, adds 'resize' as argument on unmount for window.removeEventListener

#### Issue addressed
#398

## Testing 

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_
