### PR TITLE
Remove Internet Explorer 11 specific logic from KTextTruncator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Components:** KTextTruncator
   - **Breaking:** no
   - **Impacts a11y:** -
-  - **Guidance:** Consumers need to ensure the modal  is still working correctly.
+  - **Guidance:** Consumers need to ensure the component KTextTruncator  is still working correctly.
 
 [#652]: https://github.com/learningequality/kolibri-design-system/pull/652/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ Changelog is rather internal in nature. See release notes for the public overvie
 ## Upcoming version 5.x.x (`develop` branch)
 
 - [#652]
-  - **Description:** Remove Internet Explorer 11 specific logic from KTextTruncator.
-  - **Products impact:** bugfix.
+  - **Description:** KTextTruncator drops support for Internet Explorer 11
+  - **Products impact:** browser support update
   - **Addresses:**  https://github.com/learningequality/kolibri-design-system/issues/643
   - **Components:** KTextTruncator
-  - **Breaking:** no
+  - **Breaking:** yes
   - **Impacts a11y:** -
-  - **Guidance:** Consumers need to ensure the component KTextTruncator  is still working correctly.
+  - **Guidance:** To be used in newer versions of products that don't need to support IE11 (Kolibri 0.17 and higher)
 
 [#652]: https://github.com/learningequality/kolibri-design-system/pull/652/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Upcoming version 5.x.x (`develop` branch)
 
+- [#652]
+  - **Description:** Remove Internet Explorer 11 specific logic from KTextTruncator.
+  - **Products impact:** bugfix.
+  - **Addresses:**  https://github.com/learningequality/kolibri-design-system/issues/643
+  - **Components:** KTextTruncator
+  - **Breaking:** no
+  - **Impacts a11y:** -
+  - **Guidance:** Consumers need to ensure the modal  is still working correctly.
+
+[#652]: https://github.com/learningequality/kolibri-design-system/pull/652/
+
 - [#590]
   - **Description:** Modal now shrinks when the content has a smaller height.
   - **Products impact:** bugfix.

--- a/lib/KTextTruncator.vue
+++ b/lib/KTextTruncator.vue
@@ -32,10 +32,6 @@
   /**
    * Truncates text to a certain number of lines
    * and adds an ellipsis character "…"
-   *
-   * Internet Explorer note:
-   * Depending on length of words of the text, there might
-   * be a gap between the last visible word and "…"
    */
   export default {
     name: 'KTextTruncator',
@@ -55,15 +51,6 @@
         type: Number,
         required: false,
         default: 1,
-      },
-      /**
-       * Text line height in rem.
-       * Used only for Internet Explorer fallback.
-       */
-      lineHeightIE: {
-        type: Number,
-        required: false,
-        default: 1.4,
       },
     },
     computed: {
@@ -101,47 +88,9 @@
             // needed to make line clamp work for very long word with no spaces
             overflowWrap: 'break-word',
           };
-        } else {
-          /*
-              (C)
-              Fallback for multiple lines in Internet Explorer and some older versions
-              of other browsers that don't support line clamp
-              (https://caniuse.com/mdn-css_properties_-webkit-line-clamp).
-              Calculate max height and add "..." in `::before` while covering it with
-              white rectangle defined in `::after` when text doesn't need to be truncated.
-              Adapted from https://hackingui.com/a-pure-css-solution-for-multiline-text-truncation/
-              and https://css-tricks.com/line-clampin/#the-hide-overflow-place-ellipsis-pure-css-way.
-            */
-          const ellipsisWidth = '1rem';
-          return {
-            overflow: 'hidden',
-            position: 'relative',
-            lineHeight: `${this.lineHeightIE}rem`,
-            maxHeight: `${this.maxLines * this.lineHeightIE}rem`,
-            // needed to make truncation work for very long word with no spaces
-            // `word-wrap` is a legacy name for `overflow-wrap` that needs to be used for IE
-            wordWrap: 'break-word',
-            // create space for "..."
-            paddingRight: ellipsisWidth,
-            marginRigth: `-${ellipsisWidth}`,
-            '::before': {
-              content: "'…'",
-              position: 'absolute',
-              right: 0,
-              bottom: 0,
-            },
-            // cover "..." with white rectangle when text
-            // doesn't need to be truncated
-            '::after': {
-              content: "''",
-              position: 'absolute',
-              right: 0,
-              width: ellipsisWidth,
-              height: '100%',
-              background: this.$themeTokens.surface,
-            },
-          };
         }
+          // Default return value for when neither condition is met
+        return {};
       },
     },
   };

--- a/lib/KTextTruncator.vue
+++ b/lib/KTextTruncator.vue
@@ -72,9 +72,6 @@
             whiteSpace: 'nowrap',
           };
         }
-
-        // 54 is random number only to be able to define `supports` test condition
-        if ('CSS' in window && CSS.supports && CSS.supports('-webkit-line-clamp: 54')) {
           /*
               (B)
               For multiple lines, use line clamp in browsers that support it
@@ -87,10 +84,7 @@
             '-webkit-box-orient': 'vertical',
             // needed to make line clamp work for very long word with no spaces
             overflowWrap: 'break-word',
-          };
-        }
-          // Default return value for when neither condition is met
-        return {};
+        };
       },
     },
   };

--- a/lib/KTextTruncator.vue
+++ b/lib/KTextTruncator.vue
@@ -72,18 +72,18 @@
             whiteSpace: 'nowrap',
           };
         }
-          /*
+        /*
               (B)
               For multiple lines, use line clamp in browsers that support it
               (https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp)
             */
-          return {
-            overflow: 'hidden',
-            display: '-webkit-box',
-            '-webkit-line-clamp': `${this.maxLines}`,
-            '-webkit-box-orient': 'vertical',
-            // needed to make line clamp work for very long word with no spaces
-            overflowWrap: 'break-word',
+        return {
+          overflow: 'hidden',
+          display: '-webkit-box',
+          '-webkit-line-clamp': `${this.maxLines}`,
+          '-webkit-box-orient': 'vertical',
+          // needed to make line clamp work for very long word with no spaces
+          overflowWrap: 'break-word',
         };
       },
     },


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

In summary, to remove IE11 support from the KTextTruncator component:

Remove the lineHeightIE prop.
Remove the IE11 fallback logic and related styles from the truncate method.

This change, treated as a breaking change, aims to simplify the component by removing unnecessary code for the unsupported IE11 browser. The updated component should be thoroughly tested to ensure no regressions.

#### Issue addressed

[#643](https://github.com/learningequality/kolibri-design-system/issues/643)

Addresses #652

### Before/after screenshots
<!-- Insert images here if applicable -->
Before
![image](https://github.com/learningequality/kolibri-design-system/assets/93144092/6539f210-991d-4b3a-91d7-9602de27ff93)


After
![image](https://github.com/learningequality/kolibri-design-system/assets/93144092/58b9b1d0-b632-4ccf-8698-9d5395c3e7e3)



## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
