### PR TITLE
Match media testing guard and bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 <!-- All new changelog items should come here -->
 
+- [#470]
+  - **Description:** Fix bug and add test guard in MediaQuery implementation
+  - **Products impact:** none
+  - **Addresses:** -
+  - **Components:** none
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -
+
+[#470]: https://github.com/learningequality/kolibri-design-system/pull/470
+
 - [#469]
   - **Description:** Throttle the resize listener handler
   - **Products impact:** updated API

--- a/lib/useKResponsiveWindow/MediaQuery.js
+++ b/lib/useKResponsiveWindow/MediaQuery.js
@@ -10,13 +10,17 @@ export default class MediaQuery {
   constructor(query, eventHandler) {
     this.query = query;
     this.eventHandler = eventHandler;
+    this._mediaQueryList = null;
   }
 
   /**
    * @returns {Object} Media query list
    */
   get mediaQueryList() {
-    return window.matchMedia(this.query);
+    if (!this._mediaQueryList) {
+      this._mediaQueryList = window.matchMedia(this.query);
+    }
+    return this._mediaQueryList;
   }
 
   /**

--- a/lib/useKResponsiveWindow/MediaQuery.js
+++ b/lib/useKResponsiveWindow/MediaQuery.js
@@ -32,8 +32,8 @@ export default class MediaQuery {
    * @returns {Object} Containing mediaQueryList, eventHandler, and stopListening
    */
   startListening() {
-    //Prevent function execution if Nuxt is server side rendering
-    if (this.isNuxtServerSideRendering()) {
+    // Prevent function execution if Nuxt is server side rendering
+    if (this.isNuxtServerSideRendering() || !window.matchMedia) {
       return;
     }
 
@@ -48,6 +48,10 @@ export default class MediaQuery {
    * Stop listening for media query events
    */
   stopListening() {
+    // Prevent function execution if Nuxt is server side rendering
+    if (this.isNuxtServerSideRendering() || !window.matchMedia) {
+      return;
+    }
     if (this.mediaQueryList.removeEventListener) {
       this.mediaQueryList.removeEventListener('change', this.eventHandler);
     } else {


### PR DESCRIPTION
## Description
* Adds an additional guard to prevent attempting to access the window.matchMedia API when it is in an environment that it is not supported
* Fixes a hitherto unnoticed bug, whereby the use of a JS getter to return the value of window.matchMedia meant that removing event listeners was doing nothing, as the getter was returning a new instance each time (and so was not unbinding the listener from the instance that it had actually been bound to).
* Does this by caching the window.matchMedia result call, to minimize code changes and to continue to allow delay of instantiation of the mediaQueryList object.

#### Issue addressed
Fixes failing tests seen in develop on Kolibri
Fixes unreported bug that would stop listeners from being unbound

## Testing checklist
- [x] The change has been added to the `changelog`

