### PR TITLE
Fix inner items size changes in KListWithOverflow and add appendToBody prop to KModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Version 4.x.x (`release-v4` branch)
 
+
+- [#680]
+  - **Description:** Adds boolean `appendToBody` prop to teleport the modal to the body element if true.
+  - **Products impact:** new API.
+  - **Addresses:** https://github.com/learningequality/kolibri/issues/12447.
+  - **Components:** KModal.
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** 
+
+- [#680]
+  - **Description:** Fixes the calculation of overflowed items when changes in the size of the list item slots occur.
+  - **Products impact:** bugfix.
+  - **Addresses:** https://github.com/learningequality/kolibri/issues/12447.
+  - **Components:** KListWithOverflow.
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** 
+
+[#680]: https://github.com/learningequality/kolibri-design-system/pull/680
+
 - [#673]
   - **Description:** Remove white space below Ktabs
   - **Products impact:** bugfix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 
 - [#680]
-  - **Description:** Adds boolean `appendToBody` prop to teleport the modal to the body element if true.
+  - **Description:** Adds boolean `appendToRoot` prop to teleport the modal to the body element if true.
   - **Products impact:** new API.
   - **Addresses:** https://github.com/learningequality/kolibri/issues/12447.
   - **Components:** KModal.

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -101,6 +101,12 @@
       // avoids sharing it across multiple instances, ensuring each component has its own function.
       this.throttledSetOverflowItems = throttle(this.setOverflowItems, 100);
       this.$watch('elementWidth', this.throttledSetOverflowItems);
+
+      // Add resize observer to watch inner list items size changes
+      if (typeof window !== 'undefined' && window.ResizeObserver) {
+        const resizeObserver = new ResizeObserver(this.throttledSetOverflowItems);
+        resizeObserver.observe(this.$refs.list);
+      }
     },
     methods: {
       getSize(element) {

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -104,8 +104,13 @@
 
       // Add resize observer to watch inner list items size changes
       if (typeof window !== 'undefined' && window.ResizeObserver) {
-        const resizeObserver = new ResizeObserver(this.throttledSetOverflowItems);
-        resizeObserver.observe(this.$refs.list);
+        this.resizeObserver = new ResizeObserver(this.throttledSetOverflowItems);
+        this.resizeObserver.observe(this.$refs.list);
+      }
+    },
+    beforeUnmount() {
+      if (this.resizeObserver) {
+        this.resizeObserver.disconnect();
       }
     },
     methods: {

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <component :is="teleportWrapper" to="body">
+  <component :is="wrapper" v-bind="wrapperProps">
     <!-- Accessibility properties for the overlay -->
     <transition name="modal-fade" appear>
       <div
@@ -197,9 +197,9 @@
         required: false,
       },
       /**
-       * Whether or not the modal should be teleported to the body
+       * Whether or not the modal should be teleported to the root of the document
        */
-      appendToBody: {
+      appendToRoot: {
         type: Boolean,
         default: false,
       },
@@ -247,8 +247,11 @@
           height: `${this.contentHeight}px`,
         };
       },
-      teleportWrapper() {
-        return this.appendToBody ? 'Teleport' : 'div';
+      wrapper() {
+        return this.appendToRoot ? 'Teleport' : 'div';
+      },
+      wrapperProps() {
+        return this.appendToRoot ? { to: 'body' } : {};
       },
     },
     created() {

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -1,106 +1,109 @@
 <template>
 
-  <!-- Accessibility properties for the overlay -->
-  <transition name="modal-fade" appear>
-    <div
-      id="modal-window"
-      ref="modal-overlay"
-      class="modal-overlay"
-      @keyup.esc.stop="emitCancelEvent"
-      @keyup.enter="handleEnter"
-    >
-      <!-- KeenUiSelect targets modal by using div.modal selector -->
+  <component :is="teleportWrapper" to="body">
+    <!-- Accessibility properties for the overlay -->
+    <transition name="modal-fade" appear>
       <div
-        ref="modal"
-        class="modal"
-        :tabindex="0"
-        role="dialog"
-        aria-labelledby="modal-title"
-        :style="[
-          modalSizeStyles,
-          { background: $themeTokens.surface },
-          containsKSelect ? { overflowY: 'unset' } : { overflowY: 'auto' }
-        ]"
+        id="modal-window"
+        ref="modal-overlay"
+        class="modal-overlay"
+        @keyup.esc.stop="emitCancelEvent"
+        @keyup.enter="handleEnter"
       >
-
-        <!-- Modal Title -->
-        <h1
-          id="modal-title"
-          ref="title"
-          class="title"
+        <!-- KeenUiSelect targets modal by using div.modal selector -->
+        <div
+          ref="modal"
+          class="modal"
+          :tabindex="0"
+          role="dialog"
+          aria-labelledby="modal-title"
+          :style="[
+            modalSizeStyles,
+            { background: $themeTokens.surface },
+            containsKSelect ? { overflowY: 'unset' } : { overflowY: 'auto' }
+          ]"
         >
-          {{ title }}
-          <!-- Accessible error reporting per @radina -->
-          <span
-            v-if="hasError"
-            class="visuallyhidden"
-          >
-            {{ errorMessage }}
-          </span>
-        </h1>
 
-        <!-- Stop propagation of enter key to prevent the submit event from being emitted twice -->
-        <form
-          class="form"
-          @submit.prevent="emitSubmitEvent"
-          @keyup.enter.stop
-        >
-          <!-- Wrapper for main content -->
-          <div
-            ref="content"
-            class="content"
-            :style="[ contentSectionMaxHeight, scrollShadow ? {
-              borderTop: `1px solid ${$themeTokens.fineLine}`,
-              borderBottom: `1px solid ${$themeTokens.fineLine}`,
-            } : {} ]"
-            :class="{
-              'scroll-shadow': scrollShadow,
-              'contains-kselect': containsKSelect
-            }"
+          <!-- Modal Title -->
+          <h1
+            id="modal-title"
+            ref="title"
+            class="title"
           >
