### PR TITLE
useKResponsiveWindow update fixing resizing behavior in Learn > Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 
 Changelog Guidelines
 
@@ -42,6 +42,15 @@ Changelog Guidelines
 Changelog is rather internal in nature. See release notes for the public overview and guidelines. Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
 ## Version 1.5.x
+
+- [#453]
+  - **Description:** Fix sidepanel opening in Kolibri Library page after resizing window
+  - **Products impact:** bugfix
+  - **Addresses:** https://github.com/learningequality/kolibri/issues/11212
+  - **Components:** `useKResponsiveWindow` (composable)
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -
 
 <!-- Release notes prepared for all items below -->
 
@@ -214,7 +223,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 [#426]: https://github.com/learningequality/kolibri-design-system/pull/426
 
 - [#426]
-  - **Description:** Fix `KTabsList` focus state 
+  - **Description:** Fix `KTabsList` focus state
   - **Products impact:** bugfix
   - **Addresses:** -
   - **Components:** `KTabsList`, `KTabs`
@@ -338,7 +347,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Description:** Fix `KDropdownMenu` not showing after its refactor in [#346] by adding missing template tags to `KButton`
   - **Products impact:** bugfix
   - **Addresses:** https://github.com/learningequality/kolibri/issues/9754
-  - **Components:** `KDropdownMenu`, `KButton` 
+  - **Components:** `KDropdownMenu`, `KButton`
   - **Breaking:** no
   - **Impacts a11y:** no
   - **Guidance:** -

--- a/lib/tabs/__tests__/KTabsPanel.spec.js
+++ b/lib/tabs/__tests__/KTabsPanel.spec.js
@@ -92,11 +92,16 @@ describe(`KTabsPanel`, () => {
 
     // switch to a tab which has no focusable elements
     wrapper.setProps({ activeTabId: 'lessonsTab' });
+
+    // Need to wait two ticks - initial value change is in response to a watcher on the updated prop,
+    // and then the value is only updated after the nextTick
+    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     expect(wrapper.attributes('tabindex')).toBe('0');
 
     // switch to a tab with a focusable element
     wrapper.setProps({ activeTabId: 'groupsTab' });
+    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     expect(wrapper.attributes('tabindex')).toBe('-1');
   });

--- a/lib/useKResponsiveWindow/__tests__/useKResponsiveWindow.spec.js
+++ b/lib/useKResponsiveWindow/__tests__/useKResponsiveWindow.spec.js
@@ -4,10 +4,14 @@ import { defineComponent } from '@vue/composition-api';
 import { mount } from '@vue/test-utils';
 import useKResponsiveWindow from '..';
 
-const resizeWindow = (width, height) => {
+const resizeWindow = (width, height = 768) => {
   window.innerWidth = width;
   window.innerHeight = height;
   window.dispatchEvent(new Event('resize'));
+  setMedia({
+    width: `${width}px`,
+    height: `${height}px`,
+  });
 };
 
 const TestComponent = () =>
@@ -28,9 +32,10 @@ describe('useKResponsiveWindow composable', () => {
     });
   });
 
-  it('check if returned properties are initialized on mount', () => {
-    resizeWindow(1700, 768);
+  it('check if returned properties are initialized on mount', async () => {
+    resizeWindow(1700);
     const wrapper = mount(TestComponent());
+    await wrapper.vm.$nextTick();
     expect(wrapper.vm.windowWidth).toEqual(1700);
     expect(wrapper.vm.windowHeight).toEqual(768);
     expect(wrapper.vm.windowBreakpoint).toEqual(7);
@@ -44,121 +49,107 @@ describe('useKResponsiveWindow composable', () => {
   });
 
   describe('check if windowBreakpoint is set on width change', () => {
-    it('windowBreakpoint is 0 if width <= 480px', () => {
-      setMedia({
-        width: '400px',
-      });
+    it('windowBreakpoint is 0 if width <= 480px', async () => {
+      resizeWindow(400);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(0);
     });
 
-    it('windowBreakpoint is 1 if 480px < width <= 600px', () => {
-      setMedia({
-        width: '540px',
-      });
+    it('windowBreakpoint is 1 if 480px < width <= 600px', async () => {
+      resizeWindow(540);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(1);
     });
 
-    it('windowBreakpoint is 2 if 600px < width <= 840px', () => {
-      setMedia({
-        width: '800px',
-      });
+    it('windowBreakpoint is 2 if 600px < width <= 840px', async () => {
+      resizeWindow(800);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(2);
     });
 
-    it('windowBreakpoint is 3 if 840px < width <= 944px', () => {
-      setMedia({
-        width: '944px',
-      });
+    it('windowBreakpoint is 3 if 840px < width <= 944px', async () => {
+      resizeWindow(944);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(3);
     });
 
-    it('windowBreakpoint is 4 if 944px < width <= 1264px', () => {
-      setMedia({
-        width: '1264px',
-      });
+    it('windowBreakpoint is 4 if 944px < width <= 1264px', async () => {
+      resizeWindow(1264);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(4);
     });
 
-    it('windowBreakpoint is 5 if 1264px < width <= 1424px', () => {
-      setMedia({
-        width: '1424px',
-      });
+    it('windowBreakpoint is 5 if 1264px < width <= 1424px', async () => {
+      resizeWindow(1424);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(5);
     });
 
-    it('windowBreakpoint is 6 if 1424px < width <= 1584px', () => {
-      setMedia({
-        width: '1584px',
-      });
+    it('windowBreakpoint is 6 if 1424px < width <= 1584px', async () => {
+      resizeWindow(1584);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(6);
     });
 
-    it('windowBreakpoint is 7 if width >= 1601px', () => {
-      setMedia({
-        width: '1800px',
-      });
+    it('windowBreakpoint is 7 if width >= 1601px', async () => {
+      resizeWindow(1800);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(7);
     });
   });
 
   describe('check if windowIsSmall is set on width change', () => {
-    it('windowIsSmall is false if width > 600px', () => {
-      setMedia({
-        width: '601px',
-      });
+    it('windowIsSmall is false if width > 600px', async () => {
+      resizeWindow(601);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowIsSmall).toEqual(false);
     });
 
-    it('windowIsSmall is true if width <= 600px', () => {
-      setMedia({
-        width: '600px',
-      });
+    it('windowIsSmall is true if width <= 600px', async () => {
+      resizeWindow(600);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowIsSmall).toEqual(true);
     });
   });
 
   describe('check if windowIsMedium is set on width change', () => {
-    it('windowIsMedium is false if width <= 600px', () => {
-      setMedia({
-        width: '600px',
-      });
+    it('windowIsMedium is false if width <= 600px', async () => {
+      resizeWindow(600);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowIsMedium).toEqual(false);
     });
 
-    it('windowIsMedium is true if 600px < width >= 840px', () => {
-      setMedia({
-        width: '700px',
-      });
+    it('windowIsMedium is true if 600px < width <= 840px', async () => {
+      resizeWindow(700);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowIsMedium).toEqual(true);
     });
   });
 
   describe('check if windowIsLarge is set on width change', () => {
-    it('windowIsLarge is false if width <= 840px', () => {
-      setMedia({
-        width: '840px',
-      });
+    it('windowIsLarge is false if width <= 840px', async () => {
+      resizeWindow(840);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowIsLarge).toEqual(false);
     });
 
-    it('windowIsLarge is true if width > 840px', () => {
-      setMedia({
-        width: '841px',
-      });
+    it('windowIsLarge is true if width > 840px', async () => {
+      resizeWindow(841);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowIsLarge).toEqual(true);
     });
   });
@@ -191,27 +182,24 @@ describe('useKResponsiveWindow composable', () => {
   });
 
   describe('check if windowGutter is set on width change', () => {
-    it('windowGutter is 16px if windowIsSmall is true(width <= 600px)', () => {
-      setMedia({
-        width: '600px',
-      });
+    it('windowGutter is 16px if windowIsSmall is true(width <= 600px)', async () => {
+      resizeWindow(600);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowIsSmall).toEqual(true);
       expect(wrapper.vm.windowGutter).toEqual(16);
     });
-    it('windowGutter is 16px if windowBreakpoint < 4(width < 1264px) and smallest dimension(width, height) is smaller than 600px', () => {
-      setMedia({
-        width: '500px',
-      });
+    it('windowGutter is 16px if windowBreakpoint < 4(width < 1264px) and smallest dimension(width, height) is smaller than 600px', async () => {
+      resizeWindow(500, 500);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowBreakpoint).toEqual(1);
       expect(wrapper.vm.windowGutter).toEqual(16);
     });
-    it('windowGutter is 24px if windowIsSmall is false(width > 600px)', () => {
-      setMedia({
-        width: '841px',
-      });
+    it('windowGutter is 24px if windowIsSmall is false(width > 600px)', async () => {
+      resizeWindow(841);
       const wrapper = mount(TestComponent());
+      await wrapper.vm.$nextTick();
       expect(wrapper.vm.windowGutter).toEqual(24);
     });
   });

--- a/lib/useKResponsiveWindow/index.js
+++ b/lib/useKResponsiveWindow/index.js
@@ -1,132 +1,139 @@
-import { computed, onBeforeUnmount, onMounted, ref } from '@vue/composition-api';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from '@vue/composition-api';
 import useKWindowDimensions from '../useKWindowDimensions';
 import MediaQuery from './MediaQuery';
+
+/** Global variables */
+const { windowWidth, windowHeight } = useKWindowDimensions();
+
+/*
+  Implementing breakpoint controlled by watchers to work around
+  optimization issue: https://github.com/vuejs/vue/issues/10344
+  If that issue ever gets addressed, we should make them computed props.
+*/
+const windowBreakpoint = ref(null);
+const windowGutter = ref(16);
+
+const windowIsPortrait = ref(false);
+const windowIsLandscape = ref(false);
+const windowIsShort = ref(false);
+
+const windowIsLarge = computed(() => windowBreakpoint.value > 2);
+const windowIsMedium = computed(() => windowBreakpoint.value === 2);
+const windowIsSmall = computed(() => windowBreakpoint.value < 2);
+
+const usageCount = ref(0);
+
+const orientationQuery = new MediaQuery('screen and (orientation: portrait)', event => {
+  updateOrientation(event.matches);
+});
+const heightQuery = new MediaQuery('screen and (max-height: 600px)', event => {
+  windowIsShort.value = event.matches;
+});
+
+/**
+ * Initialize media query window properties
+ */
+function initProps() {
+  orientationQuery.eventHandler(orientationQuery.mediaQueryList);
+  heightQuery.eventHandler(heightQuery.mediaQueryList);
+};
+
+initProps();
+
+/**
+ * Start listening to media query changes
+ */
+function startListening() {
+  orientationQuery.startListening();
+  heightQuery.startListening();
+};
+
+/**
+ * Stop listening to media query changes
+ */
+function stopListening() {
+  orientationQuery.stopListening();
+  heightQuery.stopListening();
+};
+
+/**
+ * Update window breakpoint
+ */
+function updateBreakPoint() {
+  const SCROLL_BAR = 16;
+  const widthBreakpoints = [
+    480, 600, 840, 960 - SCROLL_BAR, 1280 - SCROLL_BAR, 1440 - SCROLL_BAR, 1600 - SCROLL_BAR,
+  ];
+
+  // if windowWidth is null (upon initialization), breakpoint = 0
+  const firstMatchingWidthIndex = windowWidth.value
+    ? widthBreakpoints.findIndex(matchingWidth => windowWidth.value < matchingWidth)
+    : 0;
+
+  // if windowWidth > 1585, breakpoint = 7
+  const matchingBreakpoint = firstMatchingWidthIndex >= 0
+    ? firstMatchingWidthIndex
+    : 7;
+
+  windowBreakpoint.value = matchingBreakpoint;
+  updateGutter();
+};
+
+watch([windowWidth, windowHeight], updateBreakPoint);
+
+/**
+ * Update window gutter
+ */
+function updateGutter() {
+  if (windowIsSmall.value || smallestWindowDimensionIsLessThan(600)) {
+    windowGutter.value = 16;
+  } else {
+    windowGutter.value = 24;
+  }
+};
+
+/**
+ * Check if the smallest window dimension(width or height) is smaller than the specified dimension
+ * @param {Number} dimension in px
+ * @returns {Boolean}
+ */
+function smallestWindowDimensionIsLessThan(dimension) {
+  return (
+    windowBreakpoint.value < 4 && Math.min(windowWidth.value, windowHeight.value) < dimension
+  );
+};
+
+/**
+ * Update window orientation
+ * @param {Boolean} portrait
+ */
+function updateOrientation(portrait) {
+  windowIsPortrait.value = portrait;
+  windowIsLandscape.value = !windowIsPortrait.value;
+};
 
 /**
  * Export window properties
  * @returns {Object} Object with window properties
  */
 export default function useKResponsiveWindow() {
-  /** Window properties */
-  const { windowWidth, windowHeight } = useKWindowDimensions();
-  const windowBreakpoint = ref(null);
-  const windowIsPortrait = ref(false);
-  const windowIsLandscape = ref(false);
-  const windowGutter = ref(16);
-  const windowIsShort = ref(false);
-  const windowIsLarge = computed(() => windowBreakpoint.value > 2);
-  const windowIsMedium = computed(() => windowBreakpoint.value === 2);
-  const windowIsSmall = computed(() => windowBreakpoint.value < 2);
-
-  const orientationQuery = new MediaQuery('screen and (orientation: portrait)', event => {
-    updateOrientation(event.matches);
-    updateGutter();
-  });
-
-  const heightQuery = new MediaQuery('screen and (max-height: 600px)', event => {
-    windowIsShort.value = event.matches;
-  });
-
-  /**
-   * Generate width media queries
-   */
-  const widthQueries = (() => {
-    const SCROLL_BAR = 16;
-    const queries = [
-      '(max-width: 480px)',
-      '(max-width: 600px)',
-      '(max-width: 840px)',
-      `(max-width: ${960 - SCROLL_BAR}px)`,
-      `(max-width: ${1280 - SCROLL_BAR}px)`,
-      `(max-width: ${1440 - SCROLL_BAR}px)`,
-      `(max-width: ${1600 - SCROLL_BAR}px)`,
-      '(min-width: 1601px)',
-    ];
-
-    return queries.map(
-      (query, index) =>
-        new MediaQuery(`screen and ${query}`, () => {
-          windowBreakpoint.value = index;
-          updateGutter();
-        })
-    );
-  })();
-
-  /**
-   * Initialize window properties
-   */
-  const initProps = () => {
-    orientationQuery.eventHandler(orientationQuery.mediaQueryList);
-    heightQuery.eventHandler(heightQuery.mediaQueryList);
-    for (const widthQuery of widthQueries) {
-      if (widthQuery.mediaQueryList.matches) {
-        widthQuery.eventHandler(widthQuery.mediaQueryList);
-        break;
-      }
-    }
-  };
-
-  /**
-   * Start listening to media query changes
-   */
-  const startListening = () => {
-    orientationQuery.startListening();
-    heightQuery.startListening();
-    for (const widthQuery of widthQueries) {
-      widthQuery.startListening();
-    }
-  };
-
-  /**
-   * Stop listening to media query changes
-   */
-  const stopListening = () => {
-    orientationQuery.stopListening();
-    heightQuery.stopListening();
-    for (const widthQuery of widthQueries) {
-      widthQuery.stopListening();
-    }
-  };
-
-  /**
-   * Update window gutter
-   */
-  const updateGutter = () => {
-    if (windowIsSmall.value) {
-      windowGutter.value = 16;
-    } else if (smallestWindowDimensionIsLessThan(600)) {
-      windowGutter.value = 16;
-    } else {
-      windowGutter.value = 24;
-    }
-  };
-
-  /**
-   * Check if the smallest window dimension(width or height) is smaller than the specified dimension
-   * @param {Number} dimension in px
-   * @returns {Boolean}
-   */
-  const smallestWindowDimensionIsLessThan = dimension => {
-    return (
-      windowBreakpoint.value < 4 && Math.min(windowWidth.value, windowHeight.value) < dimension
-    );
-  };
-
-  /**
-   * Update window orientation
-   * @param {Boolean} portrait
-   */
-  const updateOrientation = portrait => {
-    windowIsPortrait.value = portrait;
-    windowIsLandscape.value = !windowIsPortrait.value;
-  };
+  // Do this to ensure that we call the useKWindowDimension lifecycle hooks
+  useKWindowDimensions();
 
   onMounted(() => {
-    initProps();
-    startListening();
+    if (usageCount.value === 0) {
+      // No component is currently using this, so we need to initialize
+      startListening();
+    }
+    usageCount.value++;
   });
+
   onBeforeUnmount(() => {
-    stopListening();
+    usageCount.value--;
+    if (usageCount.value === 0) {
+      // No component is now using this, so we can clean up
+      stopListening();
+    }
   });
 
   return {

--- a/lib/useKResponsiveWindow/index.js
+++ b/lib/useKResponsiveWindow/index.js
@@ -36,7 +36,7 @@ const heightQuery = new MediaQuery('screen and (max-height: 600px)', event => {
 function initProps() {
   orientationQuery.eventHandler(orientationQuery.mediaQueryList);
   heightQuery.eventHandler(heightQuery.mediaQueryList);
-};
+}
 
 initProps();
 
@@ -46,7 +46,7 @@ initProps();
 function startListening() {
   orientationQuery.startListening();
   heightQuery.startListening();
-};
+}
 
 /**
  * Stop listening to media query changes
@@ -54,7 +54,7 @@ function startListening() {
 function stopListening() {
   orientationQuery.stopListening();
   heightQuery.stopListening();
-};
+}
 
 /**
  * Update window breakpoint
@@ -62,22 +62,26 @@ function stopListening() {
 function updateBreakPoint() {
   const SCROLL_BAR = 16;
   const widthBreakpoints = [
-    480, 600, 840, 960 - SCROLL_BAR, 1280 - SCROLL_BAR, 1440 - SCROLL_BAR, 1600 - SCROLL_BAR,
+    480,
+    600,
+    840,
+    960 - SCROLL_BAR,
+    1280 - SCROLL_BAR,
+    1440 - SCROLL_BAR,
+    1600 - SCROLL_BAR,
   ];
 
   // if windowWidth is null (upon initialization), breakpoint = 0
   const firstMatchingWidthIndex = windowWidth.value
-    ? widthBreakpoints.findIndex(matchingWidth => windowWidth.value < matchingWidth)
+    ? widthBreakpoints.findIndex(matchingWidth => windowWidth.value <= matchingWidth)
     : 0;
 
   // if windowWidth > 1585, breakpoint = 7
-  const matchingBreakpoint = firstMatchingWidthIndex >= 0
-    ? firstMatchingWidthIndex
-    : 7;
+  const matchingBreakpoint = firstMatchingWidthIndex >= 0 ? firstMatchingWidthIndex : 7;
 
   windowBreakpoint.value = matchingBreakpoint;
   updateGutter();
-};
+}
 
 watch([windowWidth, windowHeight], updateBreakPoint);
 
@@ -90,7 +94,7 @@ function updateGutter() {
   } else {
     windowGutter.value = 24;
   }
-};
+}
 
 /**
  * Check if the smallest window dimension(width or height) is smaller than the specified dimension
@@ -98,10 +102,8 @@ function updateGutter() {
  * @returns {Boolean}
  */
 function smallestWindowDimensionIsLessThan(dimension) {
-  return (
-    windowBreakpoint.value < 4 && Math.min(windowWidth.value, windowHeight.value) < dimension
-  );
-};
+  return windowBreakpoint.value < 4 && Math.min(windowWidth.value, windowHeight.value) < dimension;
+}
 
 /**
  * Update window orientation
@@ -110,7 +112,7 @@ function smallestWindowDimensionIsLessThan(dimension) {
 function updateOrientation(portrait) {
   windowIsPortrait.value = portrait;
   windowIsLandscape.value = !windowIsPortrait.value;
-};
+}
 
 /**
  * Export window properties

--- a/lib/useKResponsiveWindow/index.js
+++ b/lib/useKResponsiveWindow/index.js
@@ -1,10 +1,8 @@
 import { computed, onBeforeUnmount, onMounted, ref, watch } from '@vue/composition-api';
-import useKWindowDimensions from '../useKWindowDimensions';
+import useKWindowDimensions, { windowWidth, windowHeight } from '../useKWindowDimensions';
 import MediaQuery from './MediaQuery';
 
 /** Global variables */
-const { windowWidth, windowHeight } = useKWindowDimensions();
-
 /*
   Implementing breakpoint controlled by watchers to work around
   optimization issue: https://github.com/vuejs/vue/issues/10344
@@ -34,8 +32,10 @@ const heightQuery = new MediaQuery('screen and (max-height: 600px)', event => {
  * Initialize media query window properties
  */
 function initProps() {
-  orientationQuery.eventHandler(orientationQuery.mediaQueryList);
-  heightQuery.eventHandler(heightQuery.mediaQueryList);
+  if (window.matchMedia) {
+    orientationQuery.eventHandler(orientationQuery.mediaQueryList);
+    heightQuery.eventHandler(heightQuery.mediaQueryList);
+  }
 }
 
 initProps();

--- a/lib/useKWindowDimensions.js
+++ b/lib/useKWindowDimensions.js
@@ -2,8 +2,8 @@ import './composition-api'; //Due to @vue/composition-api shortcomings, add plug
 import { onMounted, onUnmounted, ref } from '@vue/composition-api';
 
 /** Global variables */
-const windowWidth = ref(null);
-const windowHeight = ref(null);
+export const windowWidth = ref(null);
+export const windowHeight = ref(null);
 const isListenerAdded = ref(false);
 const usageCount = ref(0);
 


### PR DESCRIPTION
## Description
this PR fixes a bug observed during QA review of Kolibri in `Learn` > `Library` - in certain cases, rapidly resizing the browser window would cause the sidepanel to automatically display when the screen was small, behavior we did not expect nor want at that screen size. beneath the surface, the components were receiving conflicting information about the current screen size because `useKResponsiveWindow` was not updating in the way we expected. 

to address those issues, this PR introduces changes to the scope of variables within `useKResponsiveWindow` and to the way the composable uses `useKWindowDimensions`. 

#### Issue addressed
[reported as a Kolibri issue ](https://github.com/learningequality/kolibri/issues/11212)

### Before/after screenshots
BEFORE, courtesy of @pcenov:

https://github.com/learningequality/kolibri/assets/79847249/0b63d243-e140-4830-b9b9-0a915bddfd61


AFTER (just a boring video of me resizing successfully):

https://github.com/learningequality/kolibri-design-system/assets/43046460/b67220e5-2fcb-45b1-94bf-8cbe29866df3



## Steps to test

Please see reviewer guidance provided in https://github.com/learningequality/kolibri/pull/11315 & test behavior of this change on that kolibri branch

## Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
this doesn't necessarily introduce tech debt, but has revealed some existing underlying issues regarding the functioning of `KResponsiveWindowMixin` (which is still in use in many places), as it is likely attaching an excessive amount of listeners which could have a performance impact. there is an issue forthcoming for retrofitting the mixin to use the composable updated here to reduce the amount of unnecessary and sometimes detrimental extra listeners.

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] ~Critical and brittle code paths are covered by unit tests~
- [x] The change has been added to the `changelog`

## Reviewer guidance

- [ ] Is the code clean and well-commented?
- [ ] Are there tests?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
