### PR TITLE
KTabLists overflow enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Upcoming version 5.x.x (`develop` branch)
 
+- [#635]
+  - **Description:** KListWithOverflow now takes into account the margin of items to calculate available space.
+  - **Products impact:** bugfix.
+  - **Addresses:** -.
+  - **Components:** KListWithOverflow.
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -
+
+- [#635]
+  - **Description:** KListWithOverflow now emits an event `updateOverflowItems` when overflowItems are recalculated.
+  - **Products impact:** new API.
+  - **Addresses:** -.
+  - **Components:** KListWithOverflow.
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -.
+
+- [#635]
+  - **Description:** Kbutton and KIconButton now emit @focus event.
+  - **Products impact:** new API.
+  - **Addresses:** -.
+  - **Components:** KButton, KIconButton.
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -.
+
+- [#635]
+  - **Description:** KTabsList now shows a "more" button for the overflowed tabs if they dont fit in the available space.
+  - **Products impact:** updated API.
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/623.
+  - **Components:** KTabsList, KTabs.
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -.
+
+- [#635]
+  - **Description:** KTabsList now receives a `tabAppearanceOverrides` prop to override styles of tab items.
+  - **Products impact:** new API.
+  - **Addresses:** .
+  - **Components:** KTabsList.
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -.  
+
+[#635]: https://github.com/learningequality/kolibri-design-system/pull/635
+
 - [#549]
   - **Description:** Internal refactor of `KSelect` as part of moving away from Keen UI where related files were renamed and some functionality that wasn't exposed for public use was removed.
   - **Products impact:** none

--- a/docs/pages/ktabs.vue
+++ b/docs/pages/ktabs.vue
@@ -4,7 +4,7 @@
     <DocsPageSection title="Overview" anchor="#overview">
       <p>Displays tabs:</p>
 
-      <DocsShow>
+      <DocsShow block style="max-width: 400px;">
         <KTabs
           tabsId="coachReportsTabs"
           ariaLabel="Coach reports"

--- a/docs/pages/ktabslist.vue
+++ b/docs/pages/ktabslist.vue
@@ -5,7 +5,7 @@
 
       <p>Displays the tab list of a tabbed interface:</p>
 
-      <DocsShow language="html">
+      <DocsShow language="html" block style="max-width: 400px;">
         <KTabsList
           v-model="ex1activeTabId"
           tabsId="tabsIntro"
@@ -178,7 +178,7 @@
 
       <p>Using props is the most straightforward:</p>
 
-      <DocsShow language="html" dark>
+      <DocsShow language="html" dark block style="max-width: 400px;">
         <KTabsList
           v-model="ex2activeTabId"
           tabsId="tabsProps"
@@ -210,7 +210,7 @@
 
       <p>When that's not sufficient, <code>appearanceOverrides</code> and <code>appearanceOverridesActive</code> can be used, where the former complements or overrides styles common to all tabs and the latter contains styles specific to an active tab:</p>
 
-      <DocsShow language="html">
+      <DocsShow language="html" block style="max-width: 530px">
         <KTabsList
           v-model="ex3activeTabId"
           tabsId="tabsAppearanceOverrides"
@@ -254,7 +254,7 @@
 
       <p>Lastly, the <code>tab</code> slot can be used to adjust labels, for example to add icons. It's a scoped slot that exposes <code>tab</code> object and <code>isActive</code> boolean value:</p> 
 
-      <DocsShow language="html">
+      <DocsShow language="html" block style="max-width: 485px;">
         <KTabsList
           v-model="ex4activeTabId"
           tabsId="tabsSlot"

--- a/docs/pages/playground.vue
+++ b/docs/pages/playground.vue
@@ -31,17 +31,17 @@
 
 <script>
 
+  /*
+    Playground is a Vue component too,
+    so you can also use `data`, `methods`, etc.
+    as usual if helpful
+  */
   export default {
+    name: 'Playground',
     data() {
-      return {
-        tabs: [
-          { id: 'tabLessons', label: 'Lessons' },
-          { id: 'tabLearners', label: 'Learners' },
-          { id: 'tabGroups', label: 'Groups' },
-        ],
-        activeTabId: 'tabLessons',
-      };
+      return {};
     },
+    methods: {},
   };
 
 </script>

--- a/docs/pages/playground.vue
+++ b/docs/pages/playground.vue
@@ -1,4 +1,3 @@
-
 <template>
 
   <!--
@@ -31,6 +30,7 @@
 
 
 <script>
+
   export default {
     data() {
       return {

--- a/docs/pages/playground.vue
+++ b/docs/pages/playground.vue
@@ -1,3 +1,4 @@
+
 <template>
 
   <!--
@@ -30,18 +31,17 @@
 
 
 <script>
-
-  /*
-    Playground is a Vue component too,
-    so you can also use `data`, `methods`, etc.
-    as usual if helpful
-  */
   export default {
-    name: 'Playground',
     data() {
-      return {};
+      return {
+        tabs: [
+          { id: 'tabLessons', label: 'Lessons' },
+          { id: 'tabLearners', label: 'Learners' },
+          { id: 'tabGroups', label: 'Groups' },
+        ],
+        activeTabId: 'tabLessons',
+      };
     },
-    methods: {},
   };
 
 </script>

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -140,13 +140,13 @@
     mounted() {
       this.trigger = this.$el.parentElement;
     },
-    beforeDestroy() {
-      window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
-    },
     computed: {
       menuItemsRef() {
         return this.$refs.menu.$el.querySelectorAll('li');
       },
+    },
+    beforeDestroy() {
+      window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);
     },
     methods: {
       handleOpen() {
@@ -204,12 +204,10 @@
         // manage rotating through the options using arrow keys
         // UP arrow: .keyCode is depricated and should used only as a fallback
         if (
-          (
-            event.key == 'ArrowUp' ||
+          (event.key == 'ArrowUp' ||
             event.keyCode == 38 ||
             event.key == 'ArrowLeft' ||
-            event.keyCode == 37
-          ) &&
+            event.keyCode == 37) &&
           popoverIsOpen
         ) {
           event.preventDefault();
@@ -222,12 +220,11 @@
           });
           // DOWN arrow
         } else if (
-          (
-            event.key == 'ArrowDown' ||
+          (event.key == 'ArrowDown' ||
             event.keyCode == 40 ||
             event.key == 'ArrowRight' ||
-            event.keyCode == 39
-          ) && popoverIsOpen
+            event.keyCode == 39) &&
+          popoverIsOpen
         ) {
           event.preventDefault();
           this.$nextTick(() => {
@@ -271,7 +268,7 @@
           const items = this.menuItemsRef;
           items[idx].focus();
         });
-      }
+      },
     },
   };
 

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -119,6 +119,11 @@
         trigger: null,
       };
     },
+    computed: {
+      menuItemsRef() {
+        return this.$refs.menu.$el.querySelectorAll('li');
+      },
+    },
     watch: {
       isContextMenuActive() {
         if (this.isContextMenuActive) {
@@ -139,11 +144,6 @@
     },
     mounted() {
       this.trigger = this.$el.parentElement;
-    },
-    computed: {
-      menuItemsRef() {
-        return this.$refs.menu.$el.querySelectorAll('li');
-      },
     },
     beforeDestroy() {
       window.removeEventListener('keydown', this.handleOpenMenuNavigation, true);

--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -203,7 +203,15 @@
 
         // manage rotating through the options using arrow keys
         // UP arrow: .keyCode is depricated and should used only as a fallback
-        if ((event.key == 'ArrowUp' || event.keyCode == 38) && popoverIsOpen) {
+        if (
+          (
+            event.key == 'ArrowUp' ||
+            event.keyCode == 38 ||
+            event.key == 'ArrowLeft' ||
+            event.keyCode == 37
+          ) &&
+          popoverIsOpen
+        ) {
           event.preventDefault();
           this.$nextTick(() => {
             if (prevSibling) {
@@ -213,7 +221,14 @@
             }
           });
           // DOWN arrow
-        } else if ((event.key == 'ArrowDown' || event.keyCode == 40) && popoverIsOpen) {
+        } else if (
+          (
+            event.key == 'ArrowDown' ||
+            event.keyCode == 40 ||
+            event.key == 'ArrowRight' ||
+            event.keyCode == 39
+          ) && popoverIsOpen
+        ) {
           event.preventDefault();
           this.$nextTick(() => {
             if (sibling) {

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -258,6 +258,7 @@
   .list-wrapper {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     width: 100%;
   }
   .list {

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -86,6 +86,9 @@
           this.setOverflowItems();
         });
       },
+      overflowItems() {
+        this.$emit('updateOverflowItems', this.overflowItems);
+      },
     },
     mounted() {
       // For some reason KIconButtons takes 2 ticks to render their actual size

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -70,6 +70,10 @@
         type: [Object, String],
         default: null,
       },
+      isAriaVisible: {
+        type: Boolean,
+        default: false,
+      },
     },
     data() {
       return {
@@ -160,11 +164,9 @@
           // all the following items will be hidden.
           if (itemWidth >= availableWidth || overflowItemsIdx.length > 0) {
             overflowItemsIdx.push(i);
-            item.style.visibility = 'hidden';
-            item.style.position = 'absolute';
+            this.hideItem(item);
           } else {
-            item.style.visibility = 'visible';
-            item.style.position = 'unset';
+            this.showItem(item);
             maxWidth += itemWidth;
             availableWidth -= itemWidth;
             const itemHeight = itemsSizes[i].height;
@@ -183,8 +185,7 @@
           while (overflowItemsIdx.length > 0) {
             const idx = overflowItemsIdx.pop();
             const item = list.children[idx];
-            item.style.visibility = 'visible';
-            item.style.position = 'unset';
+            this.showItem(item);
             maxWidth += itemsSizes[idx].width;
             availableWidth -= itemsSizes[idx].width;
           }
@@ -223,7 +224,7 @@
         const lastVisibleIdx = firstOverflowedIdx - 1;
         if (this.isDivider(this.items[lastVisibleIdx])) {
           const dividerNode = list.children[lastVisibleIdx];
-          dividerNode.style.visibility = 'hidden';
+          this.hideItem(dividerNode);
           return itemsSizes[lastVisibleIdx].width;
         }
       },
@@ -243,6 +244,25 @@
 
         this.isMoreButtonVisible = false;
         moreButtonWrapper.style.visibility = 'visible';
+      },
+      showItem(item) {
+        item.style.position = 'unset';
+          item.style.visibility = 'visible';
+        if (this.isAriaVisible) {
+          item.style.opacity = 1;
+          item.style.zIndex = 'unset';
+        }
+      },
+      hideItem(item) {
+        item.style.position = 'absolute';
+        if (this.isAriaVisible) {
+          item.style.opacity = 0;
+          item.style.zIndex = -1;
+          item.style.visibility = 'visible';
+
+        } else {
+          item.style.visibility = 'hidden';
+        }
       },
       isDivider(item) {
         return typeof item === 'object' && item.type === 'divider';

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -107,7 +107,15 @@
         if (!element) {
           return { width: 0, height: 0 };
         }
-        const { width, height } = element.getBoundingClientRect();
+        let { width, height } = element.getBoundingClientRect();
+
+        const style = element.currentStyle || window.getComputedStyle(element);
+        const marginX = parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+        const marginY = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+
+        width += marginX;
+        height += marginY;
+
         return { width, height };
       },
       /**
@@ -173,7 +181,9 @@
             const idx = overflowItemsIdx.pop();
             const item = list.children[idx];
             item.style.visibility = 'visible';
+            item.style.position = 'unset';
             maxWidth += itemsSizes[idx].width;
+            availableWidth -= itemsSizes[idx].width;
           }
         }
 

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -247,7 +247,7 @@
       },
       showItem(item) {
         item.style.position = 'unset';
-          item.style.visibility = 'visible';
+        item.style.visibility = 'visible';
         if (this.isAriaVisible) {
           item.style.opacity = 1;
           item.style.zIndex = 'unset';
@@ -259,7 +259,6 @@
           item.style.opacity = 0;
           item.style.zIndex = -1;
           item.style.visibility = 'visible';
-
         } else {
           item.style.visibility = 'hidden';
         }

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -12,6 +12,7 @@
     @keyup.enter.stop.prevent="handlePressEnter"
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
+    @focus="$emit('focus')"
   >
     <!-- @slot Slot alternative to the `icon` prop -->
     <slot name="icon"></slot>

--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -12,7 +12,7 @@
     @keyup.enter.stop.prevent="handlePressEnter"
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
-    @focus="$emit('focus')"
+    @focus="(event) => $emit('focus', event)"
   >
     <!-- @slot Slot alternative to the `icon` prop -->
     <slot name="icon"></slot>

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -21,6 +21,8 @@
       :secondary-text="hasSecondaryText ? option[keys.secondaryText] : null"
       :target="option[keys.target]"
       :isSelected="option[keys.isSelected]"
+      :role="option[keys.role]"
+      :ariaRoleDescription="option[keys.ariaRoleDescription]"
 
       :type="option[keys.type]"
       @click.native="($event) => selectOption(option, $event)"
@@ -82,6 +84,8 @@
             href: 'href',
             target: 'target',
             isSelected: 'isSelected',
+            role: 'role',
+            ariaRoleDescription: 'ariaRoleDescription',
           };
         },
       },

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -20,6 +20,7 @@
       :label="option[keys.type] === 'divider' ? null : option[keys.label] || option"
       :secondary-text="hasSecondaryText ? option[keys.secondaryText] : null"
       :target="option[keys.target]"
+      :isSelected="option[keys.isSelected]"
 
       :type="option[keys.type]"
       @click.native="($event) => selectOption(option, $event)"
@@ -80,6 +81,7 @@
             disabled: 'disabled',
             href: 'href',
             target: 'target',
+            isSelected: 'isSelected',
           };
         },
       },

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -8,7 +8,7 @@
     @blur="isActive = false"
     :role="role"
     :aria-roledescription="ariaRoleDescription"
-    :aria-selected="isSelected"
+    :aria-selected="isSelected ? 'true' : 'false'"  
     :class="classes"
     :style="activeStyle"
     :href="isAnchor ? (disabled ? null : href) : null"

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -21,7 +21,7 @@
           :icon="icon"
         />
  
-        <div class="ui-menu-option-text">
+        <div class="ui-menu-option-text" :style="labelStyles">
           {{ label }}
         </div>
 
@@ -70,6 +70,10 @@
         type: Boolean,
         default: false,
       },
+      isSelected: {
+        type: Boolean,
+        default: false,
+      },
     },
 
     computed: {
@@ -83,6 +87,16 @@
 
       activeStyle() {
         return this.isActive ? {...this.$coreOutline, outlineOffset: '-2px' } : {}
+      },
+      labelStyles() {
+        if (this.isSelected) {
+          return {
+            fontWeight: 'bold',
+            textDecoration: 'underline',
+            color: this.$themeTokens.primary,
+          };
+        }
+        return {};
       },
       isDivider() {
         return this.type === 'divider';

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -6,7 +6,7 @@
     supports-modality=keyboard
     @focus="isActive = true"
     @blur="isActive = false"
-    role="menu-item"
+    role="tab"
     :class="classes"
     :style="activeStyle"
     :href="isAnchor ? (disabled ? null : href) : null"

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -6,7 +6,9 @@
     supports-modality=keyboard
     @focus="isActive = true"
     @blur="isActive = false"
-    role="tab"
+    :role="role"
+    :aria-roledescription="ariaRoleDescription"
+    :aria-selected="isSelected"
     :class="classes"
     :style="activeStyle"
     :href="isAnchor ? (disabled ? null : href) : null"
@@ -74,6 +76,11 @@
         type: Boolean,
         default: false,
       },
+      role: {
+        type: String,
+        default: 'menu-item',
+      },
+      ariaRoleDescription: String
     },
 
     computed: {

--- a/lib/tabs/KTabs.vue
+++ b/lib/tabs/KTabs.vue
@@ -3,7 +3,7 @@
   <div>
     <KTabsList
       v-model="activeTabId"
-      v-bind="{ tabsId, tabs, ariaLabel, ariaLabelledBy, color, colorActive, backgroundColor, hoverBackgroundColor, appearanceOverrides, appearanceOverridesActive, enablePrint }"
+      v-bind="{ tabsId, tabs, ariaLabel, ariaLabelledBy, color, colorActive, backgroundColor, hoverBackgroundColor, appearanceOverrides, appearanceOverridesActive, tabAppearanceOverrides, enablePrint }"
     >
       <!-- provide the same `tab` slot and send its properties further up from `KTabsList` -->
       <template #tab="{ tab, isActive }">

--- a/lib/tabs/KTabs.vue
+++ b/lib/tabs/KTabs.vue
@@ -3,7 +3,7 @@
   <div>
     <KTabsList
       v-model="activeTabId"
-      v-bind="{ tabsId, tabs, ariaLabel, ariaLabelledBy, color, colorActive, backgroundColor, hoverBackgroundColor, appearanceOverrides, appearanceOverridesActive, tabAppearanceOverrides, enablePrint }"
+      v-bind="{ tabsId, tabs, ariaLabel, ariaLabelledBy, color, colorActive, backgroundColor, hoverBackgroundColor, appearanceOverrides, appearanceOverridesActive, tabAppearanceOverrides, enablePrint, moreButtonTooltip }"
     >
       <!-- provide the same `tab` slot and send its properties further up from `KTabsList` -->
       <template #tab="{ tab, isActive }">

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -123,10 +123,6 @@
         type: String,
         required: true,
       },
-      tabAppearanceOverrides: {
-        type: [Object, String],
-        default: null,
-      },
     },
     data() {
       return {

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -4,6 +4,7 @@
     v-show="enablePrint || !$isPrint"
     ref="tabList"
     role="tablist"
+    isAriaVisible
     :items="tabsItems"
     :[ariaLabelAttrName]="ariaLabelAttr"
     @updateOverflowItems="overflowTabs = $event"
@@ -185,9 +186,11 @@
         return this.tabs.map(tab => this.$refs[this.tabRefLabel(tab.id)]);
       },
       tabsItems() {
-        return this.tabs.map(tab => ({
+        return this.tabs.map((tab, idx) => ({
           ...tab,
           isSelected: this.isTabActive(tab.id),
+          role: 'tab',
+          ariaRoleDescription: `tab ${idx + 1} of ${this.tabs.length}`
         }));
       },
       lastTabIdx() {

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -70,6 +70,7 @@
         tooltip="More"
         icon="optionsHorizontal"
         :style="overflowButtonStyles()"
+        @focus="focusedTabIdx = moreButtonFocusIdx"
       >
         <template #menu>
           <KDropdownMenu
@@ -131,6 +132,7 @@
         focusedTabIdx: 0,
         firstTabIdx: 0,
         overflowTabs: [],
+        moreButtonFocusIdx: -1,
       };
     },
     computed: {
@@ -187,6 +189,9 @@
           return 0;
         }
         return this.tabs.length - 1 - this.overflowTabs.length;
+      },
+      isMoreButtonFocused() {
+        return this.focusedTabIdx === this.moreButtonFocusIdx;
       },
     },
     mounted() {
@@ -262,13 +267,18 @@
         let newFocusedTabIdx;
         if (this.focusedTabIdx === this.firstTabIdx) {
           newFocusedTabIdx = this.lastTabIdx;
+        } else if (this.isMoreButtonFocused) {
+          newFocusedTabIdx = this.lastTabIdx;
         } else {
           newFocusedTabIdx = this.focusedTabIdx - 1;
         }
         this.focusTab(newFocusedTabIdx);
       },
       focusNextTab() {
-        if (this.focusedTabIdx === this.lastTabIdx && this.overflowTabs.length) {
+        if (
+          (this.isMoreButtonFocused || this.focusedTabIdx === this.lastTabIdx) &&
+          this.overflowTabs.length
+        ) {
           this.focusOverflowedTab(0);
           return;
         }

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -4,7 +4,7 @@
     v-show="enablePrint || !$isPrint"
     ref="tabList"
     role="tablist"
-    :items="tabs"
+    :items="tabsItems"
     :[ariaLabelAttrName]="ariaLabelAttr"
     @updateOverflowItems="overflowTabs = $event"
   >
@@ -183,6 +183,12 @@
       },
       tabsRef() {
         return this.tabs.map(tab => this.$refs[this.tabRefLabel(tab.id)]);
+      },
+      tabsItems() {
+        return this.tabs.map(tab => ({
+          ...tab,
+          isSelected: this.isTabActive(tab.id),
+        }));
       },
       lastTabIdx() {
         if (!this.tabs || !this.tabs.length) {

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -131,7 +131,6 @@
         focusedTabIdx: 0,
         firstTabIdx: 0,
         overflowTabs: [],
-        moreButtonFocusIdx: -1,
       };
     },
     computed: {
@@ -188,9 +187,6 @@
           return 0;
         }
         return this.tabs.length - 1 - this.overflowTabs.length;
-      },
-      isMoreButtonFocused() {
-        return this.focusedTabIdx === this.moreButtonFocusIdx;
       },
     },
     mounted() {
@@ -259,10 +255,7 @@
         this.focusTab(this.lastTabIdx);
       },
       focusPreviousTab() {
-        if (
-          this.focusedTabIdx === this.firstTabIdx &&
-          this.overflowTabs.length
-        ) {
+        if (this.focusedTabIdx === this.firstTabIdx && this.overflowTabs.length) {
           this.focusOverflowedTab(this.overflowTabs.length - 1);
           return;
         }
@@ -275,10 +268,7 @@
         this.focusTab(newFocusedTabIdx);
       },
       focusNextTab() {
-        if (
-          this.focusedTabIdx === this.lastTabIdx &&
-          this.overflowTabs.length
-        ) {
+        if (this.focusedTabIdx === this.lastTabIdx && this.overflowTabs.length) {
           this.focusOverflowedTab(0);
           return;
         }

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -5,6 +5,7 @@
     role="tablist"
     :items="tabs"
     :[ariaLabelAttrName]="ariaLabelAttr"
+    ref="tabList"
   >
     <template #item="{ item: tab }">
       <!-- https://v3.router.vuejs.org/api/#example-applying-active-class-to-outer-element -->
@@ -18,6 +19,7 @@
           :id="getTabElementId(tabsId, tab.id)"
           ref="tab"
           role="tab"
+          :key="tab.id"
           :data-activeroute="isActive"
           :data-tabid="tab.id"
           :href="href"
@@ -62,7 +64,7 @@
     <template #more="{ overflowItems }">
       <KIconButton
         tooltip="More"
-        icon="optionsVertical"
+        icon="optionsHorizontal"
         :style="overflowButtonStyles(overflowItems)"
       >
         <template #menu>
@@ -170,6 +172,12 @@
           )
         );
       },
+      tabsRef() {
+        const tabList = this.$refs.tabList;
+        const tabs = tabList.$refs.tab;
+        console.log("tabs", tabs, this.$refs.tab);
+        return tabs || [];
+      },
     },
     mounted() {
       /*
@@ -182,7 +190,7 @@
        */
       if (this.useRouter) {
         this.$nextTick(() => {
-          const activeRouteTab = this.$refs.tab.find(tab => tab.dataset.activeroute);
+          const activeRouteTab = this.tabsRef.find(tab => tab.dataset.activeroute);
           if (activeRouteTab !== undefined) {
             const activeRouteTabId = activeRouteTab.dataset.tabid;
             this.emitActivate(activeRouteTabId);
@@ -225,7 +233,7 @@
       focusTab(tabIdx) {
         if (tabIdx !== undefined && tabIdx !== null) {
           this.focusedTabIdx = tabIdx;
-          this.$refs.tab[tabIdx].focus();
+          this.tabsRef[tabIdx].focus();
         }
       },
       focusFirstTab() {
@@ -253,11 +261,17 @@
         this.focusTab(activeTabIdx);
       },
       onClick(tabId, navigate, event) {
+        if (this.useRouter) {
+          this.$router.push({ name: tabId });
+        }
         this.focusedTabIdx = this.getTabIdx(tabId);
         this.emitClick(tabId);
         this.emitActivate(tabId);
         if (navigate) {
           navigate(event);
+        }
+        if (this.useRouter && !navigate) {
+
         }
       },
       onKeyUp(event) {
@@ -295,6 +309,8 @@
       },
       overflowButtonStyles(overflow) {
         return {
+          width: '38px !important',
+          height: '38px !important',
           border: this.activeSectionIsHidden(overflow)
             ? '2px solid ' + this.$themeTokens.primary
             : 'none',

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -190,7 +190,7 @@
           ...tab,
           isSelected: this.isTabActive(tab.id),
           role: 'tab',
-          ariaRoleDescription: `tab ${idx + 1} of ${this.tabs.length}`
+          ariaRoleDescription: `tab ${idx + 1} of ${this.tabs.length}`,
         }));
       },
       lastTabIdx() {

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -73,7 +73,7 @@
       >
         <template #menu>
           <KDropdownMenu
-            ref="moreButton"
+            ref="tabsMenu"
             :options="overflowItems"
             @select="(tab) => onClick(tab.id)"
             @focusBeforeFirstElement="focusBeforeMoreButton"
@@ -211,24 +211,12 @@
           }
         });
       }
-      this.$el.addEventListener('keyup', this.onKeyUp);
-      document.addEventListener('keydown', this.preventScroll);
+      this.$el.addEventListener('keydown', this.onKeyDown);
     },
     beforeDestroy() {
-      this.$el.removeEventListener('keyup', this.onKeyUp);
-      document.removeEventListener('keydown', this.preventScroll);
+      this.$el.removeEventListener('keydown', this.onKeyDown);
     },
     methods: {
-      preventScroll(event) {
-        if (['ArrowLeft', 'ArrowRight'].includes(event.key)) {
-          if (
-            this.$el.contains(document.activeElement) ||
-            this.$refs.moreButton.$el.contains(document.activeElement)
-          ) {
-            event.preventDefault();
-          }
-        }
-      },
       classes(tabId) {
         return [
           'tab',
@@ -271,28 +259,32 @@
         this.focusTab(this.lastTabIdx);
       },
       focusPreviousTab() {
+        if (
+          this.focusedTabIdx === this.firstTabIdx &&
+          this.overflowTabs.length
+        ) {
+          this.focusOverflowedTab(this.overflowTabs.length - 1);
+          return;
+        }
         let newFocusedTabIdx;
         if (this.focusedTabIdx === this.firstTabIdx) {
-          if (this.overflowTabs.length) {
-            this.$refs.moreButton.focusItem(this.overflowTabs.length - 1);
-            return;
-          } else {
-            newFocusedTabIdx = this.lastTabIdx;
-          }
+          newFocusedTabIdx = this.lastTabIdx;
         } else {
           newFocusedTabIdx = this.focusedTabIdx - 1;
         }
         this.focusTab(newFocusedTabIdx);
       },
       focusNextTab() {
+        if (
+          this.focusedTabIdx === this.lastTabIdx &&
+          this.overflowTabs.length
+        ) {
+          this.focusOverflowedTab(0);
+          return;
+        }
         let newFocusedTabIdx;
         if (this.focusedTabIdx === this.lastTabIdx) {
-          if (this.overflowTabs.length) {
-            this.$refs.moreButton.focusItem(0);
-            return;
-          } else {
-            newFocusedTabIdx = this.firstTabIdx;
-          }
+          newFocusedTabIdx = this.firstTabIdx;
         } else {
           newFocusedTabIdx = this.focusedTabIdx + 1;
         }
@@ -312,6 +304,9 @@
       focusAfterMoreButton() {
         requestAnimationFrame(() => this.focusFirstTab());
       },
+      focusOverflowedTab(idx) {
+        this.$refs.tabsMenu.focusItem(idx);
+      },
       onClick(tabId, navigate, event) {
         this.focusedTabIdx = this.getTabIdx(tabId);
         const tab = this.tabs[this.focusedTabIdx];
@@ -327,7 +322,7 @@
           navigate(event);
         }
       },
-      onKeyUp(event) {
+      onKeyDown(event) {
         const handlers = {
           ArrowLeft: this.focusPreviousTab,
           ArrowRight: this.focusNextTab,

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -1,15 +1,15 @@
 <template>
 
-  <div
+  <KListWithOverflow
     v-show="enablePrint || !$isPrint"
     role="tablist"
+    :items="tabs"
     :[ariaLabelAttrName]="ariaLabelAttr"
   >
-    <template v-if="useRouter">
+    <template #item="{ item: tab }">
       <!-- https://v3.router.vuejs.org/api/#example-applying-active-class-to-outer-element -->
       <router-link
-        v-for="tab in tabs"
-        :key="tab.id"
+        v-if="useRouter"
         v-slot="{ href, navigate, isActive }"
         :to="tab.to"
         custom
@@ -37,13 +37,9 @@
           </slot>
         </a>
       </router-link>
-    </template>
-
-    <template v-else>
       <button
-        v-for="tab in tabs"
+        v-else
         :id="getTabElementId(tabsId, tab.id)"
-        :key="tab.id"
         ref="tab"
         type="button"
         role="tab"
@@ -63,7 +59,21 @@
         </slot>
       </button>
     </template>
-  </div>
+    <template #more="{ overflowItems }">
+      <KIconButton
+        tooltip="More"
+        icon="optionsVertical"
+        :style="overflowButtonStyles(overflowItems)"
+      >
+        <template #menu>
+          <KDropdownMenu
+            :options="overflowItems"
+            @select="(tab) => onClick(tab.id)"
+          />
+        </template>
+      </KIconButton>
+    </template>
+  </KListWithOverflow>
 
 </template>
 
@@ -278,6 +288,17 @@
          * programatically in addition to user interaction.
          */
         this.$emit('click', tabId);
+      },
+      activeSectionIsHidden(overflow) {
+        const ids = overflow.map(i => i.id);
+        return ids.includes(this.activeTabId);
+      },
+      overflowButtonStyles(overflow) {
+        return {
+          border: this.activeSectionIsHidden(overflow)
+            ? '2px solid ' + this.$themeTokens.primary
+            : 'none',
+        };
       },
     },
   };

--- a/lib/tabs/__tests__/KTabs.spec.js
+++ b/lib/tabs/__tests__/KTabs.spec.js
@@ -46,6 +46,7 @@ describe(`KTabs`, () => {
       ariaLabel: 'Coach tabs',
       ariaLabelledBy: 'id-of-element-with-label',
       color: 'colorCode',
+      moreButtonTooltip: 'More',
       colorActive: 'colorActiveCode',
       backgroundColor: 'backgroundColorCode',
       hoverBackgroundColor: 'hoverBackgroundColorCode',

--- a/lib/tabs/__tests__/KTabs.spec.js
+++ b/lib/tabs/__tests__/KTabs.spec.js
@@ -55,6 +55,9 @@ describe(`KTabs`, () => {
       appearanceOverridesActive: {
         color: 'appearanceOverridesActiveColorCode',
       },
+      tabAppearanceOverrides: {
+        height: 'appearanceOverridesTabHeight',
+      },
       enablePrint: true,
     };
     const wrapper = makeWrapper({ propsData: props });

--- a/lib/tabs/__tests__/KTabsList.spec.js
+++ b/lib/tabs/__tests__/KTabsList.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount, mount, createLocalVue } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 import KTabsList from '../KTabsList.vue';
 
@@ -41,7 +41,7 @@ describe(`KTabsList`, () => {
   });
 
   it(`smoke test`, () => {
-    const wrapper = shallowMount(KTabsList);
+    const wrapper = mount(KTabsList);
     expect(wrapper.exists()).toBeTruthy();
   });
 

--- a/lib/tabs/__tests__/KTabsList.spec.js
+++ b/lib/tabs/__tests__/KTabsList.spec.js
@@ -41,7 +41,7 @@ describe(`KTabsList`, () => {
   });
 
   it(`smoke test`, () => {
-    const wrapper = makeWrapper({ propsData: {tabs: [] }})
+    const wrapper = makeWrapper({ propsData: { tabs: [] } });
     expect(wrapper.exists()).toBeTruthy();
   });
 

--- a/lib/tabs/__tests__/KTabsList.spec.js
+++ b/lib/tabs/__tests__/KTabsList.spec.js
@@ -41,7 +41,7 @@ describe(`KTabsList`, () => {
   });
 
   it(`smoke test`, () => {
-    const wrapper = mount(KTabsList);
+    const wrapper = makeWrapper({ propsData: {tabs: [] }})
     expect(wrapper.exists()).toBeTruthy();
   });
 

--- a/lib/tabs/tabsMixin.js
+++ b/lib/tabs/tabsMixin.js
@@ -111,6 +111,13 @@ export default {
       required: false,
       default: false,
     },
+    /**
+     * If provided, overrides the styles of the tab items.
+     */
+    tabAppearanceOverrides: {
+      type: [Object, String],
+      default: null,
+    },
   },
   computed: {
     /**

--- a/lib/tabs/tabsMixin.js
+++ b/lib/tabs/tabsMixin.js
@@ -118,6 +118,13 @@ export default {
       type: [Object, String],
       default: null,
     },
+    /**
+     * Tooltip text for the more button when the tabs overflow.
+     */
+    moreButtonTooltip: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     /**


### PR DESCRIPTION
## Description
This PR introduces KListWithOverflow in KTabsList, so KTabsList now shows a "more" button for the overflowed tabs if they dont fit in the available space.

#### Issue addressed
Addresses #623

### Screencasts

https://github.com/learningequality/kolibri/assets/51239030/613e416b-f966-4235-9313-15e620f4e0ee

https://github.com/learningequality/kolibri/assets/51239030/cced15c4-a9cb-4508-8f2c-9a46c223f399

## Changelog

- [#635]
  - **Description:** KListWithOverflow now takes into account the margin of items to calculate available space.
  - **Products impact:** bugfix.
  - **Addresses:** -.
  - **Components:** KListWithOverflow.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

- [#635]
  - **Description:** KListWithOverflow now emits an event `updateOverflowItems` when overflowItems are recalculated.
  - **Products impact:** new API.
  - **Addresses:** -.
  - **Components:** KListWithOverflow.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

- [#635]
  - **Description:** Kbutton and KIconButton now emit @focus event.
  - **Products impact:** new API.
  - **Addresses:** -.
  - **Components:** KButton, KIconButton.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

- [#635]
  - **Description:** KTabsList now shows a "more" button for the overflowed tabs if they dont fit in the available space.
  - **Products impact:** updated API.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/623.
  - **Components:** KTabsList, KTabs.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

- [#635]
  - **Description:** KTabsList now receives a `tabAppearanceOverrides` prop to override styles of tab items.
  - **Products impact:** new API.
  - **Addresses:** .
  - **Components:** KTabsList.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.  

[#635]: https://github.com/learningequality/kolibri-design-system/pull/635

## Steps to test

Play with KTabsList and KTabs in the playground and check that it handles overflow properly.

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
