### PR TITLE
Update development documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 3.x.x (`release-v3` branch)
 
+- [#557]
+  - **Description:** Updates development documentation in regards to linking products development servers to local KDS
+  - **Products impact:** -
+  - **Addresses:** -
+  - **Components:** -
+  - **Breaking:** -
+  - **Impacts a11y:** -
+  - **Guidance:** -
+
+[#557]: https://github.com/learningequality/kolibri-design-system/pull/557
+
 - [#542]
   - **Description:** Adds a new `sort` icon
   - **Products impact:** New icon

--- a/dev_docs/03_how_to_update_library.md
+++ b/dev_docs/03_how_to_update_library.md
@@ -51,14 +51,18 @@ When creating a new component, it is recommended to add a new documentation page
 
 ### (2) Preview updates in a product
 
-To see local Kolibri Design System updates reflected in a product that is using it (such as [Kolibri Learning Platform](https://github.com/learningequality/kolibri) or [Kolibri Studio](https://github.com/learningequality/studio)): 
+You can test local Kolibri Design System updates reflected in a product that is using it, such as [Kolibri Learning Platform](https://github.com/learningequality/kolibri) or [Kolibri Studio](https://github.com/learningequality/studio).
+
+For Kolibri Learning Platform, we recommend `devserver-with-kds` command. See ["Running Kolibri with local Kolibri Design System"](https://kolibri-dev.readthedocs.io/en/develop/howtos/development_with_kds.html) guide.
+
+In other products, you can use `yarn link`:
 
 1. While in the root of your local `kolibri-design-system` repository, run `yarn link`.
-2. In the root of the product where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system` and then `yarn install`.
+2. In the root of a product where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system` and then `yarn install`.
 
 Now, when you run the product your changes in `kolibri-design-system` will be updated live when running the product's development server.
 
-For example, to test Kolibri Design System in Kolibri Learning Platform (local `kolibri` repository):
+For example, to test Kolibri Design System in Kolibri Studio (local `studio` repository):
 
 ```bash
 # change to the Kolibri Design System repository and add it to yarn's local package registry
@@ -66,16 +70,14 @@ cd ./kolibri-design-system
 yarn link
 
 # change to the Kolibri repository and link it to the local Kolibri Design System package
-cd ../kolibri
+cd ../studio
 yarn link kolibri-design-system
 
-# re-install Kolibri dependencies
+# re-install Studio dependencies
 yarn install
 
-# run the Kolibri development server
+# run the Studio development server
 yarn run devserver
 ```
 
-Note that to be able to run the Kolibri development server, at first you need to have it set up as described in [Kolibri developer documentation](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html).
-
-Now you're all set to see your changes to the Kolibri Design System working live in Kolibri!
+Now you're all set to see your changes to the Kolibri Design System working live in Studio!


### PR DESCRIPTION
## Description

This accompanies Kolibri PR https://github.com/learningequality/kolibri/pull/11917 which introduces a new how to guide on using Kolibri's `devserver-with-kds`. Updates relevant parts of documentation to reflect that `devserver-with-kds` is recommended for local development with Kolibri.

## Changelog

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- [#557]
  - **Description:** Updates development documentation in regards to linking products development servers to local KDS
  - **Products impact:** -
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -

[#557]: https://github.com/learningequality/kolibri-design-system/pull/557

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
