### PR TITLE
Modal Adjust to Input Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Upcoming version 5.x.x (`develop` branch)
 
+- [#590]
+  - **Description:** Modal now resizes dynamically to adjust size based on content changes.
+  - **Products impact:** bugfix.
+  - **Addresses:**  https://github.com/learningequality/kolibri-design-system/issues/570
+  - **Components:** KModal.
+  - **Breaking:** No
+  - **Impacts a11y:** -
+  - **Guidance:** Consumers need to ensure the modal content is wrapped correctly for the resizing logic to work effectively. No additional steps required for integration.
+
+[#590]: https://github.com/learningequality/kolibri-design-system/pull/590/
+
 - [#549]
   - **Description:** Internal refactor of `KSelect` as part of moving away from Keen UI where related files were renamed and some functionality that wasn't exposed for public use was removed.
   - **Products impact:** none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ Changelog is rather internal in nature. See release notes for the public overvie
 ## Upcoming version 5.x.x (`develop` branch)
 
 - [#590]
-  - **Description:** Modal now resizes dynamically to adjust size based on content changes.
+  - **Description:** Modal now shrinks when the content has a smaller height.
   - **Products impact:** bugfix.
   - **Addresses:**  https://github.com/learningequality/kolibri-design-system/issues/570
   - **Components:** KModal.
-  - **Breaking:** No
+  - **Breaking:** no
   - **Impacts a11y:** -
-  - **Guidance:** Consumers need to ensure the modal content is wrapped correctly for the resizing logic to work effectively. No additional steps required for integration.
+  - **Guidance:** Consumers need to ensure the modal height is still working correctly.
 
 [#590]: https://github.com/learningequality/kolibri-design-system/pull/590/
 

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -99,7 +99,7 @@
 </template>
   
 
-  <script>
+<script>
 
   import debounce from 'lodash/debounce';
   import useKResponsiveWindow from './composables/useKResponsiveWindow';
@@ -349,7 +349,7 @@
 </script>
 
 
-  <style lang="scss" scoped>
+<style lang="scss" scoped>
 
   @import './styles/definitions';
 

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -299,17 +299,6 @@
         }
       }, 50),
 
-      attachInputListeners() {
-        const textInputs = this.$refs.content.querySelectorAll('input[type="text"], textarea');
-        const handleInput = () => {
-          // Call adjustContentHeight to manage height changes
-          this.adjustContentHeight();
-        };
-        textInputs.forEach(input => {
-          input.removeEventListener('input', handleInput); // Ensure no duplicates
-          input.addEventListener('input', handleInput);
-        });
-      },
       adjustContentHeight() {
         // Manage content height adjustment here
         this.$refs.content.style.height = 'auto';
@@ -449,4 +438,5 @@
   }
 
 </style>
+
   

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -206,9 +206,8 @@
         };
       },
       modalWidth() {
-        if (this.size === 'small') return '300px';
-        if (this.size === 'medium') return '450px';
-        if (this.size === 'large') return '100%';
+        if (this.size === SIZE_SM) return '300px';
+        if (this.size === SIZE_MD) return '450px';
         return `${this.size}px`;
       },
       maxModalWidth() {

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -97,7 +97,7 @@
   </transition>
 
 </template>
-  
+
 
 <script>
 
@@ -208,6 +208,7 @@
       modalWidth() {
         if (this.size === SIZE_SM) return '300px';
         if (this.size === SIZE_MD) return '450px';
+        if (this.size === SIZE_LG) return '100%';
         return `${this.size}px`;
       },
       maxModalWidth() {
@@ -216,7 +217,6 @@
       contentSectionMaxHeight() {
         return {
           'max-height': `${this.maxContentHeight}px`,
-          height: 'auto',
         };
       },
     },
@@ -292,8 +292,9 @@
           // (otherwise KSelect will be trapped inside modal if KSelect is opened a second time)
           if (this.$refs.content.clientHeight !== 0 && !this.containsKSelect) {
             // add a vertical scrollbar if content doesn't fit
-            this.$refs.content.style.overflowY =
-              this.$refs.content.scrollHeight > this.$refs.content.clientHeight ? 'auto' : 'hidden';
+            if (this.$refs.content.scrollHeight > this.$refs.content.clientHeight) {
+              this.$refs.content.style.overflowY = 'auto';
+            }
           }
         }
       }, 50),
@@ -433,5 +434,3 @@
   }
 
 </style>
-
-

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -298,10 +298,6 @@
         }
       }, 50),
 
