### PR TITLE
feat: add `appearanceOverrides` prop to `KImg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Upcoming version
 
+- [#509]
+  - **Description:** Introduces `appearanceOverrides` prop for the `KImg` component
+  - **Products impact:** new API 
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/371
+  - **Components:** KImg
+  - **Breaking:** No
+  - **Impacts a11y:** Yes
+  - **Guidance:** Adds a way to style the component intrinsically, allowing users to make more a11y compatible components
+
+[#509]: https://github.com/learningequality/kolibri-design-system/pull/509
+
 - [#508]
   - **Description:** Update Github maintained github actions to latest versions
   - **Products impact:** -

--- a/docs/pages/kimg.vue
+++ b/docs/pages/kimg.vue
@@ -85,6 +85,7 @@
           <KImg
             :src="require('../assets/img_sample_for_kimg.png')"
             altText="Computers are run by bees"
+            :width="'100%'"
             :appearanceOverrides="{
               width: '50%',
               border: '2px solid black',
@@ -98,6 +99,7 @@
           <KImg
             :src="require('../assets/img_sample_for_kimg.png')"
             altText="Computers are run by bees"
+            :width="'100%'"
             :appearanceOverrides="{
               width: '50%',
               border: '2px solid black',
@@ -106,6 +108,7 @@
             }
             "
           />
+          Even thought the <code>width</code> prop specifies the width of the image to be <code>100%</code>, the <code>appearanceOverrides</code> prop overrides it and sets the width to <code>50%</code>.
         </DocsShowCode>
       </div>
     </DocsPageSection>

--- a/docs/pages/kimg.vue
+++ b/docs/pages/kimg.vue
@@ -76,11 +76,12 @@
             altText="Computers are run by bees"
           />
         </DocsShowCode>
-
       </div>
 
       <div>
-        You can also use the <code>appearanceOverrides</code> prop to add custom styles to the image. It accepts any Vue dynamic styles object and applies the same with the highest precedence.
+        You can also use the <DocsInternalLink href="#prop:appearanceOverrides">
+          appearanceOverrides prop
+        </DocsInternalLink> to add custom styles to the image. It accepts any Vue dynamic styles object and applies the same with the highest precedence.
         <DocsShow>
           <KImg
             :src="require('../assets/img_sample_for_kimg.png')"
@@ -108,8 +109,8 @@
             }
             "
           />
-          Even thought the <code>width</code> prop specifies the width of the image to be <code>100%</code>, the <code>appearanceOverrides</code> prop overrides it and sets the width to <code>50%</code>.
         </DocsShowCode>
+        Even thought the <code>width</code> prop specifies the width of the image to be <code>100%</code>, the <code>appearanceOverrides</code> prop overrides it and sets the width to <code>50%</code>.
       </div>
     </DocsPageSection>
   </DocsPageTemplate>

--- a/docs/pages/kimg.vue
+++ b/docs/pages/kimg.vue
@@ -78,6 +78,36 @@
         </DocsShowCode>
 
       </div>
+
+      <div>
+        You can also use the <code>appearanceOverrides</code> prop to add custom styles to the image. It accepts any Vue dynamic styles object and applies the same with the highest precedence.
+        <DocsShow>
+          <KImg
+            :src="require('../assets/img_sample_for_kimg.png')"
+            altText="Computers are run by bees"
+            :appearanceOverrides="{
+              width: '50%',
+              border: '2px solid black',
+              padding: '10px',
+              borderRadius: '5px'
+            }
+            "
+          />
+        </DocsShow>
+        <DocsShowCode language="html">
+          <KImg
+            :src="require('../assets/img_sample_for_kimg.png')"
+            altText="Computers are run by bees"
+            :appearanceOverrides="{
+              width: '50%',
+              border: '2px solid black',
+              padding: '10px',
+              borderRadius: '5px'
+            }
+            "
+          />
+        </DocsShowCode>
+      </div>
     </DocsPageSection>
   </DocsPageTemplate>
 

--- a/lib/KImg.vue
+++ b/lib/KImg.vue
@@ -81,6 +81,14 @@
         type: [Number, String],
         default: undefined,
       },
+      /**
+       * Accepts a Vue dynamic styles object to override the default styles to modify the appearance of the component.
+       * It's attributes always take precedence over any specified styling (internal component's styles, styles calculated from props etc.)
+       */
+      appearanceOverrides: {
+        type: Object,
+        default: () => ({}),
+      },
     },
     data() {
       return {
@@ -91,6 +99,7 @@
           minHeight: this.imgMinHeight,
           maxWidth: this.imgMaxWidth,
           minWidth: this.imgMinWidth,
+          ...this.appearanceOverrides,
         },
       };
     },


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Adds the `appearanceOverrides` prop to `KImg` component for styling

#### Issue addressed
Fixes #371  

## Changelog

- [#509]
  - **Description:** Introduces `appearanceOverrides` prop for the `KImg` component
  - **Products impact:** new API 
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/371
  - **Components:** KImg
  - **Breaking:** No
  - **Impacts a11y:** Yes
  - **Guidance:** Adds a way to style the component intrinsically, allowing users to make more a11y compatible components

[#509]: https://github.com/learningequality/kolibri-design-system/pull/509

### At a high level, how did you implement this?
I added a new prop to the component and then passed its styles to the `styleObject`.

### Does this introduce any tech-debt items?
No

## Testing checklist
- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [X] Critical and brittle code paths are covered by unit tests
- [X] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
