### PR TITLE
DRAFT: Updates `DD` to `dd` and `YYYY` to `yyyy` to fix error from `date-fns/format`

### DIFF
--- a/docs/pages/kdaterange.vue
+++ b/docs/pages/kdaterange.vue
@@ -57,7 +57,7 @@
           [validationConstants.START_DATE_AFTER_END_DATE]: 'Start date cannot be after end date',
           [validationConstants.FUTURE_DATE]: 'Cannot select a future date',
           [validationConstants.DATE_BEFORE_FIRST_ALLOWED]:
-            'Date must be after ' + format(this.firstAllowedDate, 'DD/MM/YYYY'),
+            'Date must be after ' + format(this.firstAllowedDate, 'dd/MM/yyyy'),
         };
       },
     },

--- a/lib/KDateRange/KDateCalendar.vue
+++ b/lib/KDateRange/KDateCalendar.vue
@@ -263,9 +263,9 @@
         var currDate = this.getDate(key, result);
         return (
           (this.selectedStartDate &&
-            format(this.selectedStartDate, 'DD/MM/YYYY') === format(currDate, 'DD/MM/YYYY')) ||
+            format(this.selectedStartDate, 'dd/MM/yyyy') === format(currDate, 'dd/MM/yyyy')) ||
           (this.selectedEndDate &&
-            format(this.selectedEndDate, 'DD/MM/YYYY') === format(currDate, 'DD/MM/YYYY'))
+            format(this.selectedEndDate, 'dd/MM/yyyy') === format(currDate, 'dd/MM/yyyy'))
         );
       },
       /**
@@ -282,18 +282,18 @@
           this.isValidDate(this.selectedStartDate) &&
           this.isValidDate(this.selectedEndDate) &&
           isAfter(this.selectedEndDate, this.selectedStartDate) &&
-          format(this.selectedStartDate, 'DD/MM/YYYY') !==
-            format(this.selectedEndDate, 'DD/MM/YYYY')
+          format(this.selectedStartDate, 'dd/MM/yyyy') !==
+            format(this.selectedEndDate, 'dd/MM/yyyy')
         ) {
           if (
             this.selectedStartDate &&
-            format(this.selectedStartDate, 'DD/MM/YYYY') === format(currDate, 'DD/MM/YYYY') &&
+            format(this.selectedStartDate, 'dd/MM/yyyy') === format(currDate, 'dd/MM/yyyy') &&
             !(dayInWeekIndex === 7)
           ) {
             return 'first';
           } else if (
             this.selectedEndDate &&
-            format(this.selectedEndDate, 'DD/MM/YYYY') === format(currDate, 'DD/MM/YYYY') &&
+            format(this.selectedEndDate, 'dd/MM/yyyy') === format(currDate, 'dd/MM/yyyy') &&
             !(dayInWeekIndex === 1) &&
             !(result === 1)
           ) {

--- a/lib/KDateRange/index.vue
+++ b/lib/KDateRange/index.vue
@@ -187,10 +187,10 @@
     data() {
       return {
         dateRange: {
-          start: this.defaultStartDate ? format(this.defaultStartDate, 'YYYY-MM-DD') : null,
+          start: this.defaultStartDate ? format(this.defaultStartDate, 'yyyy-MM-dd') : null,
           end:
             this.defaultStartDate && this.defaultEndDate
-              ? format(this.defaultEndDate, 'YYYY-MM-DD')
+              ? format(this.defaultEndDate, 'yyyy-MM-dd')
               : null,
         },
         modalSize: 480,
@@ -259,7 +259,7 @@
         if (!date) {
           return null;
         }
-        return format(date, 'YYYY-MM-DD');
+        return format(date, 'yyyy-MM-dd');
       },
       /** Returns startDateInvalid message from validation machine */
       invalidStart() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "aphrodite": "https://github.com/learningequality/aphrodite/",
     "autosize": "3.0.21",
     "css-element-queries": "1.2.0",
-    "date-fns": "1.30.1",
+    "date-fns": "^3.6.0",
     "frame-throttle": "3.0.0",
     "fuzzysearch": "1.0.3",
     "lodash": "4.17.21",
@@ -81,5 +81,8 @@
   },
   "browserslist": [
     "extends browserslist-config-kolibri"
-  ]
+  ],
+  "volta": {
+    "node": "10.24.1"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4759,10 +4759,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
## Description

The error reported in https://github.com/learningequality/kolibri/issues/12350 shows that `date-fns` is complaining about the use of all-caps date formatting throughout.

Initially, I fixed this in the `DataPage` component in Kolibri, but then the complaint extended to KDS components.

I am not sure if this is the proper fix, but I'm making the PR as I made the changes to be sure they'd fix the issue, and they do.

But, will wait for thoughts from @LianaHarris360 