-            <!-- @slot Main content of modal -->
-            <slot></slot>
-          </div>
-
-          <div
-            ref="actions"
-            class="actions"
-          >
-            <!-- @slot Alternative buttons and actions below main content -->
-            <slot
-              v-if="$slots.actions"
-              name="actions"
+            {{ title }}
+            <!-- Accessible error reporting per @radina -->
+            <span
+              v-if="hasError"
+              class="visuallyhidden"
             >
-            </slot>
-            <template v-else>
-              <KButton
-                v-if="cancelText"
-                name="cancel"
-                :text="cancelText"
-                appearance="flat-button"
-                :disabled="cancelDisabled || $attrs.disabled"
-                @click="emitCancelEvent"
-              />
-              <KButton
-                v-if="submitText"
-                name="submit"
-                :text="submitText"
-                :primary="true"
-                :disabled="submitDisabled || $attrs.disabled"
-                type="submit"
-              />
-            </template>
-          </div>
-        </form>
+              {{ errorMessage }}
+            </span>
+          </h1>
+
+          <!-- Stop propagation of enter key to prevent the submit event from being emitted twice -->
+          <form
+            class="form"
+            @submit.prevent="emitSubmitEvent"
+            @keyup.enter.stop
+          >
+            <!-- Wrapper for main content -->
+            <div
+              ref="content"
+              class="content"
+              :style="[ contentSectionMaxHeight, scrollShadow ? {
+                borderTop: `1px solid ${$themeTokens.fineLine}`,
+                borderBottom: `1px solid ${$themeTokens.fineLine}`,
+              } : {} ]"
+              :class="{
+                'scroll-shadow': scrollShadow,
+                'contains-kselect': containsKSelect
+              }"
+            >
+              <!-- @slot Main content of modal -->
+              <slot></slot>
+            </div>
+
+            <div
+              ref="actions"
+              class="actions"
+            >
+              <!-- @slot Alternative buttons and actions below main content -->
+              <slot
+                v-if="$slots.actions"
+                name="actions"
+              >
+              </slot>
+              <template v-else>
+                <KButton
+                  v-if="cancelText"
+                  name="cancel"
+                  :text="cancelText"
+                  appearance="flat-button"
+                  :disabled="cancelDisabled || $attrs.disabled"
+                  @click="emitCancelEvent"
+                />
+                <KButton
+                  v-if="submitText"
+                  name="submit"
+                  :text="submitText"
+                  :primary="true"
+                  :disabled="submitDisabled || $attrs.disabled"
+                  type="submit"
+                />
+              </template>
+            </div>
+          </form>
+        </div>
       </div>
