### PR TITLE
Kdaterange date formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 - [#403] - Add `KOptionalText` to KDS
 - [#420] - Add `KTabs`, `KTabsList`, and `KTabsPanel`
 - [#420] - Fix randomly missing focus ring
+- [#427] - Update `KDateRange` to use `vue-intl` function `$formatDate` for date formatting and translations
 
 <!-- Referenced PRs -->
 [#425]: https://github.com/learningequality/kolibri-design-system/pull/425
@@ -33,6 +34,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 [#420]: https://github.com/learningequality/kolibri-design-system/pull/420
 [#424]: https://github.com/learningequality/kolibri-design-system/pull/424
 [#426]: https://github.com/learningequality/kolibri-design-system/pull/426
+[#427]: https://github.com/learningequality/kolibri-design-system/pull/427
 
 ## Version 1.4.x
 

--- a/docs/pages/kdaterange.vue
+++ b/docs/pages/kdaterange.vue
@@ -17,7 +17,6 @@
             cancelText="Cancel"
             title="Select a date range"
             description="(Optional) Description of modal component"
-            dateLocale="en-US"
             startDateLegendText="Start Date"
             endDateLegendText="End Date"
             previousMonthText="Previous Month"

--- a/jest.conf/setup.js
+++ b/jest.conf/setup.js
@@ -7,6 +7,7 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import KThemePlugin from '../lib/KThemePlugin';
 import KContentPlugin from '../lib/content/KContentPlugin';
+import VueIntl from 'vue-intl';
 
 global.beforeEach(() => {
   return new Promise(resolve => {
@@ -28,6 +29,7 @@ global.afterEach(() => {
 Vue.use(VueRouter);
 Vue.use(KThemePlugin);
 Vue.use(KContentPlugin);
+Vue.use(VueIntl);
 
 Vue.config.silent = true;
 Vue.config.devtools = false;

--- a/jest.conf/setup.js
+++ b/jest.conf/setup.js
@@ -5,9 +5,9 @@ import * as AphroditeNoImportant from 'aphrodite/no-important';
 
 import Vue from 'vue';
 import VueRouter from 'vue-router';
+import VueIntl from 'vue-intl';
 import KThemePlugin from '../lib/KThemePlugin';
 import KContentPlugin from '../lib/content/KContentPlugin';
-import VueIntl from 'vue-intl';
 
 global.beforeEach(() => {
   return new Promise(resolve => {

--- a/lib/KDateRange/KDateCalendar.vue
+++ b/lib/KDateRange/KDateCalendar.vue
@@ -21,7 +21,7 @@
         @click="goNextMonth"
       />
       <div class="calendar-month-left">
-        <div class="months-text">
+        <div class="months-text" data-test="previousMonth">
           {{ monthString(activeMonth) + ' ' + activeYearStart }}
         </div>
         <ul v-for="weekIndex in 6" :key="weekIndex" class="calendar-days">
@@ -36,7 +36,7 @@
             :class="[{
               'calendar-days--disabled': isDateDisabled(weekIndex, dayInWeekIndex, activeMonthDay, activeMonthDate) || isDateDisabledLeft(weekIndex, dayInWeekIndex, activeMonthDay),
               'selected-first': ( selectionOrder(weekIndex, dayInWeekIndex, 'first', activeMonthDay, activeMonthDate) === 'first'),
-              'selected-second': ( selectionOrder(weekIndex, dayInWeekIndex, 'first', activeMonthDay, activeMonthDate) === 'second')
+              'selected-second': ( selectionOrder(weekIndex, dayInWeekIndex, 'first', activeMonthDay, activeMonthDate) === 'second'),
             }]"
             @click="selectFirstItem(weekIndex, dayInWeekIndex)"
           >
@@ -55,7 +55,7 @@
         </ul>
       </div>
       <div class="calendar-month-right">
-        <div class="months-text">
+        <div class="months-text" data-test="currentMonth">
           {{ monthString(nextActiveMonth) + ' ' + activeYearEnd }}
         </div>
         <ul v-for="weekIndex in 6" :key="weekIndex" class="calendar-days">
@@ -389,7 +389,7 @@
       monthString(monthIndex) {
         const date = new Date();
         date.setMonth(monthIndex);
-        return date.toLocaleString(this.dateLocale, { month: 'long' });
+        return this.$formatDate(date, { month: 'long' });
       },
     },
   };

--- a/lib/KDateRange/KDateCalendar.vue
+++ b/lib/KDateRange/KDateCalendar.vue
@@ -49,7 +49,6 @@
               :isEndOfWeek="dayInWeekIndex === 7"
               :isStartOfWeek="dayInWeekIndex === 1"
               :activeMonth="activeMonth"
-              :dateLocale="dateLocale"
             />
           </li>
         </ul>
@@ -83,7 +82,6 @@
               :isEndOfWeek="dayInWeekIndex === 7"
               :isStartOfWeek="dayInWeekIndex === 1"
               :activeMonth="nextActiveMonth"
-              :dateLocale="dateLocale"
             />
           </li>
         </ul>
@@ -134,13 +132,6 @@
       selectedEndDate: {
         type: [Date, null],
         default: null,
-      },
-      /**
-       *  Locale string for date formatting
-       */
-      dateLocale: {
-        type: String,
-        required: true,
       },
       /**
        *  label for previous month button

--- a/lib/KDateRange/KDateDay.vue
+++ b/lib/KDateRange/KDateDay.vue
@@ -61,10 +61,6 @@
         type: Number,
         default: null,
       },
-      dateLocale: {
-        type: String,
-        required: true,
-      },
     },
     data() {
       return {};
@@ -109,7 +105,7 @@
       toMonthName(monthNumber) {
         const date = new Date();
         date.setMonth(monthNumber);
-        return date.toLocaleString(this.dateLocale, { month: 'long' });
+        return this.$formatDate(date, { month: 'long' });
       },
     },
   };

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -38,10 +38,6 @@
       KTextBox,
     },
     props: {
-      dateLocale: {
-        type: String,
-        required: true,
-      },
       inputRef: {
         type: String,
         default: null,
@@ -76,7 +72,7 @@
         return (
           this.legendText +
           ' ' +
-          this.valueAsDate.toLocaleDateString(this.dateLocale, {
+          this.$formatDate(this.valueAsDate, {
             year: 'numeric',
             weekday: 'long',
             month: 'long',

--- a/lib/KDateRange/__tests__/KDateRange.spec.js
+++ b/lib/KDateRange/__tests__/KDateRange.spec.js
@@ -1,5 +1,7 @@
+import Vue from 'vue';
 import { mount } from '@vue/test-utils';
 import KDateRange from '../index';
+import KDateCalendar from '../KDateCalendar';
 import validationConstants from '../validationConstants';
 
 const DEFAULT_PROPS = {
@@ -16,13 +18,13 @@ const DEFAULT_PROPS = {
   [validationConstants.DATE_BEFORE_FIRST_ALLOWED]: 'Date must be after 01/01/2022',
 };
 
-function makeWrapper(kDateRangeProps = {}) {
+function makeKDateRangeWrapper(kDateRangeProps = {}) {
   return mount(KDateRange, {
     propsData: { ...DEFAULT_PROPS, ...kDateRangeProps },
   });
 }
 
-function getElements(wrapper) {
+function getKDateRangeElements(wrapper) {
   return {
     startDate: () => wrapper.find('[data-test="startDate"]'),
     endDate: () => wrapper.find('[data-test="endDate"]'),
@@ -33,7 +35,7 @@ function getElements(wrapper) {
 describe('KDateRange component', () => {
   let wrapper;
   beforeAll(() => {
-    wrapper = makeWrapper();
+    wrapper = makeKDateRangeWrapper();
   });
 
   it(`smoke test`, () => {
@@ -72,16 +74,65 @@ describe('KDateRange component', () => {
     const start = new Date(2022, 8, 1);
     const end = new Date(2022, 11, 1);
     await wrapper.vm.setSelectedDatesFromCalendar({ start: start, end: end });
-    const startDate = getElements(wrapper).startDate();
-    const endDate = getElements(wrapper).endDate();
+    const startDate = getKDateRangeElements(wrapper).startDate();
+    const endDate = getKDateRangeElements(wrapper).endDate();
     expect(startDate.props().value).toEqual(wrapper.vm.getDateString(start));
     expect(endDate.props().value).toEqual(wrapper.vm.getDateString(end));
   });
 
   it('on submission, the submit event should be emitted', async () => {
-    const kModal = getElements(wrapper).kModal();
+    const kModal = getKDateRangeElements(wrapper).kModal();
     kModal.vm.$emit('submit');
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().submit).toBeTruthy();
   });
+});
+
+const KDATECALENDAR_PROPS = {
+  firstAllowedDate: new Date(2022, 0, 1),
+  lastAllowedDate: new Date(),
+  selectedStartDate: new Date(2022, 8, 1),
+  selectedEndDate: new Date(),
+  dateLocale: 'en',
+  previousMonthText: 'Previous Month',
+  nextMonthText: 'Next Month',
+};
+
+function makeKDateCalendarWrapper(kDateCalendarProps = {}) {
+  return mount(KDateCalendar, {
+    propsData: { ...KDATECALENDAR_PROPS, ...kDateCalendarProps },
+  });
+}
+
+function getKDateCalendarElements(wrapper) {
+  return {
+    previousMonthDisplay: () => wrapper.find('[data-test="previousMonth"]'),
+    currentMonthDisplay: () => wrapper.find('[data-test="currentMonth"]'),
+  };
+}
+
+describe('KDateCalendar component', () => {
+  let wrapper;
+  beforeAll(() => {
+    wrapper = makeKDateCalendarWrapper();
+  });
+  
+
+  it(`smoke test`, () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('the month and year display on the left-side calendar view should contain the previous month', async () => {
+    const previousMonthDisplay = getKDateCalendarElements(wrapper).previousMonthDisplay();
+    const previousMonth = new Date().setDate(0);
+    const date = Vue.prototype.$formatDate(previousMonth, { month: 'long', year:'numeric' });
+    expect(previousMonthDisplay.text()).toBe(date);
+  });
+
+  it('the month and year display on the right-side calendar view should contain the current month', async () => {
+    const currentMonthDisplay = getKDateCalendarElements(wrapper).currentMonthDisplay();
+    const date = Vue.prototype.$formatDate(new Date(), { month: 'long', year:'numeric' });
+    expect(currentMonthDisplay.text()).toBe(date);
+  });
+
 });

--- a/lib/KDateRange/__tests__/KDateRange.spec.js
+++ b/lib/KDateRange/__tests__/KDateRange.spec.js
@@ -116,7 +116,6 @@ describe('KDateCalendar component', () => {
   beforeAll(() => {
     wrapper = makeKDateCalendarWrapper();
   });
-  
 
   it(`smoke test`, () => {
     expect(wrapper.exists()).toBe(true);
@@ -125,14 +124,13 @@ describe('KDateCalendar component', () => {
   it('the month and year display on the left-side calendar view should contain the previous month', async () => {
     const previousMonthDisplay = getKDateCalendarElements(wrapper).previousMonthDisplay();
     const previousMonth = new Date().setDate(0);
-    const date = Vue.prototype.$formatDate(previousMonth, { month: 'long', year:'numeric' });
+    const date = Vue.prototype.$formatDate(previousMonth, { month: 'long', year: 'numeric' });
     expect(previousMonthDisplay.text()).toBe(date);
   });
 
   it('the month and year display on the right-side calendar view should contain the current month', async () => {
     const currentMonthDisplay = getKDateCalendarElements(wrapper).currentMonthDisplay();
-    const date = Vue.prototype.$formatDate(new Date(), { month: 'long', year:'numeric' });
+    const date = Vue.prototype.$formatDate(new Date(), { month: 'long', year: 'numeric' });
     expect(currentMonthDisplay.text()).toBe(date);
   });
-
 });

--- a/lib/KDateRange/__tests__/KDateRange.spec.js
+++ b/lib/KDateRange/__tests__/KDateRange.spec.js
@@ -93,7 +93,6 @@ const KDATECALENDAR_PROPS = {
   lastAllowedDate: new Date(),
   selectedStartDate: new Date(2022, 8, 1),
   selectedEndDate: new Date(),
-  dateLocale: 'en',
   previousMonthText: 'Previous Month',
   nextMonthText: 'Next Month',
 };

--- a/lib/KDateRange/index.vue
+++ b/lib/KDateRange/index.vue
@@ -21,7 +21,6 @@
         <div class="left-input">
           <KDateInput
             :value="dateRange.start"
-            :dateLocale="dateLocale"
             inputRef="dateStartRangeInput"
             :errorMessage="invalidStartErrorMessage"
             :legendText="startDateLegendText"
@@ -34,7 +33,6 @@
             :value="dateRange.end"
             inputRef="dateEndRangeInput"
             :errorMessage="invalidEndErrorMessage"
-            :dateLocale="dateLocale"
             :legendText="endDateLegendText"
             data-test="endDate"
             @updateDate="debouncedSetEndDate"
@@ -47,7 +45,6 @@
           :lastAllowedDate="lastAllowedDate"
           :selectedStartDate="createDate(dateRange.start)"
           :selectedEndDate="createDate(dateRange.end)"
-          :dateLocale="dateLocale"
           :previousMonthText="previousMonthText"
           :nextMonthText="nextMonthText"
           v-bind.sync="dateRange"
@@ -139,13 +136,6 @@
       description: {
         type: [String, null],
         default: null,
-      },
-      /**
-       *  Locale string for language and date formatting
-       */
-      dateLocale: {
-        type: String,
-        required: true,
       },
       /**
        *  Start date input label

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash": "^4.17.15",
     "popper.js": "^1.14.6",
     "purecss": "^0.6.2",
-    "tippy.js": "^4.2.1"
+    "tippy.js": "^4.2.1",
+    "vue-intl": "^3.1.0"
   },
   "peerDependencies": {},
   "devDependencies": {
@@ -65,7 +66,7 @@
     "vue-simple-markdown": "^1.1.5",
     "vue-template-compiler": "2.6.14",
     "xml-loader": "^1.2.1",
-    "date-fns":"^1.30.1"
+    "date-fns": "^1.30.1"
   },
   "resolutions": {
     "@babel/preset-env": "7.12.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15009,6 +15009,16 @@ vue-intl@3.0.0:
     intl-messageformat "^1.3.0"
     intl-relativeformat "^1.3.0"
 
+vue-intl@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vue-intl/-/vue-intl-3.1.0.tgz#707f1f7406595c9b4afc6049254b333093be37be"
+  integrity sha512-0v3S5gspuYnt6j1G+KLfPUsNnjRdbMOcYrWYoSd1gYk6rX8VuOyh7NLztPrSIJt+NLs/qzLOZXxI1LORukEiqA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    intl-format-cache "^2.0.5"
+    intl-messageformat "^1.3.0"
+    intl-relativeformat "^1.3.0"
+
 vue-jest@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/vue-jest/-/vue-jest-2.6.0.tgz#23dc99a4dce0bb59fea3946e1317b234968cf12a"


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

This PR updates the `KDateRange` component to use the `vue-intl` `$formatDate` function, which displays the months of the year within the KDateCalendar in the correct language. 

### Before/after screenshots
<!-- Insert images here if applicable -->
Updated KDateRange component with correct month name displayed for previously unsupported languages:

Burmese - my
<img width="434" alt="Burmese" src="https://user-images.githubusercontent.com/46411498/223533320-d50f98bb-0c77-4540-b210-fbf39df5d361.png">
#
Georgian - ka
<img width="447" alt="Georgian" src="https://user-images.githubusercontent.com/46411498/223533336-41f9230c-08a4-490f-af38-e3301dc32396.png">
#
Khmer - km
<img width="441" alt="Khmer" src="https://user-images.githubusercontent.com/46411498/223533348-30b225bc-31f8-4c78-ab7c-c5001d766d85.png">
#
Chichewa, Chewa, Nyanja - nyn
<img width="441" alt="Chichewa, Chewa, Nyanja" src="https://user-images.githubusercontent.com/46411498/223533370-e3cd8ee0-5d58-49d6-aa70-a073f2b48762.png">
#
Fulfulde (Cameroon) - ff-cm
<img width="433" alt="Fulfulde Mbororoore" src="https://user-images.githubusercontent.com/46411498/223533382-78fb3a47-393a-4ba4-aac9-b9827d33e16c.png">
#
Hausa - ha
<img width="444" alt="Hausa" src="https://user-images.githubusercontent.com/46411498/223533402-0406e470-0503-4cb5-8437-3c72cb203b60.png">
#
Yoruba - yo
<img width="430" alt="Yoruba" src="https://user-images.githubusercontent.com/46411498/223533415-10981294-a508-4bdb-bec9-6d4aae6a615a.png">


## Steps to test

1. Use corresponding PR to test in Kolibri: https://github.com/learningequality/kolibri/pull/10207
2. Change the language to one of the previously mentioned above
3. Navigate to Facility > Data
4. Select Generate Log for either session or summary logs
5. The months should be displayed in the selected language

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->
`$formatDate` function is used within `KDateCalendar` and displays the month of the date that is passed in.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Does this work as expected across multiple browsers?

## Comments
<!-- Any additional notes you'd like to add -->
Code works as expected within the Safari browser, but did not work for me when using Chrome, not sure if this is specific to my device.