### PR TITLE
Add an option to freeze loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 - [#420] - Add `KTabs`, `KTabsList`, and `KTabsPanel`
 - [#420] - Fix randomly missing focus ring
 - [#427] - Update `KDateRange` to use `vue-intl` function `$formatDate` for date formatting and translations
-- [#433] - Add new `props` to `KCircularLoader`:  `freeze` and `show`
+- [#433] - Add new `props` to `KCircularLoader`:  `minVisibleTime` and `show`
 
 <!-- Referenced PRs -->
 [#425]: https://github.com/learningequality/kolibri-design-system/pull/425

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 - [#420] - Add `KTabs`, `KTabsList`, and `KTabsPanel`
 - [#420] - Fix randomly missing focus ring
 - [#427] - Update `KDateRange` to use `vue-intl` function `$formatDate` for date formatting and translations
+- [#433] - Add new `props` to `KCircularLoader`:  `freeze` and `show`
 
 <!-- Referenced PRs -->
 [#425]: https://github.com/learningequality/kolibri-design-system/pull/425
@@ -35,6 +36,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 [#424]: https://github.com/learningequality/kolibri-design-system/pull/424
 [#426]: https://github.com/learningequality/kolibri-design-system/pull/426
 [#427]: https://github.com/learningequality/kolibri-design-system/pull/427
+[#433]: https://github.com/learningequality/kolibri-design-system/pull/433
 
 ## Version 1.4.x
 

--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -11,6 +11,7 @@
 
   <transition name="ui-progress-circular--transition-fade">
     <div
+      v-if="showLoader"
       class="ui-progress-circular"
       :class="[classes, { delay }]"
       :style="{ 'width': size + 'px', 'height': size + 'px' }"
@@ -92,6 +93,13 @@
         default: 'indeterminate', // 'indeterminate' or 'determinate'
       },
       /**
+       * Whether the loader should be displayed or not. It needs to be used instead of `v-if/v-show` for `freeze` to work.
+       */
+      show: {
+        type: Boolean,
+        default: true,
+      },
+      /**
        * For determinate loaders, value between 0 and 100 representing percentage completion
        */
       progress: {
@@ -104,6 +112,13 @@
       delay: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * Do not hide the loader until `freeze` in milliseconds. Useful to avoid jarring UX when the actions finishes very fast. In comparison to `delay`, `freeze` emhpasises that an action associated with the loader is indeed taking place. `show` needs to be used instead of `v-if/v-show` for this to work.
+       */
+      freeze: {
+        type: Number,
+        default: 0,
       },
       /**
        * Overall size of the loader in pixels
@@ -121,7 +136,18 @@
       },
     },
 
+    data() {
+      return {
+        isFrozen: false,
+        freezeTimeoutId: null,
+      };
+    },
+
     computed: {
+      showLoader() {
+        return this.show || this.isFrozen;
+      },
+
       classes() {
         return [`ui-progress-circular--type-${this.type}`];
       },
@@ -158,6 +184,28 @@
       },
     },
 
+    watch: {
+      show(oldVal, newVal) {
+        if (oldVal === newVal) {
+          return;
+        }
+        this.freezeLoader();
+      },
+      freeze(oldVal, newVal) {
+        if (oldVal === newVal) {
+          return;
+        }
+        if (newVal === 0 || newVal < 0) {
+          clearTimeout(this.freezeTimeoutId);
+        } else {
+          this.freezeLoader();
+        }
+      },
+    },
+    mounted() {
+      this.freezeLoader();
+    },
+
     methods: {
       moderateProgress(progress) {
         if (isNaN(progress) || progress < 0) {
@@ -169,6 +217,15 @@
         }
 
         return progress;
+      },
+
+      freezeLoader() {
+        if (this.show && this.freeze > 0) {
+          this.isFrozen = true;
+          this.freezeTimeoutId = setTimeout(() => {
+            this.isFrozen = false;
+          }, this.freeze);
+        }
       },
     },
   };

--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -93,7 +93,7 @@
         default: 'indeterminate', // 'indeterminate' or 'determinate'
       },
       /**
-       * Whether the loader should be displayed or not. It needs to be used instead of `v-if/v-show` for `freeze` to work.
+       * Whether the loader should be displayed or not. It needs to be used instead of `v-if/v-show` for `minVisibleTime` to work.
        */
       show: {
         type: Boolean,
@@ -114,9 +114,9 @@
         default: false,
       },
       /**
-       * Do not hide the loader until `freeze` in milliseconds. Useful to avoid jarring UX when the actions finishes very fast. In comparison to `delay`, `freeze` emhpasises that an action associated with the loader is indeed taking place. `show` needs to be used instead of `v-if/v-show` for this to work.
+       * Do not hide the loader until `minVisibleTime` in milliseconds. Useful to avoid jarring UX when the actions finishes very fast. In comparison to `delay`, `minVisibleTime` emphasizes that an action associated with the loader is indeed taking place. `show` needs to be used instead of `v-if/v-show` for this to work.
        */
-      freeze: {
+      minVisibleTime: {
         type: Number,
         default: 0,
       },
@@ -220,11 +220,11 @@
       },
 
       freezeLoader() {
-        if (this.show && this.freeze > 0) {
+        if (this.show && this.minVisibleTime > 0) {
           this.isFrozen = true;
           this.freezeTimeoutId = setTimeout(() => {
             this.isFrozen = false;
-          }, this.freeze);
+          }, this.minVisibleTime);
         }
       },
     },


### PR DESCRIPTION
## Description

Accompanying PR to https://github.com/learningequality/kolibri/pull/10558 which, by means of two new props `show` and `freeze`, adds an option to prevent the loader from hiding for the chosen amount of time even when the condition for displaying it (e.g. "is the request still processing?") is not truthy anymore. Example:

```vue
<KCircularLoader
  :show="shouldShow"
  :freeze="3000"
/>
```

means that the loader component will be displayed for 3 seconds even when `shouldShow` is falsy sooner than 3s.

This is to prevent the loader from appearing and disappearing very fast (see `props` comments to understand how this is different from the `delay` prop)

## Steps to test

It's used in https://github.com/learningequality/kolibri/pull/10558. When you click the download button on a remote content page, the loader will stay there for 3 seconds even though the mocked download takes only 1 second to complete. 

## Comments

I am not sure if `freeze` is a good name because it may suggest that we freeze it in the sense of stopping loading animation which is not the case. Thoughts welcome.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_
