### PR TITLE
Added custom implementation of GH Action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,23 +1,34 @@
-name: Changelog is updated
-
-on: [pull_request]
-
-permissions:
-  pull-requests: read
-
+name: Check Changelog.md
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   check-changelog:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ankitjain28may/list-files-in-pr@v1.0
-        id: list-files
-        with:
-          githubToken: ${{ github.token }}
-          outputFormat: 'space-delimited'
-      - run: |
-          for file in ${{ steps.list-files.outputs.pullRequestFiles }}; do
-            if [ $file = "CHANGELOG.md" ]; then
-              exit 0
-            fi
-          done
-          exit 1
+     runs-on: ubuntu-latest
+     permissions: write-all
+     steps:
+          - uses: actions/checkout@v2
+          - name: Fetch changed files
+            id: fetch-changed-files
+            run: |
+              response=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+               repos/${owner}/${REPO}/pulls/${PULL_NUMBER}/files)
+              echo "$response" | jq '.' > response.json
+              
+          
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              owner: ${{ github.repository_owner }}
+              REPO: ${{ github.event.repository.name }}
+              PULL_NUMBER: ${{ github.event.pull_request.number }}
+          - name: Check if Changelog.md is changed
+            run: |
+              if [[ $(jq '.[].filename' response.json) == *"CHANGELOG.md"* ]]; then
+                echo "Changelog.md is changed"
+                exit 0
+              else
+                echo "Changelog.md is not changed"
+                exit 1
+              fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 Changelog is rather internal in nature. See release notes for the public overview and guidelines. Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
 ## Upcoming version
+
 - [#505]
   - **Description:**  Added custom implementation of GH action that checks that changelog is updated in each pull request
-  - **Products impact:** 
-  - **Addresses:** -
+  - **Products impact:** none
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/481
   - **Components:** -
   - **Breaking:** 
   - **Impacts a11y:** 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Changelog is rather internal in nature. See release notes for the public overview and guidelines. Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
 ## Upcoming version
+- [#504]
+  - **Description:**  Added custom implementation of GH action that checks that changelog is updated in each pull request
+  - **Products impact:** 
+  - **Addresses:** -
+  - **Components:** -
+  - **Breaking:** 
+  - **Impacts a11y:** 
+  - **Guidance:** -
+
+[#504]: https://github.com/learningequality/kolibri-design-system/pull/504
 
 - [#500]
   - **Description:** Upgrades vue-router dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Changelog is rather internal in nature. See release notes for the public overview and guidelines. Releases are recorded as git tags in the [Github releases](https://github.com/learningequality/kolibri-design-system/releases) page.
 
 ## Upcoming version
-- [#504]
+- [#505]
   - **Description:**  Added custom implementation of GH action that checks that changelog is updated in each pull request
   - **Products impact:** 
   - **Addresses:** -
@@ -12,7 +12,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Impacts a11y:** 
   - **Guidance:** -
 
-[#504]: https://github.com/learningequality/kolibri-design-system/pull/504
+[#505]: https://github.com/learningequality/kolibri-design-system/pull/505
 
 - [#500]
   - **Description:** Upgrades vue-router dependency


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
- [X] Added custom implementation of Github Action to check whether CHANGELOG.md has been updated in the created Pull request or not
- [X] Removed Github 3rd party application, used official Github REST APIs for the implementation

#### Issue addressed
#481 


### Before/after screenshots
<!-- Insert images here if applicable -->

## Changelog

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- [#505]
  - **Description:**  Added custom implementation of GH action that checks that changelog is updated in each pull request
  - **Products impact:** 
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** 
  - **Impacts a11y:** 
  - **Guidance:** -

[#505]: https://github.com/learningequality/kolibri-design-system/pull/505



