### PR TITLE
KDropdownMenu: Context Menu support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Impacts a11y:** no.
   - **Guidance:** -.
 
+  - [#583]
+  - **Description:** KDropdownMenu menu support to show a header slot.
+  - **Products impact:** new API.
+  - **Addresses:** - .
+  - **Components:** KDropdownMenu.
+  - **Breaking:** no.
+  - **Impacts a11y:** no.
+  - **Guidance:** -.
+
 [#583]: https://github.com/learningequality/kolibri-design-system/pull/583
 
 - [#611]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Impacts a11y:** no.
   - **Guidance:** -.
 
-  - [#583]
+- [#583]
   - **Description:** KDropdownMenu menu support to show a header slot.
   - **Products impact:** new API.
   - **Addresses:** - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Impacts a11y:** no.
   - **Guidance:** -.
 
-[#583]: https://github.com/learningequality/kolibri-design-system/pull/583
-
 - [#583]
   - **Description:** New `useKContextMenu` private composable
   - **Products impact:** - .
@@ -22,6 +20,15 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Components:** - .
   - **Breaking:** - .
   - **Impacts a11y:** - .
+  - **Guidance:** -.
+
+- [#583]
+  - **Description:** Expose the event object as second argument on KDropdownMenu's select event.
+  - **Products impact:** updated API.
+  - **Addresses:** - .
+  - **Components:** KDropdownMenu.
+  - **Breaking:** no.
+  - **Impacts a11y:** no.
   - **Guidance:** -.
 
 [#583]: https://github.com/learningequality/kolibri-design-system/pull/583

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 - [#583]
   - **Description:** KDropdownMenu menu support to show context menus with `isContextMenu` prop.
   - **Products impact:** new API.
-  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/571.
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/571, https://github.com/learningequality/studio/issues/4403.
   - **Components:** KDropdownMenu.
   - **Breaking:** no.
   - **Impacts a11y:** no.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 3.x.x (`release-v3` branch)
 
+- [#583]
+  - **Description:** KDropdownMenu menu support to show context menus with `isContextMenu` prop.
+  - **Products impact:** new API.
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/571.
+  - **Components:** KDropdownMenu.
+  - **Breaking:** no.
+  - **Impacts a11y:** no.
+  - **Guidance:** -.
+
+[#583]: https://github.com/learningequality/kolibri-design-system/pull/583
+
+- [#583]
+  - **Description:** New `useKContextMenu` private composable
+  - **Products impact:** - .
+  - **Addresses:** - .
+  - **Components:** - .
+  - **Breaking:** - .
+  - **Impacts a11y:** - .
+  - **Guidance:** -.
+
+[#583]: https://github.com/learningequality/kolibri-design-system/pull/583
+
 - [#611]
   - **Description:** Adds a new `maxWidth` prop
   -  **Products impact:** new API 

--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -12,6 +12,57 @@
       <p>
         Please see the <DocsInternalLink href="/buttons#dropdowns" text="Dropdown section of the Buttons and links page" /> on the buttons page for more details about how to use with a button, and a code example.
       </p>
+
+      <h3>Context menu</h3>
+
+      <p>
+        This component can be also used to create a context menu, which is a dropdown menu that appears when a user right-clicks on an element.
+      </p>
+
+      <DocsShow block>
+        <p>
+          For example, you can right click on this paragraph to see a context menu.
+        </p>
+        <KDropdownMenu
+          isContextMenu
+          :options="[
+            { label: 'Option 1' },
+            { label: 'Option 2' },
+            { label: 'Option 3' },
+          ]"
+        />
+      </DocsShow>
+
+      <DocsShow block>
+        <p>
+          Note that just one context menu can be open at a time. If you right-click on this paragraph, any other context menu will close.
+        </p>
+        <KDropdownMenu
+          isContextMenu
+          :options="[
+            { label: 'Option 1' },
+            { label: 'Option 2' },
+          ]"
+        />
+      </DocsShow>
+
+      <p>
+        To achieve this, set the <code>isContextMenu</code> prop to true.
+        The context menu will then be attached to the parent element.
+      </p>
+      <DocsShowCode language="html">
+        <div>
+          <p> ... </p>
+          <KDropdownMenu
+            isContextMenu
+            :options="[
+              { label: 'Option 1' },
+              { label: 'Option 2' },
+              { label: 'Option 3' },
+            ]"
+          />
+        </div>
+      </DocsShowCode>
     </DocsPageSection>
   </DocsPageTemplate>
 

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -87,6 +87,10 @@
           ].includes(val);
         },
       },
+      /**
+       * Whether or not the dropdown is a context menu, if true, the dropdown will open when
+       * the user right-clicks the parent element
+       */
       isContextMenu : {
         type: Boolean,
         default: false,

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -1,36 +1,36 @@
 <template>
 
   <div>
-  <UiPopover
-    v-if="trigger"
-    ref="popover"
-    :z-index="100"
-    :trigger="trigger"
-    :containFocus="true"
-    :dropdownPosition="position"
-    :positionX="contextMenuPosition[0]"
-    :positionY="contextMenuPosition[1]"
-    :openOn="isContextMenu ? 'manual' : 'click'"
-    :constrainToScrollParent="constrainToScrollParent"
-    @close="handleClose"
-    @open="handleOpen"
-  >
-    <UiMenu 
-      ref="menu" 
-      :options="options" 
-      :hasIcons="hasIcons" 
-      @select="handleSelection" 
-    />
-  </UiPopover>
-</div>
+    <UiPopover
+      v-if="trigger"
+      ref="popover"
+      :z-index="100"
+      :trigger="trigger"
+      :containFocus="true"
+      :dropdownPosition="position"
+      :positionX="contextMenuPosition[0]"
+      :positionY="contextMenuPosition[1]"
+      :openOn="isContextMenu ? 'manual' : 'click'"
+      :constrainToScrollParent="constrainToScrollParent"
+      @close="handleClose"
+      @open="handleOpen"
+    >
+      <UiMenu 
+        ref="menu" 
+        :options="options" 
+        :hasIcons="hasIcons" 
+        @select="handleSelection" 
+      />
+    </UiPopover>
+  </div>
 </template>
 
 
 <script>
 
+  import { computed } from '@vue/composition-api';
   import UiMenu from './keen/UiMenu';
   import UiPopover from './keen/UiPopover';
-  import { computed } from '@vue/composition-api';
   import useKContextMenu from './composables/_useKContextMenu';
 
   /**
@@ -41,6 +41,21 @@
     components: {
       UiPopover,
       UiMenu,
+    },
+    setup(props) {
+      if (props.isContextMenu) {
+        const { clientX, clientY, isActive } = useKContextMenu();
+        const contextMenuPosition = computed(() => [clientX.value, clientY.value]);
+
+        return {
+          contextMenuPosition,
+          isContextMenuActive: isActive,
+        };
+      }
+      return {
+        contextMenuPosition: [],
+        isContextMenuActive: null,
+      };
     },
     props: {
       /**
@@ -91,7 +106,7 @@
        * Whether or not the dropdown is a context menu, if true, the dropdown will open when
        * the user right-clicks the parent element
        */
-      isContextMenu : {
+      isContextMenu: {
         type: Boolean,
         default: false,
       },
@@ -101,23 +116,26 @@
         trigger: null,
       };
     },
+    watch: {
+      isContextMenuActive() {
+        if (this.isContextMenuActive) {
+          this.$nextTick(() => {
+            this.$refs.popover.open();
+          });
+        } else {
+          this.$refs.popover.close();
+        }
+      },
+      contextMenuPosition() {
+        if (this.isContextMenuActive) {
+          this.$nextTick(() => {
+            this.$refs.popover.open();
+          });
+        }
+      },
+    },
     mounted() {
       this.trigger = this.$el.parentElement;
-    },
-    setup(props) {
-      if (props.isContextMenu) {
-        const { clientX, clientY, isActive } = useKContextMenu();
-        const contextMenuPosition = computed(() => [clientX.value, clientY.value]);
-
-        return {
-          contextMenuPosition,
-          isContextMenuActive: isActive,
-        };
-      }
-      return {
-        contextMenuPosition: [],
-        isContextMenuActive: null,
-      };
     },
     beforeDestroy() {
       window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
@@ -190,24 +208,6 @@
           this.$refs.button.$el.focus();
         }
       },
-    },
-    watch: {
-      isContextMenuActive() {
-        if (this.isContextMenuActive) {
-          this.$nextTick(() => {
-            this.$refs.popover.open();
-          });
-        } else {
-          this.$refs.popover.close();
-        }
-      },
-      contextMenuPosition() {
-        if (this.isContextMenuActive) {
-          this.$nextTick(() => {
-            this.$refs.popover.open();
-          });
-        }
-      }
     },
   };
 

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -15,6 +15,8 @@
       @close="handleClose"
       @open="handleOpen"
     >
+      <!-- Slot to set a header to the dropdown menu -->
+      <slot name="header"></slot>
       <UiMenu 
         ref="menu" 
         :options="options" 
@@ -23,6 +25,7 @@
       />
     </UiPopover>
   </div>
+
 </template>
 
 

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -192,11 +192,11 @@
           this.closePopover();
         }
       },
-      handleSelection(selection) {
+      handleSelection(selection, $event) {
         /**
          * Emitted when an option is selected
          */
-        this.$emit('select', selection);
+        this.$emit('select', selection, $event);
         this.closePopover();
       },
       closePopover() {

--- a/lib/composables/_useKContextMenu.js
+++ b/lib/composables/_useKContextMenu.js
@@ -1,11 +1,16 @@
 import '../composition-api'; //Due to @vue/composition-api shortcomings, add plugin prior to use in kolibri, studio and tests
 
-import { onMounted, onBeforeUnmount, ref, getCurrentInstance, computed } from '@vue/composition-api';
+import {
+  ref,
+  computed,
+  onMounted,
+  onBeforeUnmount,
+  getCurrentInstance,
+} from '@vue/composition-api';
 
 const activeMenu = ref(null);
 
 export default function useKContextMenu() {
-
   const clientX = ref(0);
   const clientY = ref(0);
 
@@ -13,7 +18,6 @@ export default function useKContextMenu() {
   const id = instance.uid;
 
   const isActive = computed(() => activeMenu.value === id);
-
 
   function showMenu(event) {
     event.preventDefault();
@@ -27,7 +31,6 @@ export default function useKContextMenu() {
       activeMenu.value = null;
     }
   }
-
 
   onMounted(() => {
     const parent = instance.proxy.$el.parentElement;
@@ -46,4 +49,4 @@ export default function useKContextMenu() {
     clientY,
     isActive,
   };
-};
+}

--- a/lib/composables/_useKContextMenu.js
+++ b/lib/composables/_useKContextMenu.js
@@ -1,0 +1,49 @@
+import '../composition-api'; //Due to @vue/composition-api shortcomings, add plugin prior to use in kolibri, studio and tests
+
+import { onMounted, onBeforeUnmount, ref, getCurrentInstance, computed } from '@vue/composition-api';
+
+const activeMenu = ref(null);
+
+export default function useKContextMenu() {
+
+  const clientX = ref(0);
+  const clientY = ref(0);
+
+  const instance = getCurrentInstance();
+  const id = instance.uid;
+
+  const isActive = computed(() => activeMenu.value === id);
+
+
+  function showMenu(event) {
+    event.preventDefault();
+    activeMenu.value = id;
+    clientX.value = event.clientX;
+    clientY.value = event.clientY;
+  }
+
+  function hideMenu() {
+    if (activeMenu.value === id) {
+      activeMenu.value = null;
+    }
+  }
+
+
+  onMounted(() => {
+    const parent = instance.proxy.$el.parentElement;
+    parent.addEventListener('contextmenu', showMenu);
+    window.addEventListener('click', hideMenu);
+  });
+
+  onBeforeUnmount(() => {
+    const parent = instance.proxy.$el.parentElement;
+    parent.removeEventListener('contextmenu', showMenu);
+    window.removeEventListener('click', hideMenu);
+  });
+
+  return {
+    clientX,
+    clientY,
+    isActive,
+  };
+};

--- a/lib/composables/_useKContextMenu.js
+++ b/lib/composables/_useKContextMenu.js
@@ -40,7 +40,9 @@ export default function useKContextMenu() {
 
   onBeforeUnmount(() => {
     const parent = instance.proxy.$el.parentElement;
-    parent.removeEventListener('contextmenu', showMenu);
+    if (parent) {
+      parent.removeEventListener('contextmenu', showMenu);
+    }
     window.removeEventListener('click', hideMenu);
   });
 

--- a/lib/composables/_useKContextMenu.js
+++ b/lib/composables/_useKContextMenu.js
@@ -1,4 +1,4 @@
-import '../composition-api'; //Due to @vue/composition-api shortcomings, add plugin prior to use in kolibri, studio and tests
+import '../composition-api.js'; //Due to @vue/composition-api shortcomings, add plugin prior to use in kolibri, studio and tests
 
 import {
   ref,

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -22,8 +22,8 @@
       :target="option[keys.target]"
 
       :type="option[keys.type]"
-      @click.native="selectOption(option)"
-      @keydown.enter.native="selectOption(option)"
+      @click.native="($event) => selectOption(option, $event)"
+      @keydown.enter.native="($event) => selectOption(option, $event)"
 
       @keydown.esc.native.esc="closeMenu"
       :style="[ activeOutline ]"
@@ -107,12 +107,12 @@
     },
 
     methods: {
-      selectOption(option) {
+      selectOption(option, $event) {
         if (option.disabled || option.type === 'divider') {
           return;
         }
 
-        this.$emit('select', option);
+        this.$emit('select', option, $event);
         this.closeMenu();
       },
       closeMenu() {

--- a/lib/keen/UiPopover.vue
+++ b/lib/keen/UiPopover.vue
@@ -204,6 +204,8 @@
           this.tip.show(); // Ensure popperInstance is created
         }
 
+        // This logic is similar to what tippy.js uses to position the popup near the cursor.
+        // see https://github.com/atomiks/tippyjs/blob/v4.3.5/src/createTippy.ts#L395
         const isVerticalPlacement = ['top', 'bottom'].includes(this.position.split('-')[0]);
         const variation = this.position.split('-')[1];
         const size = isVerticalPlacement ? this.$el.clientWidth : this.$el.clientHeight;
@@ -223,7 +225,7 @@
           horizontalIncrease = 0;
         }
 
-        this.tip.popperInstance.reference.getBoundingClientRect = function getBoundingClientRect() {
+        this.tip.popperInstance.reference.getBoundingClientRect = () => {
           return {
             width: isVerticalPlacement ? size : 0,
             height: isVerticalPlacement ? 0 : size,

--- a/lib/keen/UiPopover.vue
+++ b/lib/keen/UiPopover.vue
@@ -81,6 +81,8 @@
         },
       },
       zIndex: Number,
+      positionX: Number,
+      positionY: Number,
     },
 
     data() {
@@ -188,9 +190,50 @@
        * @public
        */
       open() {
-        if (this.tip) {
+        if (!this.tip) {
+          return;
+        }
+        if (this.positionX || this.positionY) {
+          this.openInPosition(this.positionX, this.positionY);
+        } else {
           this.tip.show();
         }
+      },
+      openInPosition(x, y) {
+        if (!this.tip.popperInstance) {
+          this.tip.show(); // Ensure popperInstance is created
+        }
+
+        const isVerticalPlacement = ['top', 'bottom'].includes(this.position.split('-')[0]);
+        const variation = this.position.split('-')[1];
+        const size = isVerticalPlacement ? this.$el.clientWidth : this.$el.clientHeight;
+        const middle = size / 2;
+
+        const positionVariationMap = {
+          start: 0,
+          end: size,
+        };
+        let verticalIncrease;
+        let horizontalIncrease;
+        if (isVerticalPlacement) {
+          verticalIncrease = 0;
+          horizontalIncrease = variation ? positionVariationMap[variation] : middle;
+        } else {
+          verticalIncrease = variation ? positionVariationMap[variation] : middle;
+          horizontalIncrease = 0;
+        }
+
+        this.tip.popperInstance.reference.getBoundingClientRect = function getBoundingClientRect() {
+          return {
+            width: isVerticalPlacement ? size : 0,
+            height: isVerticalPlacement ? 0 : size,
+            top: y - verticalIncrease,
+            bottom: y + verticalIncrease,
+            left: x - horizontalIncrease,
+            right: x + horizontalIncrease
+          };
+        };
+        this.tip.show();
       },
 
       close(options = { returnFocus: true }) {


### PR DESCRIPTION
## Description
KDropdownMenu menu support to show context menus on right click setting the new `isContextMenu` prop to true.


#### Issue addressed
Closes https://github.com/learningequality/kolibri-design-system/issues/571

### Screencast

https://github.com/learningequality/kolibri-design-system/assets/51239030/ad997760-fea9-47ff-b62e-adfe81c5ca1c

## Changelog

- [#583]
  - **Description:** KDropdownMenu menu support to show context menus with `isContextMenu` prop.
  - **Products impact:** new API.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/571, https://github.com/learningequality/studio/issues/4403.
  - **Components:** KDropdownMenu.
  - **Breaking:** no.
  - **Impacts a11y:** no.
  - **Guidance:** -.

- [#583]
  - **Description:** New `useKContextMenu` private composable
  - **Products impact:** - .
  - **Addresses:** - .
  - **Components:** - .
  - **Breaking:** - .
  - **Impacts a11y:** - .
  - **Guidance:** -.

- [#583]
  - **Description:** Expose the event object as second argument on KDropdownMenu's select event.
  - **Products impact:** updated API.
  - **Addresses:** - .
  - **Components:** KDropdownMenu.
  - **Breaking:** no.
  - **Impacts a11y:** no.
  - **Guidance:** -.

- [#583]
  - **Description:** KDropdownMenu menu support to show a header slot.
  - **Products impact:** new API.
  - **Addresses:** - .
  - **Components:** KDropdownMenu.
  - **Breaking:** no.
  - **Impacts a11y:** no.
  - **Guidance:** -.
 
[#583]: https://github.com/learningequality/kolibri-design-system/pull/583

## Steps to test

1. Run the web server.
2. Go to http://localhost:4000/kdropdownmenu in the `Context menu` section
3. Play with the examples

## Implementation notes

We only need to add a `isContextMenu` prop to the KDropdownMenu and it will attach a listener to the parent element to open the menu.

```Vue
<template>
  ...
  <div class="card">
    ...
    <KDropdownMenu
      isContextMenu
      :options="options"
    /> <!-- every time the use right clicks the card, the menu will open -->
  </div>
</template>
```

### At a high level, how did you implement this?

Took advantage of the [tippy.js](https://atomiks.github.io/tippyjs/) library to support the right click operation. tippy.js does not natively support a right click [trigger](https://atomiks.github.io/tippyjs/v6/all-props/#trigger), so I had to programmatically do a manual trigger when the user right clicked.

To track this right click I made a new private composable `_useKContextMenu` which will be in charge of giving us the clientX and clientY of the right click, a boolean if the context menu should be active, and ensure that there is only one context menu open at a time.

Furthermore, I Increased the UiPopover support so that it receives a position x and y where to render the popover.

There were some complications with the positioning of the popup using tippy. First I tried to use the tippy [offset](https://atomiks.github.io/tippyjs/v6/all-props/#offset) prop to achieve the popup positioning, but the main-axis offset was buggy and it was not working. Then I tried to use its [followCursor](https://atomiks.github.io/tippyjs/v6/all-props/#followcursor) prop to 'initial' so the popup can appear in the cursor position, but it didnt work with the "manual" trigger. And seeing in their code how they achieved the positioning of the `followCursor` I realized that they achieved it by [rewriting the getBoundingClientRect of the popper instance](https://github.com/atomiks/tippyjs/blob/v4.3.5/src/createTippy.ts#L444), so that was what I replicated here. 

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
