### PR TITLE
Fix ktabs extra space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 4.x.x (`release-v4` branch)
 
+- [#673]
+  - **Description:** Remove white space below Ktabs
+  - **Products impact:** bugfix.
+  - **Addresses:** https://github.com/learningequality/kolibri/issues/12297.
+  - **Components:** KTabsList, KTabs, KTabsPanel.
+  - **Breaking:** no
+  - **Impacts a11y:**no
+  - **Guidance:** .
+
+[#673]: https://github.com/learningequality/kolibri-design-system/pull/673
+
 - [#629]
   - **Description:** Improves the contrast for highlighted text, noted in KTextbox
   - **Products impact:** None

--- a/lib/tabs/KTabsList.vue
+++ b/lib/tabs/KTabsList.vue
@@ -310,6 +310,9 @@
     border-top-left-radius: $radius;
     border-top-right-radius: $radius;
     transition: background-color $core-time ease;
+    // Setting vertical align here to prevent an extra space below the tabs
+    // https://stackoverflow.com/questions/23529369/why-does-x-overflowhidden-cause-extra-space-below
+    vertical-align: middle;
 
     @media print {
       min-width: 0;


### PR DESCRIPTION
## Description

Having an inline-block element with an `overflow: hidden` style causes an extra white space in its parent. See: https://stackoverflow.com/questions/23529369/why-does-x-overflowhidden-cause-extra-space-below.

#### Issue addressed
Needed to close https://github.com/learningequality/kolibri/issues/12297.

### Before/after screenshots

Before: 
![image](https://github.com/learningequality/kolibri-design-system/assets/51239030/1c2dc810-4a8e-4264-9589-e47f235a6e9f)

After:
![image](https://github.com/learningequality/kolibri-design-system/assets/51239030/f88a5838-ed26-4376-ac64-daf7fe0a00ff)


## Changelog

- [#673]
  - **Description:** Remove white space below Ktabs
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri/issues/12297.
  - **Components:** KTabsList, KTabs, KTabsPanel.
  - **Breaking:** no
  - **Impacts a11y:**no
  - **Guidance:** .

[#673]: https://github.com/learningequality/kolibri-design-system/pull/673

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [x] The changelog item has been pasted to the `CHANGELOG.md`

