### PR TITLE
Remove unused keen-ui dependency

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ Addresses #*PR# HERE*
   - **Impacts a11y:** Does this change improve a11y or adds new features that can be used to improve it? Choose from: yes / no
   - **Guidance:** Why and how to introduce this update to a consumer? Required for breaking changes, appreciated for changes with a11y impact, and welcomed for non-breaking changes when relevant.
 
-[#PR no]: [PR link]
+[#PR no]: PR link
 
 ## Steps to test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Impacts a11y:** no
   - **Guidance:** ~
 
-[#521]: [https://github.com/learningequality/kolibri-design-system/pull/521]
+[#521]: https://github.com/learningequality/kolibri-design-system/pull/521
 
 - [#509]
   - **Description:** Introduces `appearanceOverrides` prop for the `KImg` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 <!-- Put all new updates into this section, please -->
 
+- [#531]
+  - **Description:** Remove unused `keen-ui` dependency
+  - **Products impact:** none
+  - **Addresses:** -
+  - **Components:** -
+  - **Breaking:** -
+  - **Impacts a11y:** -
+  - **Guidance:** -
+
+[#531]: https://github.com/learningequality/kolibri-design-system/pull/531
 
 ## Version 3.0.0
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "date-fns": "^1.30.1",
     "frame-throttle": "^3.0.0",
     "fuzzysearch": "^1.0.3",
-    "keen-ui": "^1.3.0",
     "lodash": "^4.17.15",
     "popper.js": "^1.14.6",
     "purecss": "^0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,7 +2880,7 @@ autoprefixer@9.8.6, autoprefixer@^9.0.0, autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-autosize@^3.0.20, autosize@^3.0.21:
+autosize@^3.0.21:
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/autosize/-/autosize-3.0.21.tgz#f182f40d17757d978a139a4c9ca40c4c0e448603"
   integrity sha1-8YL0DRd1fZeKE5pMnKQMTA5EhgM=
@@ -4842,11 +4842,6 @@ deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
-
-deepmerge@^2.0.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -8854,17 +8849,6 @@ jstransformer@1.0.0:
   dependencies:
     is-promise "^2.0.0"
     promise "^7.0.1"
-
-keen-ui@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/keen-ui/-/keen-ui-1.3.1.tgz#981411a0afa0b3b716eb56304a8b7d563a2aa25f"
-  integrity sha512-2EAZy2YFdthCRtZvDHXvMZUTwvHda70WcjbEUaJKM1oH5q9rgecL80VBsTmmcIvfuratIEisBBiteojw3XEa5g==
-  dependencies:
-    autosize "^3.0.20"
-    deepmerge "^2.0.1"
-    fuzzysearch "^1.0.3"
-    lodash.debounce "^4.0.8"
-    tippy.js "^4.2.1"
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description

- Removes unused `keen-ui` dependency
- I also added a small fix to changelog item link format

## Changelog

- [#531]
  - **Description:** Remove unused `keen-ui` dependency
  - **Products impact:** none
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -
 
[#531]: https://github.com/learningequality/kolibri-design-system/pull/531

## Steps to test

You could confirm that the dependency is indeed not used from anywhere.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical and brittle code paths are covered by unit tests~
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

