### PR TITLE
[KOptionalText] New component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 - [#377] - Implement `useKResponsiveWindow` composable.
 - [#380] - Wrap `KRadioButton` text.
 - [#384] - Add `KDateRange` to KDS
+- [#403] - Add `KOptionalText` to KDS
 
 <!-- Referenced PRs -->
 [#351]: https://github.com/learningequality/kolibri-design-system/pull/351
@@ -23,6 +24,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 [#377]: https://github.com/learningequality/kolibri-design-system/pull/377
 [#380]: https://github.com/learningequality/kolibri-design-system/pull/380
 [#384]: https://github.com/learningequality/kolibri-design-system/pull/384
+[#403]: https://github.com/learningequality/kolibri-design-system/pull/403
 
 ## Version 1.4.x
 

--- a/docs/pages/koptionaltext.vue
+++ b/docs/pages/koptionaltext.vue
@@ -9,7 +9,7 @@
         Using the KOptionalText component is preferred to leaving a empty or blank space because it communicates to the user that a value <em>could</em> possibly exist there, and aids with visual scanning in tables, grids, and lists of data.
       </p>
     </DocsPageSection>
-    <DocsPageSection title="Example" anchor="#example">
+    <DocsPageSection title="Example using props" anchor="#example-props">
       <p>
         In the example below, an average score cannot be calculated until the user has attempted at least one exercise:
       </p>
@@ -65,11 +65,82 @@
           </tbody>
         </table>
       </DocsShow>
+      <p>
+        For this example, `text` prop is used to pass in the text to be displayed. If the text is empty or undefined, the placeholder will be displayed:
+      </p>
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="html">
+    <KOptionalText text="9%" :appearanceOverrides="{ color: 'red' }" />
+    <KOptionalText text="" /> <!-- empty string, show placeholder -->
+      </DocsShowCode>
+      <!-- eslint-enable -->
     </DocsPageSection>
-
+    <DocsPageSection title="Example using slot" anchor="#example-slot">
+      <p>
+        In the example below, it displays user information, highlighting the user's last name, but first and last names are optional:
+      </p>
+      <DocsShow>
+        <ul>
+          <li>
+            <strong>Id:</strong> 1
+          </li>
+          <li>
+            <strong>Name:&nbsp;</strong>
+            <KOptionalText>
+              <span> </span>
+              <span style="color: black; background: yellow;"> </span>
+            </KOptionalText>
+          </li>
+          ...
+        </ul>
+      </DocsShow>
+      <p>
+        An example of a user that has a first and last name:
+      </p>
+      <DocsShow>
+        <ul>
+          <li>
+            <strong>Id:</strong> 2
+          </li>
+          <li>
+            <strong>Name:&nbsp;</strong>
+            <KOptionalText>
+              <span>Peter</span>
+              <span style="color: black; background: yellow;">Jhonson</span>
+            </KOptionalText>
+          </li>
+          ...
+        </ul>
+      </DocsShow>
+      <p>
+        For this example, component slot is used to pass in some spans to be displayed. Slots can be used when there is a more complex structure to be displayed.
+      </p>
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="html">
+    <KOptionalText>
+      {{ userExampleName }}
+      {{ userExampleLastName }}
+    </KOptionalText>
+      </DocsShowCode>
+      <!-- eslint-enable -->
+    </DocsPageSection>
   </DocsPageTemplate>
 
 </template>
+
+
+<script>
+
+  export default {
+    data: () => ({
+      userExampleName: '<span> {{ user.name }} </span>',
+      userExampleLastName: '<span class="highlight"> {{ user.lastname }} </span>',
+    }),
+  };
+
+</script>
 
 
 <style lang="scss" scoped>

--- a/docs/pages/koptionaltext.vue
+++ b/docs/pages/koptionaltext.vue
@@ -1,0 +1,90 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+    <DocsPageSection title="Overview" anchor="#overview">
+      <p>
+        The <code>KOptionalText</code> component is a wrapper for <DocsLibraryLink component="KEmptyPlaceholder" /> used in situations where a text can be missing. If the text exists and is not empty, the text will be rendered, if not, a wide, light-gray dash will be rendered, like this: <KEmptyPlaceholder />
+      </p>
+      <p>
+        Using the KOptionalText component is preferred to leaving a empty or blank space because it communicates to the user that a value <em>could</em> possibly exist there, and aids with visual scanning in tables, grids, and lists of data.
+      </p>
+    </DocsPageSection>
+    <DocsPageSection title="Example" anchor="#example">
+      <p>
+        In the example below, an average score cannot be calculated until the user has attempted at least one exercise:
+      </p>
+      <DocsShow>
+        <table>
+          <thead>
+            <tr>
+              <th class="table-text">
+                <KOptionalText text="Username" />
+              </th>
+              <th class="table-number">
+                <KOptionalText text="Number of exercises" />
+              </th>
+              <th class="table-number">
+                <KOptionalText text="Average score" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="table-text">
+                <KOptionalText text="user_1" />
+              </td>
+              <td class="table-number">
+                <KOptionalText text="11" />
+              </td>
+              <td class="table-number">
+                <KOptionalText text="9%" :appearanceOverrides="{ color: 'red' }" />
+              </td>
+            </tr>
+            <tr>
+              <td class="table-text">
+                <KOptionalText text="user_2" />
+              </td>
+              <td class="table-number">
+                <KOptionalText text="0" />
+              </td>
+              <td class="table-number">
+                <KOptionalText text="" />
+              </td>
+            </tr>
+            <tr>
+              <td class="table-text">
+                <KOptionalText text="user_3" />
+              </td>
+              <td class="table-number">
+                <KOptionalText text="5" />
+              </td>
+              <td class="table-number">
+                <KOptionalText text="100%" appearanceOverrides="color: green" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </DocsShow>
+    </DocsPageSection>
+
+  </DocsPageTemplate>
+
+</template>
+
+
+<style lang="scss" scoped>
+
+  .table-number {
+    text-align: right;
+  }
+
+  .table-text {
+    text-align: left;
+  }
+
+  .table-number,
+  .table-text {
+    padding-right: 16px;
+  }
+
+</style>

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -175,6 +175,11 @@ export default [
         isCode: true,
       }),
       new Page({
+        path: '/koptionaltext',
+        title: 'KOptionalText',
+        isCode: true,
+      }),
+      new Page({
         path: '/kcheckbox',
         title: 'KCheckbox',
         isCode: true,

--- a/lib/KOptionalText.vue
+++ b/lib/KOptionalText.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <span v-if="!textEmpty" :style="textStyle">
+  <span v-if="!textEmpty" :style="appearanceOverrides">
     <template v-if="text">
       {{ text }}
     </template>
@@ -34,7 +34,7 @@
       /**
        * If provided, sets the styles of the text
        */
-      textStyle: {
+      appearanceOverrides: {
         type: Object,
         default: null,
       },
@@ -55,13 +55,16 @@
           return '';
         }
 
-        return this.$slots.default
+        return this.getNodesText(this.$slots.default);
+      },
+      getNodesText(nodes) {
+        return nodes
           .map(node => {
             if (node.text) {
               return node.text;
             }
             if (node.children) {
-              return node.children.map(child => child.text).join('');
+              return this.getNodesText(node.children);
             }
             return '';
           })

--- a/lib/KOptionalText.vue
+++ b/lib/KOptionalText.vue
@@ -50,9 +50,6 @@
       },
     },
     methods: {
-      /**
-       * Returns the text to display
-       */
       getSlotsText() {
         if (!this.$slots.default || !this.$slots.default.length) {
           return '';

--- a/lib/KOptionalText.vue
+++ b/lib/KOptionalText.vue
@@ -1,0 +1,79 @@
+<template>
+
+  <span v-if="!textEmpty" :style="textStyle">
+    <template v-if="text">
+      {{ text }}
+    </template>
+    <template v-else>
+      <slot></slot>
+    </template>
+  </span>
+
+  <KEmptyPlaceholder v-else />
+
+</template>
+
+
+<script>
+
+  import KEmptyPlaceholder from './KEmptyPlaceholder.vue';
+
+  export default {
+    name: 'KOptionalText',
+    components: {
+      KEmptyPlaceholder,
+    },
+    props: {
+      /**
+       * Text to display
+       */
+      text: {
+        type: String,
+        default: null,
+      },
+      /**
+       * If provided, sets the styles of the text
+       */
+      textStyle: {
+        type: Object,
+        default: null,
+      },
+    },
+    computed: {
+      textEmpty() {
+        if (this.text) {
+          return false;
+        }
+
+        const slotsText = this.getSlotsText();
+        return !slotsText.trim();
+      },
+    },
+    methods: {
+      /**
+       * Returns the text to display
+       */
+      getSlotsText() {
+        if (!this.$slots.default || !this.$slots.default.length) {
+          return '';
+        }
+
+        return this.$slots.default
+          .map(node => {
+            if (node.text) {
+              return node.text;
+            }
+            if (node.children) {
+              return node.children.map(child => child.text).join('');
+            }
+            return '';
+          })
+          .join('');
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/lib/KOptionalText.vue
+++ b/lib/KOptionalText.vue
@@ -41,7 +41,7 @@
     },
     computed: {
       textEmpty() {
-        if (this.text) {
+        if (this.text && this.text.trim()) {
           return false;
         }
 

--- a/lib/KOptionalText.vue
+++ b/lib/KOptionalText.vue
@@ -5,6 +5,7 @@
       {{ text }}
     </template>
     <template v-else>
+      <!-- @slot Pass sub-components to render, if none of the nodes in the entire node hierarchy contain text, then the `KEmptyPlaceholder` component will be rendered -->
       <slot></slot>
     </template>
   </span>
@@ -25,7 +26,7 @@
     },
     props: {
       /**
-       * Text to display
+       * Text to display. If the text is missing or empty, then `KEmptyPlaceholder` will be rendered
        */
       text: {
         type: String,
@@ -35,7 +36,7 @@
        * If provided, sets the styles of the text
        */
       appearanceOverrides: {
-        type: Object,
+        type: [Object, String],
         default: null,
       },
     },

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -19,6 +19,7 @@ import KImg from './KImg';
 import KLabeledIcon from './KLabeledIcon';
 import KLinearLoader from './loaders/KLinearLoader';
 import KModal from './KModal';
+import KOptionalText from './KOptionalText';
 import KPageContainer from './KPageContainer';
 import KRadioButton from './KRadioButton';
 import KRouterLink from './buttons-and-links/KRouterLink';
@@ -104,6 +105,7 @@ export default function KThemePlugin(Vue) {
   Vue.component('KLabeledIcon', KLabeledIcon);
   Vue.component('KLinearLoader', KLinearLoader);
   Vue.component('KModal', KModal);
+  Vue.component('KOptionalText', KOptionalText);
   Vue.component('KPageContainer', KPageContainer);
   Vue.component('KRadioButton', KRadioButton);
   Vue.component('KRouterLink', KRouterLink);

--- a/lib/__tests__/KOptionalText.spec.js
+++ b/lib/__tests__/KOptionalText.spec.js
@@ -1,0 +1,106 @@
+import { shallowMount } from '@vue/test-utils';
+
+import KOptionalText from '../KOptionalText.vue';
+
+describe('KOptionalText component', () => {
+  it('smoke test', () => {
+    const wrapper = shallowMount(KOptionalText);
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should render the input text', () => {
+    const text = 'Test';
+    const wrapper = shallowMount(KOptionalText, {
+      propsData: {
+        text,
+      },
+    });
+    expect(wrapper.text()).toEqual(text);
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(false);
+  });
+
+  it('should render the KEmptyplaceholder component if no text is passed', () => {
+    const wrapper = shallowMount(KOptionalText);
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(true);
+  });
+
+  it('should render the KEmptyplaceholder component if text is empty', () => {
+    const wrapper = shallowMount(KOptionalText, {
+      propsData: {
+        text: '',
+      },
+    });
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(true);
+  });
+
+  it('should render the KEmptyplaceholder component if text is undefined', () => {
+    const wrapper = shallowMount(KOptionalText, {
+      propsData: {
+        text: undefined,
+      },
+    });
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(true);
+  });
+
+  it('should render the KEmptyplaceholder component if text is null', () => {
+    const wrapper = shallowMount(KOptionalText, {
+      propsData: {
+        text: null,
+      },
+    });
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(true);
+  });
+
+  it('should render slot content when it has text content', () => {
+    const text = 'Test';
+    const wrapper = shallowMount(KOptionalText, {
+      slots: {
+        default: 'Test',
+      },
+    });
+    expect(wrapper.text()).toEqual(text);
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(false);
+  });
+
+  it('should render slot content when it has child with text content', () => {
+    const wrapper = shallowMount(KOptionalText, {
+      slots: {
+        default: '<div class="test-slot">Test</div>',
+      },
+    });
+    expect(wrapper.find('.test-slot').exists()).toBe(true);
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(false);
+  });
+
+  it('should render the KEmptyplaceholder component if slot child text content is empty', () => {
+    const wrapper = shallowMount(KOptionalText, {
+      slots: {
+        default: '<div class="test-slot"></div>',
+      },
+    });
+    expect(wrapper.find('.test-slot').exists()).toBe(false);
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(true);
+  });
+
+  it('should render slot content with multiple children if any has text content', () => {
+    const wrapper = shallowMount(KOptionalText, {
+      slots: {
+        default: '<div class="test-slot-1"></div><div class="test-slot-2">Test</div>',
+      },
+    });
+    expect(wrapper.find('.test-slot-1').exists()).toBe(true);
+    expect(wrapper.find('.test-slot-2').exists()).toBe(true);
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(false);
+  });
+
+  it('should render the KEmptyplaceholder component if text content of every slot childen is empty', () => {
+    const wrapper = shallowMount(KOptionalText, {
+      slots: {
+        default: '<div class="test-slot-1"></div><div class="test-slot-2"></div>',
+      },
+    });
+    expect(wrapper.find('.test-slot-1').exists()).toBe(false);
+    expect(wrapper.find('.test-slot-2').exists()).toBe(false);
+    expect(wrapper.find('kemptyplaceholder-stub').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description
Add a new component to KDS `KOptionalText` that will either display the text or `KEmptyPlacehlder` if it's an empty string, undefined, or null.

#### Issue addressed

Addresses #285

## Steps to test

1. Link this KDS branch to any product.
2. Use `KOptionalText` component as described in Implementation notes.

## Implementation notes

### At a high level, how did you implement this?

`KOptionalText` will recieve a `text` prop or slot that renders text nodes, if there is text to show, the text or the slot will be shown whithin a `span` element, if not, the `KEmptyPlacehlder` component will be shown. Also a `textStyle` prop can be passed which will be set to the `span` element.

Examples:

All of them will render "Hello world" in red color:

```vue
<KOptionalText text="Hello world" appearanceOverrides="color: red" />

<KOptionalText appearanceOverrides="color: red">
  Hello World
<KOptionalText/>

<KOptionalText>
  <span style="color: red">Hello </span>
  <span style="color: red">World</span>
</KOptionalText>
```


If `name` and `lastname` are nonempty strings name and lastname will be shown. If not it will render a "-":
```vue
<KOptionalText :text="`${name} ${lastname}`" />

<KOptionalText>
  <span>{{ name }}</span>
  <span>{{ lastname }}</span>
</KOptionalText>
```

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
