### PR TITLE
Corrected kdaterange month and year display and removed font-family

### DIFF
--- a/lib/KDateRange/KDateCalendar.vue
+++ b/lib/KDateRange/KDateCalendar.vue
@@ -166,7 +166,7 @@
         },
         numOfDays: 7,
         isFirstChoice: this.selectedStartDate ? true : false,
-        activeMonth: new Date().getMonth() - 1,
+        activeMonth: new Date().getMonth() - 1 == -1 ? 11 : new Date().getMonth() - 1,
         activeYearStart: new Date().getFullYear(),
       };
     },
@@ -209,7 +209,7 @@
       },
     },
     created() {
-      if (this.activeMonth === 11) this.activeYearEnd = this.activeYearStart + 1;
+      if (this.activeMonth === 11) this.activeYearStart = this.activeYearStart - 1;
     },
     methods: {
       /**
@@ -433,7 +433,6 @@
   .calendar {
     height: auto;
     margin-right: 5px;
-    font-family: 'Noto Sans';
     font-size: 14px;
     background: white;
   }

--- a/lib/KDateRange/ValidationMachine.js
+++ b/lib/KDateRange/ValidationMachine.js
@@ -98,6 +98,7 @@ export const initialContext = {
 };
 
 export const validationMachine = createMachine({
+  predictableActionArguments: true,
   id: 'fetch',
   initial: 'placeholder',
   context: initialContext,


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This PR fixes the incorrect display of the _Month Year_ on the `KDateRange` calendar when the previous month is December of last year and the current month is January. Previously, the left side of the calendar was incorrectly set to December of this year and the right side of the calendar was set to January of next year.

The `font-family` declaration has also been removed from `KDateCalendar` as it was unnecessary and caused implementation issues when `KDateRange` is used in Kolibri. 

Added `predictableActionArguments: true` to xstate validation machine to fix console warning based on XState Docs recommendations found [here](https://xstate.js.org/docs/guides/actions.html).  

#### Issue addressed
Fixes #405 

### Before/after screenshots
<!-- Insert images here if applicable -->
Before, incorrect _Month Year_ display
<img width="437" alt="CorrectKDateRange" src="https://user-images.githubusercontent.com/46411498/214100196-fc7329a2-2c5b-45ef-8e13-0cb6e5af2b39.png">


After, correct _Month Year_ display
<img width="434" alt="IncorrectKDateRange" src="https://user-images.githubusercontent.com/46411498/214100181-8f92ab7e-2cd9-46f9-be79-af8edee4390b.png">

## Steps to test

1. Open KDateRange calendar modal demo.
2. Confirm that left side of calendar displays December of last year and the right side of the calendar displays January of this year.

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->
The `activeMonth` (the month that is displayed on the left side of the calendar) is set with `new Date().getMonth() - 1`. 

When `new Date().getMonth()`  returns `0` for January, the value returned from `new Date().getMonth() - 1` is `-1` however, it should be `11`, for December. Now if `new Date().getMonth() - 1` returns `-1`, `activeMonth` is instead set to `11`.

In `created()`, if `activeMonth` is `11`, `activeYearStart` is set to last year.

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
I'm not sure if this change needs to be added in the `changelog` or not.