### PR TITLE
Warning when using `KResponsiveWindow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,18 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 <!-- All new changelog items should come here -->
 
-## Version 2.0.0
+- [#463]
+  - **Description:** Add deprecation warning for KResponsiveWindowMixin
+  - **Products impact:** updated API
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/459
+  - **Components:** KResponsiveWindowMixin
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** useKResponsiveWindow composable should be used instead
+
+[#463]: https://github.com/learningequality/kolibri-design-system/pull/463
+
+## Version 2.0.0-beta0 (released - do not add new items)
 
 - [#462]
   - **Description:** Fix internal links in design system documentation

--- a/lib/KResponsiveWindowMixin.js
+++ b/lib/KResponsiveWindowMixin.js
@@ -186,7 +186,7 @@ export default {
     },
   },
   mounted() {
-    console.warn('Please Use useKResponsiveWindow instead of KResponsiveWindow Mixin');
+    console.warn(`Please use 'useKResponsiveWindow' composable instead of 'KResponsiveWindow' mixin`);
     addWindowListener(this._updateWindow);
   },
   beforeDestroy() {

--- a/lib/KResponsiveWindowMixin.js
+++ b/lib/KResponsiveWindowMixin.js
@@ -186,6 +186,7 @@ export default {
     },
   },
   mounted() {
+    // prettier-ignore
     console.warn(`Please use 'useKResponsiveWindow' composable instead of 'KResponsiveWindow' mixin`);
     addWindowListener(this._updateWindow);
   },

--- a/lib/KResponsiveWindowMixin.js
+++ b/lib/KResponsiveWindowMixin.js
@@ -170,7 +170,6 @@ export default {
       } else {
         this.windowBreakpoint = 7;
       }
-      console.log('_updateBreakpoint() called. windowBreakpoint:');
     },
     _updateOrientation() {
       this.windowIsPortrait = this.windowWidth < this.windowHeight;

--- a/lib/KResponsiveWindowMixin.js
+++ b/lib/KResponsiveWindowMixin.js
@@ -65,7 +65,6 @@ const windowListeners = [];
 /* methods */
 
 function windowMetrics() {
-  console.warn('Please Use useKResponsiveWindow instead of KResponsiveWindow Mixin');
   return {
     width: window.innerWidth,
     height: window.innerHeight,
@@ -187,6 +186,7 @@ export default {
     },
   },
   mounted() {
+    console.warn('Please Use useKResponsiveWindow instead of KResponsiveWindow Mixin');
     addWindowListener(this._updateWindow);
   },
   beforeDestroy() {

--- a/lib/KResponsiveWindowMixin.js
+++ b/lib/KResponsiveWindowMixin.js
@@ -65,6 +65,7 @@ const windowListeners = [];
 /* methods */
 
 function windowMetrics() {
+  console.warn('Please Use useKResponsiveWindow instead of KResponsiveWindow Mixin');
   return {
     width: window.innerWidth,
     height: window.innerHeight,
@@ -169,6 +170,7 @@ export default {
       } else {
         this.windowBreakpoint = 7;
       }
+      console.log('_updateBreakpoint() called. windowBreakpoint:');
     },
     _updateOrientation() {
       this.windowIsPortrait = this.windowWidth < this.windowHeight;


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This PR consoles a warning when `KResponsiveWindow` mixin is used instead of `useKResponsive`
#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #459 

### Before/after screenshots
<!-- Insert images here if applicable -->
<img width="915" alt="Screenshot 2023-10-07 at 12 52 08 AM" src="https://github.com/learningequality/kolibri-design-system/assets/114716075/ff2b47ad-2896-4e95-958d-db3738c46246">


- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change has been added to the `changelog`

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