-      adjustContentHeight() {
-        // Manage content height adjustment here
-        this.$refs.content.style.height = 'auto';
-      },
       emitCancelEvent() {
         if (!this.cancelDisabled) {
           /**
@@ -438,4 +434,4 @@
 
 </style>
 
-  
+

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -228,7 +228,7 @@
       contentSectionMaxHeight() {
         return {
           'max-height': `${this.maxContentHeight}px`,
-          height: `${this.contentHeight}px`,
+          height: 'auto',
         };
       },
     },
@@ -318,11 +318,6 @@
               // add a vertical scrollbar if content doesn't fit
               this.$refs.content.style.overflowY =
                   this.$refs.content.scrollHeight > this.$refs.content.clientHeight ? 'auto' : 'hidden';
-          }
-  
-          // we only update when necessary
-          if (this.contentHeight !== this.$refs.content.clientHeight) {
-              this.$refs.content.style.height = `${this.contentHeight}px`;
           }
       }
   }, 50),

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -38,7 +38,7 @@
             {{ errorMessage }}
           </span>
         </h1>
-
+  
         <!-- Stop propagation of enter key to prevent the submit event from being emitted twice -->
         <form
           class="form"
@@ -61,7 +61,7 @@
             <!-- @slot Main content of modal -->
             <slot></slot>
           </div>
-
+  
           <div
             ref="actions"
             class="actions"
@@ -95,12 +95,12 @@
       </div>
     </div>
   </transition>
-
-</template>
-
-
-<script>
-
+  
+  </template>
+  
+  
+  <script>
+  
   import debounce from 'lodash/debounce';
   import useKResponsiveWindow from './composables/useKResponsiveWindow';
 
@@ -108,10 +108,10 @@
   const SIZE_MD = 'medium';
   const SIZE_LG = 'large';
   const SIZE_STRINGS = [SIZE_SM, SIZE_MD, SIZE_LG];
-
+  
   // check for Nuxt.js SSR
   const nuxtServerSideRendering = process && process.server;
-
+  
   /**
    * Used to focus attention on a singular action/task
    */
@@ -286,40 +286,54 @@
        * If there is not enough vertical space, create a vertically scrollable area and a
        * scroll shadow
        */
-      updateContentSectionStyle: debounce(function() {
-        if (this.$refs.title && this.$refs.actions) {
-          if (Math.abs(this.$refs.content.scrollHeight - this.contentHeight) >= 8) {
-            // if there's dropdown & it is opened, the new scrollHeight detected shouldn't be applied,
-            // or else the modal will elongate after the dropdown content has been closed
-            this.contentHeight = this.containsKSelect
-              ? this.modalContentHeight
-              : this.$refs.content.scrollHeight;
+       updateContentSectionStyle: debounce(function() {
+      if (this.$refs.title && this.$refs.actions) {
+          // calculate new content height based on scrollHeight
+          const newContentHeight = this.$refs.content.scrollHeight;
+          if (Math.abs(newContentHeight - this.contentHeight) >= 8) {
+              // if there's dropdown & it is opened, the new scrollHeight detected shouldn't be applied,
+              // or else the modal will elongate after the dropdown content has been closed
+              this.contentHeight = this.containsKSelect
+                  ? this.modalContentHeight
+                  : newContentHeight;
           }
-
+  
           const maxContentHeightCheck =
-            this.windowHeight -
-            this.$refs.title.clientHeight -
-            this.$refs.actions.clientHeight -
-            32;
-
+              this.windowHeight -
+              this.$refs.title.clientHeight -
+              this.$refs.actions.clientHeight -
+              32;
+  
           // to prevent max height from toggling between pixels
           // we set a threshold of how many pixels the height should change before we update
           if (Math.abs(maxContentHeightCheck - this.maxContentHeight) >= 8) {
-            this.maxContentHeight = maxContentHeightCheck;
-            this.scrollShadow = this.maxContentHeight < this.$refs.content.scrollHeight;
+              this.maxContentHeight = maxContentHeightCheck;
+              this.scrollShadow = this.maxContentHeight < this.$refs.content.scrollHeight;
           }
-
+  
           // make sure that overflow-y won't be updated to 'auto' if this function is running for the first time
           // (otherwise Firefox would add a vertical scrollbar right away) + don't apply if modal contains KSelect
           // (otherwise KSelect will be trapped inside modal if KSelect is opened a second time)
           if (this.$refs.content.clientHeight !== 0 && !this.containsKSelect) {
-            // add a vertical scrollbar if content doesn't fit
-            if (this.$refs.content.scrollHeight > this.$refs.content.clientHeight) {
-              this.$refs.content.style.overflowY = 'auto';
-            }
+              // add a vertical scrollbar if content doesn't fit
+              this.$refs.content.style.overflowY =
+                  this.$refs.content.scrollHeight > this.$refs.content.clientHeight ? 'auto' : 'hidden';
           }
-        }
-      }, 50),
+  
+          // we only update when necessary
+          if (this.contentHeight !== this.$refs.content.clientHeight) {
+              this.$refs.content.style.height = `${this.contentHeight}px`;
+          }
+      }
+  }, 50),
+      attachInputListeners() {
+        const textInputs = this.$refs.content.querySelectorAll('input[type="text"], textarea');
+        textInputs.forEach(input => {
+          input.addEventListener('input', () => {
+            this.$refs.content.style.height = 'auto'; 
+          });
+        });
+      },
       emitCancelEvent() {
         if (!this.cancelDisabled) {
           /**
@@ -367,14 +381,14 @@
       },
     },
   };
-
-</script>
-
-
-<style lang="scss" scoped>
-
+  
+  </script>
+  
+  
+  <style lang="scss" scoped>
+  
   @import './styles/definitions';
-
+  
   .modal-overlay {
     position: fixed;
     top: 0;
@@ -386,48 +400,48 @@
     background-attachment: fixed;
     transition: opacity $core-time ease;
   }
-
+  
   // TODO: margins for stacked buttons.
   .modal {
     @extend %dropshadow-16dp;
-
+  
     position: absolute;
     top: 50%;
     left: 50%;
     margin: 0 auto;
     border-radius: $radius;
     transform: translate(-50%, -50%);
-
+  
     &:focus {
       outline: none;
     }
   }
-
+  
   .form {
     @extend %momentum-scroll;
   }
-
+  
   .modal-fade-enter-active,
   .modal-fade-leave-active {
     transition: all $core-time ease;
   }
-
+  
   .modal-fade-enter,
   .modal-fade-leave-active {
     opacity: 0;
   }
-
+  
   .title {
     padding: 24px;
     margin: 0;
     font-size: 24px;
   }
-
+  
   .content {
     padding: 0 24px;
     overflow-x: hidden;
   }
-
+  
   .scroll-shadow {
     background: linear-gradient(white 30%, hsla(0, 0%, 100%, 0)),
       linear-gradient(hsla(0, 0%, 100%, 0) 10px, white 70%) bottom,
@@ -441,7 +455,7 @@
   .contains-kselect {
     overflow: unset;
   }
-
+  
   .actions {
     padding: 24px;
     text-align: right;
@@ -454,4 +468,5 @@
     margin-left: 16px;
   }
 
-</style>
+  </style>
+  

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -281,12 +281,14 @@
             this.$refs.title.clientHeight -
             this.$refs.actions.clientHeight -
             32;
+
           // to prevent max height from toggling between pixels
           // we set a threshold of how many pixels the height should change before we update
           if (Math.abs(maxContentHeightCheck - this.maxContentHeight) >= 8) {
             this.maxContentHeight = maxContentHeightCheck;
             this.scrollShadow = this.maxContentHeight < this.$refs.content.scrollHeight;
           }
+
           // make sure that overflow-y won't be updated to 'auto' if this function is running for the first time
           // (otherwise Firefox would add a vertical scrollbar right away) + don't apply if modal contains KSelect
           // (otherwise KSelect will be trapped inside modal if KSelect is opened a second time)
@@ -298,7 +300,6 @@
           }
         }
       }, 50),
-
       emitCancelEvent() {
         if (!this.cancelDisabled) {
           /**


### PR DESCRIPTION
## Description

The modal now resizes like the description input every time the input size changes.

#### Issue addressed

Addresses #570

### Before/after screenshots

Before:

![image](https://github.com/learningequality/kolibri-design-system/assets/107520089/1f3cecb5-c58d-4e0b-aa04-d43542d54e4a)

![image](https://github.com/learningequality/kolibri-design-system/assets/107520089/98924555-9b99-4f9c-ae04-b350e776f42d)

After:

https://github.com/learningequality/kolibri-design-system/assets/107520089/551fcaa9-8961-4c3b-8605-80105c684d94

<!-- Insert images here if applicable -->

## Changelog

- [#590]
  - **Description:** Modal now resizes dynamically to adjust size based on content changes.
  - **Products impact:** bugfix.
  - **Addresses:**  https://github.com/learningequality/kolibri-design-system/issues/570
  - **Components:** KModal.
  - **Breaking:** No
  - **Impacts a11y:** -
  - **Guidance:** Consumers need to ensure the modal content is wrapped correctly for the resizing logic to work effectively. No additional steps required for integration.

[#590]: https://github.com/learningequality/kolibri-design-system/pull/590/

## Steps to test

1. Go to studio 
2. Studio channels
3. Edit title and description

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ X] Contributor has fully tested the PR manually
- [ X] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`
