### PR TITLE
feat: add `onError` handler for `KImg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Upcoming version
 
+- [#502]
+  - **Description:** Add dispatching of 'error' event when failed to load image for 'KImg'
+  - **Products impact:** new API
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/372
+  - **Components:** KImg
+  - **Breaking:** no
+  - **Impacts a11y:** yes  
+  - **Guidance:** Allows the consumer to hook into the lifecycle of 'KImg' and handle the cases when the image fails to load
+
+[#502]: https://github.com/learningequality/kolibri-design-system/pull/502
+
 - [#500]
   - **Description:** Upgrades vue-router dependency
   - **Products impact:** Dependency upgrade

--- a/lib/KImg.vue
+++ b/lib/KImg.vue
@@ -155,8 +155,7 @@
       },
       onError(event) {
         /**
-         * Emitted when the image fails to load
-         * @payload {Event} event The DOM event that triggered the error
+         * Emitted when the image fails to load. The DOM event that triggered the error is available in the payload.
          */
         this.$emit('error', event);
       },

--- a/lib/KImg.vue
+++ b/lib/KImg.vue
@@ -5,6 +5,7 @@
       :src="src"
       :alt="alternateText"
       :style="styleObject"
+      @error="onError"
     >
     <slot></slot>
   </div>
@@ -81,6 +82,14 @@
         default: undefined,
       },
     },
+    emits: {
+      /**
+       * Emitted when the image fails to load
+       * @param {Event} event
+       * @returns {true} Denotes that the validation has passed
+       */
+      error: (event) => true,
+    },
     data() {
       return {
         styleObject: {
@@ -152,6 +161,9 @@
           }
         }
       },
+      onError (event) {
+        this.$emit('error', event);
+      }
     },
   };
 

--- a/lib/KImg.vue
+++ b/lib/KImg.vue
@@ -87,7 +87,8 @@
        * Emitted when the image fails to load
        * @param {Event} event
        * @returns {true} Denotes that the validation has passed
-       */
+      */
+      // eslint-disable-next-line no-unused-vars
       error: (event) => true,
     },
     data() {

--- a/lib/KImg.vue
+++ b/lib/KImg.vue
@@ -87,9 +87,9 @@
        * Emitted when the image fails to load
        * @param {Event} event
        * @returns {true} Denotes that the validation has passed
-      */
+       */
       // eslint-disable-next-line no-unused-vars
-      error: (event) => true,
+      error: event => true,
     },
     data() {
       return {
@@ -162,9 +162,9 @@
           }
         }
       },
-      onError (event) {
+      onError(event) {
         this.$emit('error', event);
-      }
+      },
     },
   };
 


### PR DESCRIPTION
## Description
`KImg` now emits the 'error' event when an error is encountered while loading the image specified in src with the `event` parameter that can be used by the clients. 

#### Issue addressed
Fixes #372 

## Changelog

- [#502]
  - **Description:** Add dispatching of 'error' event when failed to load image for 'KImg'
  - **Products impact:** new API
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/372
  - **Components:** KImg
  - **Breaking:** no
  - **Impacts a11y:** yes  
  - **Guidance:** Allows the consumer to hook into the lifecycle of 'KImg' and handle the cases when the image fails to load

[#502]: https://github.com/learningequality/kolibri-design-system/pull/502

### At a high level, how did you implement this?
Used the `@error` provided by `Vue` and declared a new event `error`

### Does this introduce any tech-debt items?
No

## Testing checklist
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [X] Critical and brittle code paths are covered by unit tests
- [X] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
