### PR TITLE
Update KDateRange to use input[type=date]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Releases are recorded as git tags in the [Github releases](https://github.com/le
 - [#420] - Fix randomly missing focus ring
 - [#427] - Update `KDateRange` to use `vue-intl` function `$formatDate` for date formatting and translations
 - [#433] - Add new `props` to `KCircularLoader`:  `minVisibleTime` and `show`
+- [#443] - Update inputs within `KDateRange` to type `date`
 
 <!-- Referenced PRs -->
 [#425]: https://github.com/learningequality/kolibri-design-system/pull/425

--- a/docs/pages/kdaterange.vue
+++ b/docs/pages/kdaterange.vue
@@ -5,9 +5,71 @@
     <DocsPageSection title="Overview" anchor="#overview">
       The KDateRange is a modal component that contains two input components and a calendar component that 
       allow for a start and end date selection. 
+      <div>
+        <KButton text="open demo" :primary="true" appearance="flat-button" :style="{ marginTop: '5px' }" @click="modalShown = true" />
+        <ClientOnly>
+          <KDateRange
+            v-if="modalShown"
+            class="demo"
+            :firstAllowedDate="firstAllowedDate"
+            :lastAllowedDate="lastAllowedDate"
+            submitText="Submit"
+            cancelText="Cancel"
+            title="Select a date range"
+            description="(Optional) Description of modal component"
+            startDateLegendText="Start Date"
+            endDateLegendText="End Date"
+            previousMonthText="Previous Month"
+            nextMonthText="Next Month"
+            v-bind="errorMessages"
+            @submit="modalShown = false"
+            @cancel="modalShown = false"
+          />
+        </ClientOnly>
+      </div>
     </DocsPageSection>
   </DocsPageTemplate>
 
 </template>
 
 
+<script>
+
+  import format from 'date-fns/format';
+  import validationConstants from '../../lib/KDateRange/validationConstants';
+  import KButton from '../../lib/buttons-and-links/KButton';
+
+  export default {
+    components: {
+      KButton,
+    },
+    data() {
+      return {
+        firstAllowedDate: new Date(2022, 0, 1),
+        lastAllowedDate: new Date(),
+        modalShown: false,
+      };
+    },
+    computed: {
+      errorMessages() {
+        return {
+          [validationConstants.MALFORMED]: 'Please enter a valid date',
+          [validationConstants.START_DATE_AFTER_END_DATE]: 'Start date cannot be after end date',
+          [validationConstants.FUTURE_DATE]: 'Cannot select a future date',
+          [validationConstants.DATE_BEFORE_FIRST_ALLOWED]:
+            'Date must be after ' + format(this.firstAllowedDate, 'DD/MM/YYYY'),
+        };
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="css" scoped>
+
+  .demo {
+    height: 850px;
+  }
+
+</style>

--- a/docs/pages/kdaterange.vue
+++ b/docs/pages/kdaterange.vue
@@ -5,72 +5,9 @@
     <DocsPageSection title="Overview" anchor="#overview">
       The KDateRange is a modal component that contains two input components and a calendar component that 
       allow for a start and end date selection. 
-      <div>
-        <KButton text="open demo" :primary="true" appearance="flat-button" :style="{ marginTop: '5px' }" @click="modalShown = true" />
-        <ClientOnly>
-          <KDateRange
-            v-if="modalShown"
-            class="demo"
-            :firstAllowedDate="firstAllowedDate"
-            :lastAllowedDate="lastAllowedDate"
-            submitText="Generate"
-            cancelText="Cancel"
-            title="Select a date range"
-            description="(Optional) Description of modal component"
-            startDateLegendText="Start Date"
-            endDateLegendText="End Date"
-            previousMonthText="Previous Month"
-            nextMonthText="Next Month"
-            v-bind="errorMessages"
-            @submit="modalShown = false"
-            @cancel="modalShown = false"
-          />
-        </ClientOnly>
-      </div>
     </DocsPageSection>
   </DocsPageTemplate>
 
 </template>
 
-
-<script>
-
-  import format from 'date-fns/format';
-  import validationConstants from '../../lib/KDateRange/validationConstants';
-  import KButton from '../../lib/buttons-and-links/KButton';
-
-  export default {
-    components: {
-      KButton,
-    },
-    data() {
-      return {
-        firstAllowedDate: new Date(2022, 0, 1),
-        lastAllowedDate: new Date(),
-        modalShown: false,
-      };
-    },
-    computed: {
-      errorMessages() {
-        return {
-          [validationConstants.MALFORMED]: 'Please enter a valid date',
-          [validationConstants.START_DATE_AFTER_END_DATE]: 'Start date cannot be after end date',
-          [validationConstants.FUTURE_DATE]: 'Cannot select a future date',
-          [validationConstants.DATE_BEFORE_FIRST_ALLOWED]:
-            'Date must be after ' + format(this.firstAllowedDate, 'DD/MM/YYYY'),
-        };
-      },
-    },
-  };
-
-</script>
-
-
-<style lang="css" scoped>
-
-  .demo {
-    height: 850px;
-  }
-
-</style>
 

--- a/docs/plugins/load-lib-components.js
+++ b/docs/plugins/load-lib-components.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import VueCompositionAPI from '@vue/composition-api';
+import VueIntl from 'vue-intl';
 import KThemePlugin from '~~/lib/KThemePlugin';
 import trackInputModality from '~~/lib/styles/trackInputModality';
 
@@ -10,3 +11,4 @@ trackInputModality({ disableFocusRingByDefault: false });
 
 Vue.use(VueCompositionAPI);
 Vue.use(KThemePlugin);
+Vue.use(VueIntl);

--- a/lib/KDateRange/KDateCalendar.vue
+++ b/lib/KDateRange/KDateCalendar.vue
@@ -156,7 +156,7 @@
           end: this.selectedStartDate && this.selectedEndDate ? this.selectedEndDate : null,
         },
         numOfDays: 7,
-        isFirstChoice: this.selectedStartDate ? true : false,
+        isFirstChoice: this.selectedStartDate == null ? true : false,
         activeMonth: new Date().getMonth() - 1 == -1 ? 11 : new Date().getMonth() - 1,
         activeYearStart: new Date().getFullYear(),
       };

--- a/lib/KDateRange/KDateDay.vue
+++ b/lib/KDateRange/KDateDay.vue
@@ -138,7 +138,6 @@
   }
 
   /* VISUALLY HIDDEN ITEMS */
-
   .k-date-vhidden {
     position: absolute;
     top: 0;

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -4,7 +4,6 @@
     <fieldset :aria-label="legendText" class="date-input-fieldset" :aria-describedby="inputId" aria-live="polite">
       <KTextBox
         :ref="inputRef"
-        :class="langDir"
         :value="value"
         type="date"
         pattern="\d{4}-\d{2}-\d{2}" 
@@ -81,12 +80,6 @@
         }
         return '';
       },
-      langDir() {
-        if (this.isRtl) {
-          return 'is-rtl';
-        }
-        return 'not-rtl';
-      },
     },
     mounted() {
       this.$nextTick(() => {
@@ -133,23 +126,21 @@
 
   /* HIDES BROWSER NATIVE DATEPICKER */
   /deep/ input[type='date'] {
-    width: 150px;
-    text-transform: uppercase !important;
     border: 0;
+    text-align: left;
+    text-transform: uppercase !important;
     &::-webkit-inner-spin-button,
     &::-webkit-calendar-picker-indicator {
       display: none;
       appearance: none;
       visibility: hidden !important;
     }
+    &:dir(rtl) {
+      clip-path: inset(0 0 0 25px);
+      text-align: left;
+    }
+    &:dir(ltr) {
+      clip-path: inset(0 25px 0 0);
+    }
   }
-
-  /deep/ div.is-rtl input[type='date'] {
-    clip-path: inset(0 0 0 25px);
-  }
-
-  /deep/ div.not-rtl input[type='date'] {
-    clip-path: inset(0 25px 0 0);
-  }
-
 </style>

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -4,6 +4,7 @@
     <fieldset :aria-label="legendText" class="date-input-fieldset" :aria-describedby="inputId" aria-live="polite">
       <KTextBox
         :ref="inputRef"
+        :class="langDir"
         :value="value"
         type="date"
         :label="legendText"
@@ -79,6 +80,12 @@
         }
         return '';
       },
+      langDir() {
+        if (this.isRtl) {
+          return 'is-rtl';
+        }
+        return 'not-rtl';
+      },
     },
     mounted() {
       this.$nextTick(() => {
@@ -124,18 +131,24 @@
   }
 
   /* HIDES BROWSER NATIVE DATEPICKER */
-  /deep/ input[type='date']::-webkit-inner-spin-button,
-  /deep/ input[type='date']::-webkit-calendar-picker-indicator {
-    display: none;
-    appearance: none;
-    visibility: hidden !important;
-  }
-
   /deep/ input[type='date'] {
     width: 150px;
-    clip-path: inset(0 25px 0 0);
     text-transform: uppercase !important;
     border: 0;
+    &::-webkit-inner-spin-button,
+    &::-webkit-calendar-picker-indicator {
+      display: none;
+      appearance: none;
+      visibility: hidden !important;
+    }
+  }
+
+  /deep/ div.is-rtl input[type='date'] {
+    clip-path: inset(0 0 0 25px);
+  }
+
+  /deep/ div.not-rtl input[type='date'] {
+    clip-path: inset(0 25px 0 0);
   }
 
 </style>

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -7,6 +7,7 @@
         :class="langDir"
         :value="value"
         type="date"
+        pattern="\d{4}-\d{2}-\d{2}" 
         :label="legendText"
         autoComplete="off"
         :invalid="Boolean(errorMessage)"

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -129,6 +129,8 @@
     text-align: left;
     text-transform: uppercase !important;
     border: 0;
+    appearance: none;
+    -webkit-appearance: none;
     &::-webkit-inner-spin-button,
     &::-webkit-calendar-picker-indicator {
       display: none;

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -107,6 +107,7 @@
 
 <style lang="scss" scoped>
 
+  /* stylelint-disable */
   .date-input-fieldset {
     padding-bottom: 0;
     border: 0;
@@ -126,11 +127,13 @@
 
   /* HIDES BROWSER NATIVE DATEPICKER */
   /deep/ input[type='date'] {
+    width: 150px;
     text-align: left;
     text-transform: uppercase !important;
     border: 0;
-    appearance: none;
     -webkit-appearance: none;
+    appearance: none;
+
     &::-webkit-inner-spin-button,
     &::-webkit-calendar-picker-indicator {
       display: none;

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -126,14 +126,14 @@
 
   /* HIDES BROWSER NATIVE DATEPICKER */
   /deep/ input[type='date'] {
-    border: 0;
     text-align: left;
     text-transform: uppercase !important;
+    border: 0;
     &::-webkit-inner-spin-button,
     &::-webkit-calendar-picker-indicator {
       display: none;
-      appearance: none;
       visibility: hidden !important;
+      appearance: none;
     }
     &:dir(rtl) {
       clip-path: inset(0 0 0 25px);
@@ -143,4 +143,5 @@
       clip-path: inset(0 25px 0 0);
     }
   }
+
 </style>

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -137,7 +137,6 @@
     }
     &:dir(rtl) {
       clip-path: inset(0 0 0 25px);
-      text-align: left;
     }
     &:dir(ltr) {
       clip-path: inset(0 25px 0 0);

--- a/lib/KDateRange/ValidationMachine.js
+++ b/lib/KDateRange/ValidationMachine.js
@@ -1,13 +1,13 @@
 import { createMachine, assign } from 'xstate';
 import { isAfter, startOfDay, isBefore } from 'date-fns';
-import validationConstants, { DATE_FMT } from './validationConstants';
+import validationConstants from './validationConstants';
 
 /**
  * @params dateStr - The input date string value
  *  Returns if the given prop is equal to the placeholder
  **/
 function isPlaceholder(dateStr) {
-  return dateStr === DATE_FMT;
+  return dateStr === null;
 }
 
 /**
@@ -15,7 +15,7 @@ function isPlaceholder(dateStr) {
  *  Returns if the given prop matches the constant dateFormat RegExp pattern
  **/
 const isCorrectFormat = dateStr => {
-  return dateFormat.test(dateStr) || dateStr === DATE_FMT;
+  return dateFormat.test(dateStr) || dateStr === null;
 };
 
 /**
@@ -24,12 +24,14 @@ const isCorrectFormat = dateStr => {
  * Returns if the end date is after the start date
  **/
 const isEndDateAfterStart = (startDate, endDate) => {
-  const [startDay, startMonth, startYear] = startDate.split('/');
-  const newStartDate = startOfDay(new Date(startYear, startMonth - 1, startDay));
+  if (startDate && endDate != null) {
+    const [startYear, startMonth, startDay] = startDate.split('-');
+    const newStartDate = startOfDay(new Date(startYear, startMonth - 1, startDay));
 
-  const [endDay, endMonth, endYear] = endDate.split('/');
-  const newEndDate = startOfDay(new Date(endYear, endMonth - 1, endDay));
-  return isAfter(newStartDate, newEndDate);
+    const [endYear, endMonth, endDay] = endDate.split('-');
+    const newEndDate = startOfDay(new Date(endYear, endMonth - 1, endDay));
+    return isAfter(newStartDate, newEndDate);
+  }
 };
 
 /**
@@ -38,9 +40,11 @@ const isEndDateAfterStart = (startDate, endDate) => {
  * Returns if the given date string is after the last allowed date
  **/
 const isDateAfterLastAllowed = (dateStr, lastAllowedDate) => {
-  const [day, month, year] = dateStr.split('/');
-  const newDate = startOfDay(new Date(year, month - 1, day));
-  return isAfter(newDate, lastAllowedDate);
+  if (!isPlaceholder(dateStr)) {
+    const [year, month, day] = dateStr.split('-');
+    const newDate = startOfDay(new Date(year, month - 1, day));
+    return isAfter(newDate, lastAllowedDate);
+  }
 };
 
 /**
@@ -49,9 +53,11 @@ const isDateAfterLastAllowed = (dateStr, lastAllowedDate) => {
  * Returns if the given date string is before the first allowed date
  **/
 const isDateBeforeFirstAllowed = (dateStr, firstAllowedDate) => {
-  const [day, month, year] = dateStr.split('/');
-  const newDate = startOfDay(new Date(year, month - 1, day));
-  return isBefore(newDate, firstAllowedDate);
+  if (!isPlaceholder(dateStr)) {
+    const [year, month, day] = dateStr.split('-');
+    const newDate = startOfDay(new Date(year, month - 1, day));
+    return isBefore(newDate, firstAllowedDate);
+  }
 };
 
 /**
@@ -85,11 +91,11 @@ export const validate = ({ startDate, endDate, firstAllowedDate, lastAllowedDate
 };
 
 /* eslint-disable no-useless-escape */
-const dateFormat = /^(0?[1-9]|[12][0-9]|3[01])[\/\-](0?[1-9]|1[012])[\/\-]\d{4}$/;
+const dateFormat = /^\d{4}-\d{2}-\d{2}$/;
 
 export const initialContext = {
-  startDate: DATE_FMT,
-  endDate: DATE_FMT,
+  startDate: null,
+  endDate: null,
   startDateInvalid: false,
   endDateInvalid: false,
   errorText: null,

--- a/lib/KDateRange/__tests__/KDateInput.spec.js
+++ b/lib/KDateRange/__tests__/KDateInput.spec.js
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 import KDateInput from '../KDateInput';
-import { DATE_FMT } from '../validationConstants';
 
 const DEFAULT_PROPS = {
   legendText: 'Start Date',
@@ -26,16 +25,8 @@ describe('KDateInput component', () => {
     wrapper = makeWrapper();
   });
 
-  it('default value should be same as constant DATE_FMT and no invalid error message should be shown', async () => {
+  it('no invalid error message should be shown for initial value', async () => {
     const textbox = getElements(wrapper).KTextbox();
     expect(textbox.props().invalid).toEqual(false);
-    expect(textbox.props().value).toEqual(DATE_FMT);
-  });
-
-  it('hidden input valueAsDate should equal date object of date string given to KDateInput', async () => {
-    await wrapper.setProps({ value: '01/10/2022' });
-    const dateValue = wrapper.vm.valueAsDate;
-    const valueAsDate = getElements(wrapper).valueDate().element._value;
-    expect(valueAsDate).toBe(dateValue);
   });
 });

--- a/lib/KDateRange/__tests__/KDateRange.spec.js
+++ b/lib/KDateRange/__tests__/KDateRange.spec.js
@@ -50,7 +50,7 @@ describe('KDateRange component', () => {
   });
 
   it('modal submit should be disabled if there is a start date, but no end date', async () => {
-    wrapper.vm.setStartDate('01/10/2022');
+    wrapper.vm.setStartDate('2022-01-10');
     wrapper.vm.setEndDate('');
     const submitDisabled = wrapper.vm.disabled;
     expect(submitDisabled).toBeTruthy();
@@ -58,14 +58,14 @@ describe('KDateRange component', () => {
 
   it('modal submit should be disabled if there is an end date, but no start date', async () => {
     wrapper.vm.setStartDate('');
-    wrapper.vm.setEndDate('01/10/2022');
+    wrapper.vm.setEndDate('2022-01-10');
     const submitDisabled = wrapper.vm.disabled;
     expect(submitDisabled).toBeTruthy();
   });
 
-  it('modal submit should be not disabled if there a valid start and end date', async () => {
-    wrapper.vm.setStartDate('01/02/2022');
-    wrapper.vm.setEndDate('01/09/2022');
+  it('modal submit should not be disabled if there a valid start and end date', async () => {
+    wrapper.vm.setStartDate('2022-01-02');
+    wrapper.vm.setEndDate('2022-01-09');
     const submitDisabled = wrapper.vm.disabled;
     expect(submitDisabled).toBeFalsy();
   });

--- a/lib/KDateRange/__tests__/ValidationMachine.spec.js
+++ b/lib/KDateRange/__tests__/ValidationMachine.spec.js
@@ -3,8 +3,8 @@ import validationConstants from '../validationConstants';
 import { validationMachine, initialContext } from '../ValidationMachine';
 
 const currentContext = {
-  startDate: '01/09/2022',
-  endDate: '01/10/2022',
+  startDate: '2022-01-09',
+  endDate: '2022-01-10',
   lastAllowedDate: new Date(),
   firstAllowedDate: new Date(2022, 0, 1),
 };
@@ -29,14 +29,14 @@ describe('Validation Machine', () => {
   });
 
   it('returns endDateInvalid error message when end date is malformed', async () => {
-    validateService.send('REVALIDATE', { startDate: '01/09/2022', endDate: 'aaaaaaa' });
+    validateService.send('REVALIDATE', { startDate: '2022-01-09', endDate: 'aaaaaaa' });
     expect(validateService._state.value).toEqual('failure');
     expect(validateService._state.context.endDateInvalid).toEqual(validationConstants.MALFORMED);
     expect(validateService._state.context.startDateInvalid).toBeFalsy();
   });
 
   it('returns startDateInvalid error message when end date is before start date', async () => {
-    validateService.send('REVALIDATE', { startDate: '01/09/2022', endDate: '01/06/2022' });
+    validateService.send('REVALIDATE', { startDate: '2022-01-09', endDate: '2022-01-06' });
     expect(validateService._state.value).toEqual('failure');
     expect(validateService._state.context.startDateInvalid).toEqual(
       validationConstants.START_DATE_AFTER_END_DATE
@@ -45,7 +45,7 @@ describe('Validation Machine', () => {
   });
 
   it('returns startDateInvalid error message when start date is before the first allowed date and endDateInvalid error message when end date is malformed', async () => {
-    validateService.send('REVALIDATE', { startDate: '01/12/2019', endDate: 'aaaaaa' });
+    validateService.send('REVALIDATE', { startDate: '2019-01-12', endDate: 'aaaaaa' });
     expect(validateService._state.value).toEqual('failure');
     expect(validateService._state.context.startDateInvalid).toEqual(
       validationConstants.DATE_BEFORE_FIRST_ALLOWED
@@ -54,7 +54,7 @@ describe('Validation Machine', () => {
   });
 
   it('returns endDateInvalid error message when end date is before first allowed and startDateInvalid error message when start date is malformed', async () => {
-    validateService.send('REVALIDATE', { startDate: 'invalid', endDate: '01/06/2019' });
+    validateService.send('REVALIDATE', { startDate: 'invalid', endDate: '2019-01-06' });
     expect(validateService._state.value).toEqual('failure');
     expect(validateService._state.context.startDateInvalid).toEqual(validationConstants.MALFORMED);
     expect(validateService._state.context.endDateInvalid).toEqual(

--- a/lib/KDateRange/index.vue
+++ b/lib/KDateRange/index.vue
@@ -68,7 +68,7 @@
   import KDateCalendar from './KDateCalendar';
   import KDateInput from './KDateInput';
   import { validationMachine, initialContext } from './ValidationMachine';
-  import validationConstants, { DATE_FMT } from './validationConstants';
+  import validationConstants from './validationConstants';
 
   export default {
     name: 'KDateRange',
@@ -189,11 +189,11 @@
     data() {
       return {
         dateRange: {
-          start: this.defaultStartDate ? format(this.defaultStartDate, DATE_FMT) : DATE_FMT,
+          start: this.defaultStartDate ? format(this.defaultStartDate, 'YYYY-MM-DD') : null,
           end:
             this.defaultStartDate && this.defaultEndDate
-              ? format(this.defaultEndDate, DATE_FMT)
-              : DATE_FMT,
+              ? format(this.defaultEndDate, 'YYYY-MM-DD')
+              : null,
         },
         modalSize: 480,
         validationMachine: null,
@@ -255,13 +255,13 @@
       },
       /** Checks if dateStr is equal to the placeholder. If so, submit should be disabled */
       isPlaceholder(dateStr) {
-        return dateStr === DATE_FMT;
+        return dateStr === null;
       },
       getDateString(date) {
         if (!date) {
-          return DATE_FMT;
+          return null;
         }
-        return format(date, DATE_FMT);
+        return format(date, 'YYYY-MM-DD');
       },
       /** Returns startDateInvalid message from validation machine */
       invalidStart() {
@@ -291,14 +291,14 @@
         if (!dateStr) {
           return null;
         }
-        const [day, month, year] = dateStr.split('/');
+        const [year, month, day] = dateStr.split('-');
         const newDate = startOfDay(new Date(year, month - 1, day));
         return newDate;
       },
       /** Updates start date with input from textbox */
       setStartDate(newVal) {
-        this.dateRange = { start: newVal, end: DATE_FMT };
-        this.validationMachine.send('REVALIDATE', { startDate: newVal, endDate: DATE_FMT });
+        this.dateRange = { start: newVal, end: null };
+        this.validationMachine.send('REVALIDATE', { startDate: newVal, endDate: null });
       },
       /** Updates end date with input from textbox */
       setEndDate(newVal) {

--- a/lib/KDateRange/validationConstants.js
+++ b/lib/KDateRange/validationConstants.js
@@ -4,5 +4,3 @@ export default {
   FUTURE_DATE: 'cannotSelectAFutureDateErrorMessage',
   DATE_BEFORE_FIRST_ALLOWED: 'dateBeforefirstAllowedErrorMessage',
 };
-
-export const DATE_FMT = 'DD/MM/YYYY';


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This pull request updates the component KDateRage to use input[type=date] to allow for the use of browser placeholders for language translation in Kolibri.

#### Issue addressed
Closes #442 

### Before/after screenshots
Before; Italian
![image](https://github.com/learningequality/kolibri-design-system/assets/46411498/96bd3920-ac8d-4ca8-a26f-0240ab36eba8)
After:
Italian
<img width="723" alt="italian" src="https://github.com/learningequality/kolibri-design-system/assets/46411498/bf4d9dce-d07d-4786-ace9-fcb05aa08a19">


Arabic
<img width="720" alt="arabic" src="https://github.com/learningequality/kolibri-design-system/assets/46411498/ea4492e6-599c-4a96-879e-bf6bfb1ca7b2">


English (UK)
<img width="1440" alt="english-uk" src="https://github.com/learningequality/kolibri-design-system/assets/46411498/ad7e952d-7bbe-44fb-bae2-f517e054449f">


## Steps to test
See this [Kolibri pull request](https://github.com/learningequality/kolibri/pull/10987) for testing.
1. In Kolibri, navigate to Facility > Data page
2. Make sure there are no previously generated session or summary logs
3. Change language in Kolibri to something other than English
4. *May have to change language in system settings as well*

## (optional) Implementation notes
- Removed validation constant `DATE_FMT` (DD/MM/YYYY)
- Set validation machine start and end date values to null instead of `DATE_FMT`
- Updated validation machine error handling
- Changed input type to date inside `KDateInput` component 
- Added event listener on mount to disable native date pickers once input is clicked or has focus
- Replaced instances of `DATE_FMT` with null
- Updated `KDateRange` tests to work with input date format


### At a high level, how did you implement this?
<!-- Briefly describe how this works -->
This update uses an `input` of type `date` which automatically sets the placeholder text to the user's system language date format.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] Is this change functional across multiple browsers?

## Comments
<!-- Any additional notes you'd like to add -->
With Safari browser, the placeholder is set to the current date rather than DD/MM/YYYY, but this date is not automatically selected on the calendar.