### PR TITLE
KListWithOverflow: Miscellaneous fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ Changelog is rather internal in nature. See release notes for the public overvie
 ## Version 3.x.x (`release-v3` branch)
 
 - [#612]
-  - **Description:** KListWithOverflow fixes
+  - **Description:** Prevent KListWithOverflow hidden elements from taking up space on the screen.
+  - **Products impact:** bugfix.
+  - **Addresses:** - .
+  - **Components:** KListWithOverflow.
+  - **Breaking:** no.
+  - **Impacts a11y:** no.
+  - **Guidance:** - .
+
+- [#612]
+  - **Description:** Scope the styles of the KListWithOverflow component.
   - **Products impact:** bugfix.
   - **Addresses:** - .
   - **Components:** KListWithOverflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 3.x.x (`release-v3` branch)
 
+- [#612]
+  - **Description:** KListWithOverflow fixes
+  - **Products impact:** bugfix.
+  - **Addresses:** - .
+  - **Components:** KListWithOverflow.
+  - **Breaking:** no.
+  - **Impacts a11y:** no.
+  - **Guidance:** - .
+
+[#612]: https://github.com/learningequality/kolibri-design-system/pull/612
+
 - [##603]
   - **Description:** Adds thumps down icon that is needed in Studio for search recomendation work.
   - **Products impact:** New Icon

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -150,8 +150,10 @@
           if (itemWidth >= availableWidth || overflowItemsIdx.length > 0) {
             overflowItemsIdx.push(i);
             item.style.visibility = 'hidden';
+            item.style.position = 'absolute';
           } else {
             item.style.visibility = 'visible';
+            item.style.position = 'unset';
             maxWidth += itemWidth;
             availableWidth -= itemWidth;
             const itemHeight = itemsSizes[i].height;
@@ -238,7 +240,7 @@
 </script>
 
 
-<style>
+<style scoped>
 
   .list-wrapper {
     display: flex;
@@ -249,6 +251,7 @@
     overflow: visible;
     display: flex;
     flex-wrap: wrap;
+    position: relative;
   }
 
   .list > * {

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -252,6 +252,7 @@
     display: flex;
     flex-wrap: wrap;
     position: relative;
+    align-items: center;
   }
 
   .list > * {


### PR DESCRIPTION
## Description

Two fixes of the KListWithOverflow component:
* Add scoped style, to avoid interfering with other styles such as those of the [LanguageSwitcherList](https://github.com/learningequality/kolibri/pull/11911#issuecomment-2040388927).
* Add `position: absolute` to hidden elements to prevent them from taking up space on the screen.
  * before: 
![image](https://github.com/learningequality/kolibri-design-system/assets/51239030/1a55cc13-31ac-4dcb-ba39-9b29682b224e)
  * after: 
![image](https://github.com/learningequality/kolibri-design-system/assets/51239030/e9790c15-9f67-4c9a-a078-d508e9c86c92)




## Changelog


- [#612]
  - **Description:** Prevent KListWithOverflow hidden elements from taking up space on the screen.
  - **Products impact:** bugfix.
  - **Addresses:** - .
  - **Components:** KListWithOverflow.
  - **Breaking:** no.
  - **Impacts a11y:** no.
  - **Guidance:** - .

- [#612]
  - **Description:** Scope the styles of the KListWithOverflow component.
  - **Products impact:** bugfix.
  - **Addresses:** - .
  - **Components:** KListWithOverflow.
  - **Breaking:** no.
  - **Impacts a11y:** no.
  - **Guidance:** - .

[#612]: https://github.com/learningequality/kolibri-design-system/pull/612

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
