### PR TITLE
Update client width to use getBoundingClientRect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 3.x.x (`release-v3` branch)
 
+- [#573]
+  - **Description:** More precise calculation of list with in KListWithOverflow.
+  - **Products impact:** bugfix.
+  - **Addresses:** -.
+  - **Components:** KListWithOverflow.
+  - **Breaking:** no.
+  - **Impacts a11y:** no.
+  - **Guidance:** -.
+
+[#573]: https://github.com/learningequality/kolibri-design-system/pull/573
+
 - [#552]
   - **Description:** New `KListWithOverflow` component.
   - **Products impact:** new API.


### PR DESCRIPTION
## Description

This PR replaces the use of `clientWidth` to use `getBoundingClientRect().width` to have a more accurate measurement of the width of the KListWithOverflow items. It also recalculates the width of the  moreButton element on each overflow calculation to make sure this value hasnt changed.

### Before/after screenshots
In very specific cases, using `clientWith` can lead to cases like this due to the lack of decimals:

![image](https://github.com/learningequality/kolibri-design-system/assets/51239030/b2f5e15e-ebd4-4189-9b04-956229641404)

Now this is fixed:

![image](https://github.com/learningequality/kolibri-design-system/assets/51239030/8ab84f1b-cf16-4e77-82e8-ea4e5e0780c2)


## Changelog

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- [#573]
  - **Description:** More precise calculation of list with in KListWithOverflow.
  - **Products impact:** bugfix.
  - **Addresses:** -.
  - **Components:** KListWithOverflow.
  - **Breaking:** no.
  - **Impacts a11y:** no.
  - **Guidance:** -.

[#573]: https://github.com/learningequality/kolibri-design-system/pull/573


## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ x If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