-    </div>
-  </transition>
+    </transition>
+  </component>
 
 </template>
 
 
 <script>
 
+  import Teleport from 'vue2-teleport';
   import debounce from 'lodash/debounce';
   import useKResponsiveWindow from './composables/useKResponsiveWindow';
 
@@ -117,6 +120,9 @@
    */
   export default {
     name: 'KModal',
+    components: {
+      Teleport,
+    },
     setup() {
       const { windowHeight, windowWidth } = useKResponsiveWindow();
       return { windowHeight, windowWidth };
@@ -182,10 +188,20 @@
         type: Boolean,
         default: false,
       },
+      /**
+       * Error message to be displayed in title
+       */
       errorMessage: {
         type: String,
         default: null,
         required: false,
+      },
+      /**
+       * Whether or not the modal should be teleported to the body
+       */
+      appendToBody: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {
@@ -230,6 +246,9 @@
           'max-height': `${this.maxContentHeight}px`,
           height: `${this.contentHeight}px`,
         };
+      },
+      teleportWrapper() {
+        return this.appendToBody ? 'Teleport' : 'div';
       },
     },
     created() {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "purecss": "2.2.0",
     "tippy.js": "4.2.1",
     "vue-intl": "3.1.0",
-    "vue2-teleport": "^1.1.4",
+    "vue2-teleport": "1.1.4",
     "xstate": "4.38.3"
   },
   "peerDependencies": {},

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "purecss": "2.2.0",
     "tippy.js": "4.2.1",
     "vue-intl": "3.1.0",
+    "vue2-teleport": "^1.1.4",
     "xstate": "4.38.3"
   },
   "peerDependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -14695,7 +14695,7 @@ vue-template-es2015-compiler@1.9.1, vue-template-es2015-compiler@^1.6.0, vue-tem
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue2-teleport@^1.1.4:
+vue2-teleport@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/vue2-teleport/-/vue2-teleport-1.1.4.tgz#30c84b1005bf9c208b1c05f4b6147300c54ee846"
   integrity sha512-mGTszyQP6k3sSSk7MBq+PZdVojHYLwg5772hl3UVpu5uaLBqWIZ5eNP6/TjkDrf1XUTTxybvpXC6inpjwO+i/Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14695,6 +14695,11 @@ vue-template-es2015-compiler@1.9.1, vue-template-es2015-compiler@^1.6.0, vue-tem
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue2-teleport@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/vue2-teleport/-/vue2-teleport-1.1.4.tgz#30c84b1005bf9c208b1c05f4b6147300c54ee846"
+  integrity sha512-mGTszyQP6k3sSSk7MBq+PZdVojHYLwg5772hl3UVpu5uaLBqWIZ5eNP6/TjkDrf1XUTTxybvpXC6inpjwO+i/Q==
+
 vue@^2.6.11:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
This PR:
* Adds `appendToBody` prop to KModal to teleport the modal to the body element.
* Adds a ResizeObserver to the innerList of KListWithOverflow, to watch inner element size changes and recalculate the overflowed Items. This should definitely fix errors caused by browsers' tricky rendering patterns.


#### Issue addressed
Helps to fix https://github.com/learningequality/kolibri/issues/12447.

## Changelog

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- [#680]
  - **Description:** Adds boolean `appendToBody` prop to teleport the modal to the body element if true. 
  - **Products impact:** new API.
  - **Addresses:** https://github.com/learningequality/kolibri/issues/12447.
  - **Components:** KModal.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** 

- [#680]
  - **Description:** Fixes the calculation of overflowed items when changes in the size of the list item slots occur.. 
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri/issues/12447.
  - **Components:** KListWithOverflow.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** 

[#680]: https://github.com/learningequality/kolibri-design-system/pull/680

## Steps to test

In Kolibri, follow https://github.com/learningequality/kolibri/issues/12447.

## Implementation notes

At the beginning of the development of KListWithOverflow I was skeptical about including a ResizeObserver for the inner list items because I thought it could have a significant impact on performance. But adding the ResizeObserver to the parent div means we only need to observe one node, and using the throttled setOverflowItems makes the performance impact minimal.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
