### PR TITLE
use requestAnimationFrame instead of setTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 2.0.0
 
+- [#491]
+  - **Description:** Replaced setTimeout with requestAnimationFrames in tests for useKWindowDimensions and useKResponsiveWindow
+  - **Products impact:** -
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/480
+  - **Components:** none
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -
+
+[#491]: [https://github.com/learningequality/kolibri-design-system/pull/491]
+
 - [#478]
   - **Description:** Changed _dev-only to dev-only
   - **Products impact:** -

--- a/lib/__tests__/useKWindowDimensions.spec.js
+++ b/lib/__tests__/useKWindowDimensions.spec.js
@@ -22,11 +22,13 @@ describe('useKWindowDimensions composable', () => {
 
   it('check if windowWidth and windowHeight properties are initialized on mount', () => {
     const wrapper = mount(TestComponent);
-    // Wait for the throttling delay
-    setTimeout(() => {
+    let animationFrameId;
+    const checkWindowDimensions = () => {
       expect(wrapper.vm.windowWidth).toEqual(expect.any(Number));
       expect(wrapper.vm.windowHeight).toEqual(expect.any(Number));
-    }, 20);
+      animationFrameId = cancelAnimationFrame(animationFrameId);
+    };
+    animationFrameId = requestAnimationFrame(checkWindowDimensions);
   });
 
   it('check if windowWidth and windowHeight change when window is resized', () => {
@@ -34,10 +36,12 @@ describe('useKWindowDimensions composable', () => {
     expect(wrapper.vm.windowWidth).not.toEqual(600);
     expect(wrapper.vm.windowHeight).not.toEqual(400);
     resizeWindow(600, 400);
-    // Wait for the throttling delay
-    setTimeout(() => {
+    let animationFrameId;
+    const checkUpdatedWindowDimensions = () => {
       expect(wrapper.vm.windowWidth).toEqual(600);
       expect(wrapper.vm.windowHeight).toEqual(400);
-    }, 20);
+      animationFrameId = cancelAnimationFrame(animationFrameId);
+    };
+    animationFrameId = requestAnimationFrame(checkUpdatedWindowDimensions);
   });
 });

--- a/lib/useKResponsiveWindow/__tests__/useKResponsiveWindow.spec.js
+++ b/lib/useKResponsiveWindow/__tests__/useKResponsiveWindow.spec.js
@@ -36,8 +36,8 @@ describe('useKResponsiveWindow composable', () => {
     resizeWindow(1700);
     const wrapper = mount(TestComponent());
     await wrapper.vm.$nextTick();
-    // Wait for the throttling delay
-    setTimeout(() => {
+    let animationFrameId;
+    const checkWindowProperties = () => {
       expect(wrapper.vm.windowWidth).toEqual(1700);
       expect(wrapper.vm.windowHeight).toEqual(768);
       expect(wrapper.vm.windowBreakpoint).toEqual(7);
@@ -48,7 +48,9 @@ describe('useKResponsiveWindow composable', () => {
       expect(wrapper.vm.windowIsLarge).toEqual(true);
       expect(wrapper.vm.windowIsMedium).toEqual(false);
       expect(wrapper.vm.windowIsSmall).toEqual(false);
-    }, 20);
+      animationFrameId = cancelAnimationFrame(animationFrameId);
+    };
+    animationFrameId = requestAnimationFrame(checkWindowProperties);
   });
 
   describe('check if windowBreakpoint is set on width change', () => {
@@ -56,80 +58,96 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(400);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(0);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 1 if 480px < width <= 600px', async () => {
       resizeWindow(540);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(1);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 2 if 600px < width <= 840px', async () => {
       resizeWindow(800);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setInterval(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(2);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 3 if 840px < width <= 944px', async () => {
       resizeWindow(944);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(3);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 4 if 944px < width <= 1264px', async () => {
       resizeWindow(1264);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(4);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 5 if 1264px < width <= 1424px', async () => {
       resizeWindow(1424);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(5);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 6 if 1424px < width <= 1584px', async () => {
       resizeWindow(1584);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(6);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 7 if width >= 1601px', async () => {
       resizeWindow(1800);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(7);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
     });
   });
 
@@ -138,10 +156,12 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(601);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowIsSmall = () => {
         expect(wrapper.vm.windowIsSmall).toEqual(false);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowIsSmall);
     });
 
     it('windowIsSmall is true if width <= 600px', async () => {
@@ -164,10 +184,12 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(700);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowIsMedium = () => {
         expect(wrapper.vm.windowIsMedium).toEqual(true);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowIsMedium);
     });
   });
 
@@ -183,10 +205,12 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(841);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowIsLarge = () => {
         expect(wrapper.vm.windowIsLarge).toEqual(true);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowIsLarge);
     });
   });
 
@@ -229,20 +253,24 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(500, 500);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowProperties = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(1);
         expect(wrapper.vm.windowGutter).toEqual(16);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowProperties);
     });
     it('windowGutter is 24px if windowIsSmall is false(width > 600px)', async () => {
       resizeWindow(841);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      // Wait for the throttling delay
-      setTimeout(() => {
+      let animationFrameId;
+      const checkWindowGutter = () => {
         expect(wrapper.vm.windowGutter).toEqual(24);
-      }, 20);
+        animationFrameId = cancelAnimationFrame(animationFrameId);
+      };
+      animationFrameId = requestAnimationFrame(checkWindowGutter);
     });
   });
 });


### PR DESCRIPTION
## Description
This PR replaces the use of setTimeout() in unit tests for useKWindowDimensions and useKResponsiveWindow with the use of requestAnimationFrame to eliminate test flakiness caused by inconsistency in setTimeout execution.

#### Issue addressed

Addresses #480 

## Changelog

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- [#491]
  - **Description:** Replaced setTimeout with requestAnimationFrames in tests for useKWindowDimensions and useKResponsiveWindow
  - **Products impact:** -
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/480
  - **Components:** none
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#491]: [https://github.com/learningequality/kolibri-design-system/pull/491]

## Steps to test

1. in `/kolibri-design-system/lib` run `yarn test` 


### At a high level, how did you implement this?
Replace setTimeout with requestAnimationFrames in related tests

### Does this introduce any tech-debt items?
no

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
requestAnimationFrame eliminates the test flakiness because it enforces the test check to await the next window paint, as opposed to relying on the window paint to potentially happen before the setTimeout is triggered. 
