### PR TITLE
Adds method that calculates space underneath KSelect before displayin…

### DIFF
--- a/lib/KSelect/KeenUiSelect.vue
+++ b/lib/KSelect/KeenUiSelect.vue
@@ -80,7 +80,7 @@
             v-show="showDropdown"
             ref="dropdown"
             class="ui-select-dropdown"
-            :style="{ color: $themeTokens.primary, backgroundColor: $themeTokens.surface }"
+            :style="{ color: $themeTokens.primary, backgroundColor: $themeTokens.surface, bottom: dropdownButtonBottom }"
             tabindex="-1"
             @keydown.enter.prevent.stop="selectHighlighted"
             @keydown.space.prevent.stop="selectHighlighted"
@@ -323,6 +323,9 @@
         initialValue: JSON.stringify(this.value),
         quickMatchString: '',
         quickMatchTimeout: null,
+        scrollableAncestor: null,
+        dropdownButtonBottom: 'auto',
+        maxDropdownHeight: 256,
       };
     },
 
@@ -532,6 +535,23 @@
 
     mounted() {
       document.addEventListener('click', this.onExternalClick);
+      // Find nearest scrollable ancestor
+      this.scrollableAncestor = this.$el;
+      while (
+        (this.scrollableAncestor &&
+          this.scrollableAncestor.clientHeight < this.scrollableAncestor.scrollHeight) ||
+        !/auto|scroll/.test(window.getComputedStyle(this.scrollableAncestor).overflowY)
+      ) {
+        if (!this.scrollableAncestor.parentNode) {
+          break;
+        }
+        this.scrollableAncestor = this.scrollableAncestor.parentNode;
+
+        // Stop if we reach the body-- tagName is likely uppercase
+        if (/body/i.test(this.scrollableAncestor.tagName)) {
+          break;
+        }
+      }
     },
 
     beforeDestroy() {
@@ -724,6 +744,7 @@
       },
 
       toggleDropdown() {
+        this.calculateSpaceBelow();
         this[this.showDropdown ? 'closeDropdown' : 'openDropdown']();
       },
 
@@ -737,7 +758,6 @@
         }
 
         this.showDropdown = true;
-
         // IE: clicking label doesn't focus the select element
         // to set isActive to true
         if (!this.isActive) {
@@ -832,6 +852,22 @@
 
       resetTouched(options = { touched: false }) {
         this.isTouched = options.touched;
+      },
+      calculateSpaceBelow() {
+        // Get the height of element
+        const buttonHeight = this.$el.getBoundingClientRect().height;
+
+        // Get the position of the element relative to the viewport
+        const buttonPosition = this.$el.getBoundingClientRect().top;
+
+        // Check if there is enough space below element
+        // and update the "dropdownButtonBottom" data property accordingly
+        const notEnoughSpaceBelow =
+          buttonPosition > this.maxDropdownHeight &&
+          this.scrollableAncestor.offsetHeight - buttonPosition <
+            buttonHeight + this.maxDropdownHeight;
+
+        this.dropdownButtonBottom = notEnoughSpaceBelow ? buttonHeight + 'px' : 'auto';
       },
     },
   };


### PR DESCRIPTION
…g dropdown

<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
When there is not enough space below the button to display the menu, the dropdown is partially hidden. This pr updates the KDS `UiSelect` component to calculate the space underneath the button to determine whether the dropdown menu will display above or below the button.

#### Issue addressed
<!-- Only necessary if applicable -->
Addresses [#7752](https://github.com/learningequality/kolibri/issues/7752)

### Before/after screenshots
<!-- Insert images here if applicable -->
Before
<img width="1440" alt="DropdownMenuBefore" src="https://user-images.githubusercontent.com/46411498/208164129-22488ef9-d590-411d-8092-441f2a3527c1.png">
 
After
<img width="1436" alt="DropdownAfter" src="https://user-images.githubusercontent.com/46411498/208162437-1d09b2b2-7776-472d-8e4e-b170cb47423f.png">


## Steps to test
Please see the corresponding Kolibri PR to test in Kolibri: https://github.com/learningequality/kolibri/pull/9927

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->
On mount, the element's nearest scrollable ancestor is found. When the button is clicked, the `position`, `buttonHeight`, `maxDropdownheight`, and the  `offsetHeight` of the `scrollableAncestor` are used to determine if there is enough space to display the dropdown menu underneath the button. If there is not, the `bottom` css property of the dropdown menu is set to the `buttonHeight`.

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?