### PR TITLE
/deep/ to ::v-deep

### DIFF
--- a/.htmlhintrc.js
+++ b/.htmlhintrc.js
@@ -1,1 +1,0 @@
-module.exports = require('kolibri-tools/.htmlhintrc');

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,1 +1,5 @@
-module.exports = require('kolibri-tools/.stylelintrc');
+const stylelintConfig = require('kolibri-format/.stylelintrc');
+
+stylelintConfig['rules']['selector-pseudo-element-no-unknown'] = [true, { ignorePseudoElements: ['v-deep'] }];
+
+module.exports = stylelintConfig;

--- a/docs/pages/icons/index.vue
+++ b/docs/pages/icons/index.vue
@@ -226,7 +226,7 @@
 <style lang="scss" scoped>
 
   // hack to simulate bad behavior
-  /deep/ .wrong-colors svg {
+  ::v-deep .wrong-colors svg {
     fill: blue !important;
   }
 

--- a/lib/KDateRange/KDateInput.vue
+++ b/lib/KDateRange/KDateInput.vue
@@ -141,7 +141,7 @@
   }
 
   /* HIDES BROWSER NATIVE DATEPICKER */
-  /deep/ input[type='date'] {
+  ::v-deep input[type='date'] {
     width: 150px;
     text-align: left;
     text-transform: uppercase !important;

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -1179,10 +1179,6 @@
     vertical-align: bottom;
   }
 
-  .ui-select-disabled /deep/ .ui-select__label-text.is-inline {
-    cursor: default;
-  }
-
   /* stylelint-disable csstree/validator */
 
   .ui-select-disabled {
@@ -1192,9 +1188,5 @@
   }
 
   /* stylelint-enable */
-
-  /deep/ .ui-select__display-value {
-    line-height: 1.3;
-  }
 
 </style>


### PR DESCRIPTION
## Description
* Removes two unused /deep/ selectors in KSelect that were referencing non-existent classes
* Replaces the two remaining /deep/ selectors used in KDS with `::v-deep` https://vue-loader.vuejs.org/guide/scoped-css.html#deep-selectors
* This behaves identically, but has the advantage of not breaking future versions of Sass (i.e. Dart Sass instead of Node Sass, which is deprecated)

#### Issue addressed
This is required as part of an extended yak shave in order to ultimately upgrade to newer NodeJS versions, where building Node Sass becomes increasingly more challenging.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Remove use of /deep/ in favour of ::v-deep
  - **Products impact:** none
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Ensure that KSelect still functions as intended when disabled.
2. Ensure that the date input styling in the docs page for the date picker is still correct
3. Ensure that the Icon is still blue on the icons page showing what not to do

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
