### PR TITLE
add flex properties to KRouterLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
 ## Develop (to become version 1.5.x)
-- [#438] - Adds `flex` properties to `KRouterLink`
+- [#438] - `KRouterLink`: Fixes alignment of an icon and a link
 - [#426] - Adds `'click'` event to `KTabsList`
 - [#425] - Adds `pinned` and `notPinned` icons. Updates `cloud` icon to outline
 - [#424] - Adds `laptop` `cloud `and `wifi` icons to KDS
@@ -38,6 +38,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 [#426]: https://github.com/learningequality/kolibri-design-system/pull/426
 [#427]: https://github.com/learningequality/kolibri-design-system/pull/427
 [#433]: https://github.com/learningequality/kolibri-design-system/pull/433
+[#438]: https://github.com/learningequality/kolibri-design-system/pull/438
 
 ## Version 1.4.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
 ## Develop (to become version 1.5.x)
+- [#438] - Adds `flex` properties to `KRouterLink`
 - [#426] - Adds `'click'` event to `KTabsList`
 - [#425] - Adds `pinned` and `notPinned` icons. Updates `cloud` icon to outline
 - [#424] - Adds `laptop` `cloud `and `wifi` icons to KDS

--- a/lib/buttons-and-links/KRouterLink.vue
+++ b/lib/buttons-and-links/KRouterLink.vue
@@ -9,6 +9,7 @@
     :class="buttonClasses"
     :to="to"
     :replace="replace"
+    style="display: flex"
     data-test="router-link"
     dir="auto"
     @mouseenter.native="hovering = true"
@@ -20,7 +21,7 @@
       <KIcon
         v-if="icon"
         :icon="icon"
-        style="top: 4px;"
+        style="top: 4px; flex-shrink: 0"
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
         data-test="icon-before"
       />
@@ -38,7 +39,7 @@
       <KIcon
         v-if="iconAfter"
         :icon="iconAfter"
-        style="top: 4px;"
+        style="top: 4px; flex-shrink: 0"
         :color="hovering ? $themeTokens.primaryDark : $themeTokens.primary"
         data-test="icon-after"
       />


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
This pull request adds flex properties to `KRouterLink`, so that when an icon is present and the link text needs to wrap, it stays on the same line as the icon, and the second line of text stays justified with the first. 

## Before/after screenshots

### Link with Icon Initial Behavior Wrap
![Link with Icon Initial Behavior Wrap](https://github.com/learningequality/kolibri-design-system/assets/81499114/0e0bd285-26c6-42dc-938a-9fbbfc9f9336)

### Link with Icon New Behavior Wrap
![Link with Icon New Behavior Wrap](https://github.com/learningequality/kolibri-design-system/assets/81499114/08e784b6-1d2e-4fca-b48c-4b1a42f08043)

### Lesson List before
![Lesson List before](https://github.com/learningequality/kolibri-design-system/assets/81499114/cd3c7b43-aefb-4726-8c57-14d39dfb7f4e)

### Lesson List after
![Lesson List after](https://github.com/learningequality/kolibri-design-system/assets/81499114/67c8fc58-7550-4c3a-8b04-6217809cb366)

# Steps to test

Tests with presence of `Icon` and `IconAfter` properties in `KRouterLink`

1. Load `[KRouterLink ](http://localhost:4000/krouterlink)` lib page
2. Adjust width of page to see link format as shown in screenshots
3. Open `KRouterLink` _doc_ Vue file
4. Adjust the `icon` property of second `KRouterLink` element from `icon` to `iconAfter`
5. Save and refresh the `[KRouterLink ](http://localhost:4000/krouterlink)` page
6. Adjust width of page to see link format as shown in screenshots

## (optional) Implementation notes

### At a high level, how did you implement this?
This adds a `display: flex` property for the `KRouterLink`. This keeps the link icons and link text from intermingling, and prevents wrapped link text from starting lower than the icon itself. The `KIcon` elements have been given element-level style properties of `flex-shrink: 0` so that they maintain the same size regardless of their parent's width.

### Does this introduce any tech-debt items?
I added the `display: flex` property directly to the `KRouterLink` element. I didn't want to complicate/break the css styling in the `buttons.scss` file that otherwise provides the style rules for `KRouterLink`. I could have added a style rule at the bottom of `KRuleLink.vue`, Because of its implementation, the `display: flex` property overrides the inherited `display: inline-block` property from `buttons.scss`.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
