### PR TITLE
Mark v2.0.0 section in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,8 @@ Changelog is rather internal in nature. See release notes for the public overvie
  
   [#485]: https://github.com/learningequality/kolibri-design-system/pull/485
 
+## Version 2.0.0
+
 - [#464]
   - **Description:** Add KTextTruncator
   - **Products impact:** new API


### PR DESCRIPTION
This is a part of preparing v2.0.0 release. Changelog now marks what's the last item belonging to v2.0.0.