### PR TITLE
Revert package.json engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 - [#565]
   - **Description:** Revert adding engines
-  - **Products impact:** -
-  - **Addresses:** -
+  - **Products impact:** Dependencies
+  - **Addresses:** KDS not being installable by consumers that don't use Node 10
   - **Components:** -
   - **Breaking:** -
   - **Impacts a11y:** -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 ## Version 4.x.x (`release-v4` branch)
 
 - [#565]
-  - **Description:** Remove node version from engines
+  - **Description:** Revert adding engines
   - **Products impact:** -
   - **Addresses:** -
   - **Components:** -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 4.x.x (`release-v4` branch)
 
+- [#565]
+  - **Description:** Remove node version from engines
+  - **Products impact:** -
+  - **Addresses:** -
+  - **Components:** -
+  - **Breaking:** -
+  - **Impacts a11y:** -
+  - **Guidance:** -
+
+[#565]: https://github.com/learningequality/kolibri-design-system/pull/565
+
 - [#560]
   - **Description:** Configure dependabot to run on Wednesday
   - **Products impact:** -

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "css-loader": "3.6.0"
   },
   "engines": {
-    "node": "10.x",
     "yarn": "1.x"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -75,9 +75,6 @@
     "postcss-loader": "3.0.0",
     "css-loader": "3.6.0"
   },
-  "engines": {
-    "yarn": "1.x"
-  },
   "browserslist": [
     "extends browserslist-config-kolibri"
   ]


### PR DESCRIPTION
- To fix KDS not being installable from consumers that don't use Node 10
- Also yarn is not required from the consumers point of view