### PR TITLE
Cleanup changelog on the develop branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Upcoming version 5.x.x (`develop` branch)
 
+
+## Version 4.x.x (`release-v4` branch)
+
 - [#555]
   - **Description:** Add action to notify us on Slack about GH issues comments from contributors community
   - **Products impact:** none
@@ -14,8 +17,6 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Guidance:** -
 
 [#555]: https://github.com/learningequality/kolibri-design-system/pull/555
-
-## Version 4.x.x (`release-v4` branch)
 
 - [#565]
   - **Description:** Revert adding engines


### PR DESCRIPTION
#555 change will be released as part of v4.

Follow-up to https://github.com/learningequality/kolibri-design-system/pull/577