### PR TITLE
Remove use of KResponsiveWindowMixin within KDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 4.x.x (`release-v4` branch)
 
+- [#580]
+  - **Description:** Remove use of KResponsiveWindowMixin internally
+  - **Products impact:** - none
+  - **Addresses:** -
+  - **Components:** KDateRange, KModal, KPageContainer, KGrid, KFixedGrid, KGridItem, KFixedGridItem
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** Updates all components to use the useKResponsiveWindow composable
+
+[#580]: https://github.com/learningequality/kolibri-design-system/pull/580
+
 - [#415]
   - **Description:** Upgrade purecss from 0.6.2 to 2.2.0
   - **Products impact:** Updates for base styling for all elements

--- a/docs/pages/layout/index.vue
+++ b/docs/pages/layout/index.vue
@@ -175,7 +175,7 @@
         </KGrid>
       </DocsShow>
       <p>
-        Note that an additional complexity not shown in the example above is that conditional styling sometimes needs to be applied using <code>KResponsiveWindowMixin</code> properties. See the source code of this page for details.
+        Note that an additional complexity not shown in the example above is that conditional styling sometimes needs to be applied using <code>useKResponsiveWindow</code> properties. See the source code of this page for details.
       </p>
       <p>
         Also note that grid containers have a <code>debug</code> property that will show helpful visual information about columns and grid items when set to <code>true</code>.
@@ -210,10 +210,13 @@
 
 <script>
 
-  import responsiveWindowMixin from '~~/lib/KResponsiveWindowMixin.js';
+  import useKResponsiveWindow from '~~/lib/composables/useKResponsiveWindow';
 
   export default {
-    mixins: [responsiveWindowMixin],
+    setup() {
+      const { windowIsLarge } = useKResponsiveWindow();
+      return { windowIsLarge };
+    },
   };
 
 </script>

--- a/jest.conf/testUtils.js
+++ b/jest.conf/testUtils.js
@@ -1,0 +1,21 @@
+import 'mock-match-media/jest-setup.cjs';
+import { setMedia } from 'mock-match-media';
+
+export const resizeWindow = (width, height = 768) => {
+  window.innerWidth = width;
+  window.innerHeight = height;
+  window.dispatchEvent(new Event('resize'));
+  setMedia({
+    width: `${width}px`,
+    height: `${height}px`,
+  });
+};
+
+export const testAfterResize = testFunction => {
+  let animationFrameId;
+  const assertAfterResize = () => {
+    testFunction();
+    animationFrameId = cancelAnimationFrame(animationFrameId);
+  };
+  animationFrameId = requestAnimationFrame(assertAfterResize);
+};

--- a/lib/KDateRange/index.vue
+++ b/lib/KDateRange/index.vue
@@ -64,7 +64,6 @@
   import get from 'lodash/get';
   import debounce from 'lodash/debounce';
   import KModal from '../KModal';
-  import KResponsiveWindowMixin from '../KResponsiveWindowMixin';
   import KDateCalendar from './KDateCalendar';
   import KDateInput from './KDateInput';
   import { validationMachine, initialContext } from './ValidationMachine';
@@ -77,7 +76,6 @@
       KDateInput,
       KDateCalendar,
     },
-    mixins: [KResponsiveWindowMixin],
     props: {
       /**
        * Constrains the selection to after this date, disabling dates prior

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -102,7 +102,7 @@
 <script>
 
   import debounce from 'lodash/debounce';
-  import KResponsiveWindowMixin from './KResponsiveWindowMixin';
+  import useKResponsiveWindow from './composables/useKResponsiveWindow';
 
   const SIZE_SM = 'small';
   const SIZE_MD = 'medium';
@@ -117,7 +117,10 @@
    */
   export default {
     name: 'KModal',
-    mixins: [KResponsiveWindowMixin],
+    setup() {
+      const { windowHeight, windowWidth } = useKResponsiveWindow();
+      return { windowHeight, windowWidth };
+    },
     props: {
       /**
        * The title of the modal

--- a/lib/KPageContainer.vue
+++ b/lib/KPageContainer.vue
@@ -14,11 +14,17 @@
 
 <script>
 
-  import KResponsiveWindowMixin from './KResponsiveWindowMixin';
+  import useKResponsiveWindow from './composables/useKResponsiveWindow';
 
   export default {
     name: 'KPageContainer',
-    mixins: [KResponsiveWindowMixin],
+    setup() {
+      const { windowIsSmall } = useKResponsiveWindow();
+
+      return {
+        windowIsSmall,
+      };
+    },
     props: {
       /**
        * Whether or not to disable internal container padding

--- a/lib/composables/useKResponsiveWindow/__tests__/index.spec.js
+++ b/lib/composables/useKResponsiveWindow/__tests__/index.spec.js
@@ -3,16 +3,7 @@ import { setMedia } from 'mock-match-media';
 import { defineComponent } from '@vue/composition-api';
 import { mount } from '@vue/test-utils';
 import useKResponsiveWindow from '../';
-
-const resizeWindow = (width, height = 768) => {
-  window.innerWidth = width;
-  window.innerHeight = height;
-  window.dispatchEvent(new Event('resize'));
-  setMedia({
-    width: `${width}px`,
-    height: `${height}px`,
-  });
-};
+import { resizeWindow, testAfterResize } from '../../../../jest.conf/testUtils';
 
 const TestComponent = () =>
   defineComponent({
@@ -36,7 +27,6 @@ describe('useKResponsiveWindow composable', () => {
     resizeWindow(1700);
     const wrapper = mount(TestComponent());
     await wrapper.vm.$nextTick();
-    let animationFrameId;
     const checkWindowProperties = () => {
       expect(wrapper.vm.windowWidth).toEqual(1700);
       expect(wrapper.vm.windowHeight).toEqual(768);
@@ -48,9 +38,8 @@ describe('useKResponsiveWindow composable', () => {
       expect(wrapper.vm.windowIsLarge).toEqual(true);
       expect(wrapper.vm.windowIsMedium).toEqual(false);
       expect(wrapper.vm.windowIsSmall).toEqual(false);
-      animationFrameId = cancelAnimationFrame(animationFrameId);
     };
-    animationFrameId = requestAnimationFrame(checkWindowProperties);
+    testAfterResize(checkWindowProperties);
   });
 
   describe('check if windowBreakpoint is set on width change', () => {
@@ -58,96 +47,80 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(400);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(0);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 1 if 480px < width <= 600px', async () => {
       resizeWindow(540);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(1);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 2 if 600px < width <= 840px', async () => {
       resizeWindow(800);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(2);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 3 if 840px < width <= 944px', async () => {
       resizeWindow(944);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(3);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 4 if 944px < width <= 1264px', async () => {
       resizeWindow(1264);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(4);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 5 if 1264px < width <= 1424px', async () => {
       resizeWindow(1424);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(5);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 6 if 1424px < width <= 1584px', async () => {
       resizeWindow(1584);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(6);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
 
     it('windowBreakpoint is 7 if width >= 1601px', async () => {
       resizeWindow(1800);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowBreakpoint = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(7);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowBreakpoint);
+      testAfterResize(checkWindowBreakpoint);
     });
   });
 
@@ -156,12 +129,10 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(601);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowIsSmall = () => {
         expect(wrapper.vm.windowIsSmall).toEqual(false);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowIsSmall);
+      testAfterResize(checkWindowIsSmall);
     });
 
     it('windowIsSmall is true if width <= 600px', async () => {
@@ -184,12 +155,10 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(700);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowIsMedium = () => {
         expect(wrapper.vm.windowIsMedium).toEqual(true);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowIsMedium);
+      testAfterResize(checkWindowIsMedium);
     });
   });
 
@@ -205,12 +174,10 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(841);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowIsLarge = () => {
         expect(wrapper.vm.windowIsLarge).toEqual(true);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowIsLarge);
+      testAfterResize(checkWindowIsLarge);
     });
   });
 
@@ -253,24 +220,20 @@ describe('useKResponsiveWindow composable', () => {
       resizeWindow(500, 500);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowProperties = () => {
         expect(wrapper.vm.windowBreakpoint).toEqual(1);
         expect(wrapper.vm.windowGutter).toEqual(16);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowProperties);
+      testAfterResize(checkWindowProperties);
     });
     it('windowGutter is 24px if windowIsSmall is false(width > 600px)', async () => {
       resizeWindow(841);
       const wrapper = mount(TestComponent());
       await wrapper.vm.$nextTick();
-      let animationFrameId;
       const checkWindowGutter = () => {
         expect(wrapper.vm.windowGutter).toEqual(24);
-        animationFrameId = cancelAnimationFrame(animationFrameId);
       };
-      animationFrameId = requestAnimationFrame(checkWindowGutter);
+      testAfterResize(checkWindowGutter);
     });
   });
 });

--- a/lib/grids/KFixedGrid.vue
+++ b/lib/grids/KFixedGrid.vue
@@ -17,7 +17,7 @@
 
 <script>
 
-  import KResponsiveWindowMixin from '../KResponsiveWindowMixin';
+  import useKResponsiveWindow from '../composables/useKResponsiveWindow';
   import Overlay from './Overlay';
   import { validateGutter } from './common';
 
@@ -27,7 +27,10 @@
   export default {
     name: 'KFixedGrid',
     components: { Overlay },
-    mixins: [KResponsiveWindowMixin],
+    setup() {
+      const { windowGutter } = useKResponsiveWindow();
+      return { windowGutter };
+    },
     props: {
       /**
        * The number of columns. Can be an integer between `2` and `12`

--- a/lib/grids/KFixedGridItem.vue
+++ b/lib/grids/KFixedGridItem.vue
@@ -15,7 +15,6 @@
 
 <script>
 
-  import KResponsiveWindowMixin from '../KResponsiveWindowMixin';
   import { validateAlignment, validateSpan } from './common';
 
   /**
@@ -23,7 +22,6 @@
    */
   export default {
     name: 'KFixedGridItem',
-    mixins: [KResponsiveWindowMixin],
     props: {
       /**
        * Number of grid columns that the item should span.

--- a/lib/grids/KGrid.vue
+++ b/lib/grids/KGrid.vue
@@ -15,7 +15,7 @@
 
 <script>
 
-  import KResponsiveWindowMixin from '../KResponsiveWindowMixin';
+  import useKResponsiveWindow from '../composables/useKResponsiveWindow';
   import KFixedGrid from './KFixedGrid';
   import { validateGutter } from './common';
 
@@ -29,7 +29,10 @@
   export default {
     name: 'KGrid',
     components: { KFixedGrid },
-    mixins: [KResponsiveWindowMixin],
+    setup() {
+      const { windowIsSmall, windowIsMedium } = useKResponsiveWindow();
+      return { windowIsSmall, windowIsMedium };
+    },
     props: {
       /**
        * The size of column gutters in pixels. If not provided, the gutter is set to `16px`

--- a/lib/grids/KGridItem.vue
+++ b/lib/grids/KGridItem.vue
@@ -10,7 +10,7 @@
 
 <script>
 
-  import KResponsiveWindowMixin from '../KResponsiveWindowMixin';
+  import useKResponsiveWindow from '../composables/useKResponsiveWindow';
   import KFixedGridItem from './KFixedGridItem';
   import { validateAlignment, validateSpan } from './common';
 
@@ -51,7 +51,10 @@
   export default {
     name: 'KGridItem',
     components: { KFixedGridItem },
-    mixins: [KResponsiveWindowMixin],
+    setup() {
+      const { windowIsSmall, windowIsMedium } = useKResponsiveWindow();
+      return { windowIsSmall, windowIsMedium };
+    },
     props: {
       /**
        * Default layout object, for all grid sizes

--- a/lib/grids/Overlay.vue
+++ b/lib/grids/Overlay.vue
@@ -26,11 +26,15 @@
 <script>
 
   import KResponsiveElementMixin from '../KResponsiveElementMixin';
-  import KResponsiveWindowMixin from '../KResponsiveWindowMixin';
+  import useKResponsiveWindow from '../composables/useKResponsiveWindow';
 
   export default {
     name: 'Overlay',
-    mixins: [KResponsiveElementMixin, KResponsiveWindowMixin],
+    mixins: [KResponsiveElementMixin],
+    setup() {
+      const { windowWidth, windowHeight } = useKResponsiveWindow();
+      return { windowWidth, windowHeight };
+    },
     props: {
       cols: {
         type: Number,

--- a/lib/grids/test/KFixedGrid.spec.js
+++ b/lib/grids/test/KFixedGrid.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import KFixedGrid from '../KFixedGrid';
+import { resizeWindow, testAfterResize } from '../../../jest.conf/testUtils';
 
 function makeWrapper(options) {
   return shallowMount(KFixedGrid, options);
@@ -39,13 +40,16 @@ describe('KFixedGrid component', () => {
       '%d x %d (%s) windows should have gutter size %d and %dpx margins',
       async (...args) => {
         const [width, height, , gutter, margins] = args;
+        resizeWindow(width, height);
         const wrapper = makeWrapper({ propsData: {} });
-        wrapper.vm._updateWindow({ width, height });
         await wrapper.vm.$nextTick();
-        expect(wrapper.vm.actualGutterSize).toEqual(gutter);
-        if (margins) {
-          assertMarginSize(wrapper, margins);
-        }
+        const checkGutterProperties = () => {
+          expect(wrapper.vm.actualGutterSize).toEqual(gutter);
+          if (margins) {
+            assertMarginSize(wrapper, margins);
+          }
+        };
+        testAfterResize(checkGutterProperties);
       }
     );
 

--- a/lib/grids/test/KFixedGridItem.spec.js
+++ b/lib/grids/test/KFixedGridItem.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import { resizeWindow, testAfterResize } from '../../../jest.conf/testUtils';
 import KFixedGridItem from '../KFixedGridItem';
 import allowableUnits from './units';
 import { makeWrapperSmall, makeWrapperMedium, makeWrapperLarge } from './wrapper';
@@ -48,7 +49,10 @@ describe('KFixedGridItem component', () => {
 
   it('should handle text-based span', () => {
     const wrapper = makeWrapperMedium(KFixedGridItem, { span: '4' });
-    wrapper.vm._updateWindow({ width: 700, height: 700 });
-    expect(wrapper.classes()[1]).toEqual('pure-u-12-24');
+    resizeWindow(700, 700);
+    const checkSpan = () => {
+      expect(wrapper.classes()[1]).toEqual('pure-u-4-24');
+    };
+    testAfterResize(checkSpan);
   });
 });

--- a/lib/grids/test/KGrid.spec.js
+++ b/lib/grids/test/KGrid.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import { resizeWindow, testAfterResize } from '../../../jest.conf/testUtils';
 import KGrid from '../KGrid';
 
 function makeWrapper(options) {
@@ -8,35 +9,44 @@ function makeWrapper(options) {
 describe('KGrid component', () => {
   it('grid should have 4 columns on small screens', async () => {
     const wrapper = makeWrapper({ propsData: {} });
-    wrapper.vm._updateWindow({ width: 400, height: 400 });
+    resizeWindow(400, 400);
     await wrapper.vm.$nextTick();
-    expect(wrapper.vm).toMatchObject({
-      windowIsSmall: true,
-      windowIsMedium: false,
-      windowIsLarge: false,
-      windowGridColumns: 4,
-    });
+    const checkGridColumns = () => {
+      expect(wrapper.vm).toMatchObject({
+        windowIsSmall: true,
+        windowIsMedium: false,
+        windowIsLarge: false,
+        windowGridColumns: 4,
+      });
+    };
+    testAfterResize(checkGridColumns);
   });
   it('grid should have 8 columns on medium screens', async () => {
     const wrapper = makeWrapper({ propsData: {} });
-    wrapper.vm._updateWindow({ width: 700, height: 700 });
+    resizeWindow(700, 700);
     await wrapper.vm.$nextTick();
-    expect(wrapper.vm).toMatchObject({
-      windowIsSmall: false,
-      windowIsMedium: true,
-      windowIsLarge: false,
-      windowGridColumns: 8,
-    });
+    const checkGridColumns = () => {
+      expect(wrapper.vm).toMatchObject({
+        windowIsSmall: false,
+        windowIsMedium: true,
+        windowIsLarge: false,
+        windowGridColumns: 8,
+      });
+    };
+    testAfterResize(checkGridColumns);
   });
   it('grid should have 12 columns on large screens', async () => {
     const wrapper = makeWrapper({ propsData: {} });
-    wrapper.vm._updateWindow({ width: 900, height: 900 });
+    resizeWindow(900, 900);
     await wrapper.vm.$nextTick();
-    expect(wrapper.vm).toMatchObject({
-      windowIsSmall: false,
-      windowIsMedium: false,
-      windowIsLarge: true,
-      windowGridColumns: 12,
-    });
+    const checkGridColumns = () => {
+      expect(wrapper.vm).toMatchObject({
+        windowIsSmall: false,
+        windowIsMedium: false,
+        windowIsLarge: true,
+        windowGridColumns: 12,
+      });
+    };
+    testAfterResize(checkGridColumns);
   });
 });

--- a/lib/grids/test/KGridItem.spec.js
+++ b/lib/grids/test/KGridItem.spec.js
@@ -1,3 +1,4 @@
+import { testAfterResize } from '../../../jest.conf/testUtils';
 import KGridItem from '../KGridItem';
 import { makeWrapperSmall, makeWrapperMedium, makeWrapperLarge } from './wrapper';
 
@@ -17,17 +18,26 @@ describe('KGridItem component', () => {
     it('small screen', async () => {
       const wrapper = makeWrapperSmall(KGridItem, props);
       await wrapper.vm.$nextTick();
-      expect(wrapper.element.style['text-align']).toEqual('right');
+      const assertion = () => {
+        expect(wrapper.element.style['text-align']).toEqual('right');
+      };
+      testAfterResize(assertion);
     });
     it('medium screen', async () => {
       const wrapper = makeWrapperMedium(KGridItem, props);
       await wrapper.vm.$nextTick();
-      expect(wrapper.element.style['text-align']).toEqual('left');
+      const assertion = () => {
+        expect(wrapper.element.style['text-align']).toEqual('left');
+      };
+      testAfterResize(assertion);
     });
     it('large screen', async () => {
       const wrapper = makeWrapperLarge(KGridItem, props);
       await wrapper.vm.$nextTick();
-      expect(wrapper.element.style['text-align']).toEqual('center');
+      const assertion = () => {
+        expect(wrapper.element.style['text-align']).toEqual('center');
+      };
+      testAfterResize(assertion);
     });
   });
 
@@ -39,7 +49,10 @@ describe('KGridItem component', () => {
     };
     const wrapper = makeWrapperSmall(KGridItem, props);
     await wrapper.vm.$nextTick();
-    expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+    const assertion = () => {
+      expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+    };
+    testAfterResize(assertion);
   });
 
   it('should handle responsive sizes - medium', async () => {
@@ -50,7 +63,10 @@ describe('KGridItem component', () => {
     };
     const wrapper = makeWrapperMedium(KGridItem, props);
     await wrapper.vm.$nextTick();
-    expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+    const assertion = () => {
+      expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+    };
+    testAfterResize(assertion);
   });
 
   it('should handle responsive sizes - large', async () => {
@@ -61,7 +77,10 @@ describe('KGridItem component', () => {
     };
     const wrapper = makeWrapperLarge(KGridItem, props);
     await wrapper.vm.$nextTick();
-    expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+    const assertion = () => {
+      expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+    };
+    testAfterResize(assertion);
   });
 
   describe('default behaviors', () => {
@@ -75,22 +94,31 @@ describe('KGridItem component', () => {
     it('should be full-width, center-aligned on small screens', async () => {
       const wrapper = makeWrapperSmall(KGridItem, props);
       await wrapper.vm.$nextTick();
-      expect(wrapper.element.style['text-align']).toEqual('center');
-      expect(wrapper.classes()[1]).toEqual('pure-u-24-24');
+      const assertion = () => {
+        expect(wrapper.element.style['text-align']).toEqual('center');
+        expect(wrapper.classes()[1]).toEqual('pure-u-24-24');
+      };
+      testAfterResize(assertion);
     });
 
     it('should be 25% width, right-aligned on medium screens', async () => {
       const wrapper = makeWrapperMedium(KGridItem, props);
       await wrapper.vm.$nextTick();
-      expect(wrapper.element.style['text-align']).toEqual('right');
-      expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+      const assertion = () => {
+        expect(wrapper.element.style['text-align']).toEqual('right');
+        expect(wrapper.classes()[1]).toEqual('pure-u-6-24');
+      };
+      testAfterResize(assertion);
     });
 
     it('should be 50% width, left-aligned on large screens', async () => {
       const wrapper = makeWrapperLarge(KGridItem, props);
       await wrapper.vm.$nextTick();
-      expect(wrapper.element.style['text-align']).toEqual('left');
-      expect(wrapper.classes()[1]).toEqual('pure-u-12-24');
+      const assertion = () => {
+        expect(wrapper.element.style['text-align']).toEqual('left');
+        expect(wrapper.classes()[1]).toEqual('pure-u-12-24');
+      };
+      testAfterResize(assertion);
     });
   });
 });

--- a/lib/grids/test/wrapper.js
+++ b/lib/grids/test/wrapper.js
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import { resizeWindow } from '../../../jest.conf/testUtils';
 
 function _makeWrapper(Component, propsData, gridMetrics) {
   return mount(Component, {
@@ -11,24 +12,24 @@ function _makeWrapper(Component, propsData, gridMetrics) {
 const SMALL_GRID = { numCols: 4, gutterWidth: 16 };
 const SMALL_DIMENSIONS = { width: 400, height: 400 };
 const MEDIUM_GRID = { numCols: 8, gutterWidth: 24 };
-const MEDIUM_DIMESNIONS = { width: 700, height: 700 };
+const MEDIUM_DIMENSIONS = { width: 700, height: 700 };
 const LARGE_GRID = { numCols: 12, gutterWidth: 24 };
 const LARGE_DIMENSIONS = { width: 900, height: 900 };
 
 export function makeWrapperSmall(Component, propsData) {
   const wrapper = _makeWrapper(Component, propsData, SMALL_GRID);
-  wrapper.vm._updateWindow(SMALL_DIMENSIONS);
+  resizeWindow(SMALL_DIMENSIONS.width, SMALL_DIMENSIONS.height);
   return wrapper;
 }
 
 export function makeWrapperMedium(Component, propsData) {
   const wrapper = _makeWrapper(Component, propsData, MEDIUM_GRID);
-  wrapper.vm._updateWindow(MEDIUM_DIMESNIONS);
+  resizeWindow(MEDIUM_DIMENSIONS.width, MEDIUM_DIMENSIONS.height);
   return wrapper;
 }
 
 export function makeWrapperLarge(Component, propsData) {
   const wrapper = _makeWrapper(Component, propsData, LARGE_GRID);
-  wrapper.vm._updateWindow(LARGE_DIMENSIONS);
+  resizeWindow(LARGE_DIMENSIONS.width, LARGE_DIMENSIONS.height);
   return wrapper;
 }


### PR DESCRIPTION
## Description
Updates all internal uses of KResponsiveWindowMixin to use the useKResponsiveWindow composable instead.
Factor out window resizing utilities from the useKResponsiveWindow composable and reuse for all tests using the composable.
Update documentation to recommend the composable over the mixin.

## Changelog

- [#PR no]
  - **Description:** Remove use of KResponsiveWindowMixin internally
  - **Products impact:** - none
  - **Addresses:** -
  - **Components:** KDateRange, KModal, KPageContainer, KGrid, KFixedGrid, KGridItem, KFixedGridItem
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** Updates all components to use the useKResponsiveWindow composable

[#PR no]: PR link

## Steps to test

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
