### PR TITLE
Add live regions logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 ## Upcoming version 5.x.x (`develop` branch)
 
+- [#687]
+  - **Description:** Adds logic that inserts ARIA live assertive and polite regions to an application's document body during KDS initialization and documents this on the new "Installation" page. Relatedly adds `useKLiveRegion` composable with public methods for updating the live regions with assertive and polite messages. 
+  - **Products impact:** new API
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/668
+  - **Components:** `useKLiveRegion`
+  - **Breaking:** No
+  - **Impacts a11y:** Yes. It will fix several places utilizing live regions that don't work in our applications at all. Furthemore, it follows the recommended practices that will fix major a11y issues with live regions we're having.
+  - **Guidance:** Find all polite and live regions (or roles) in an application. Remove them and instead use `useKLiveRegion.sendPoliteMessage` and `useKLiveRegion.sendAssertiveMessage` to update the live regions that KDS inserted to document body during installation.
+
+[#687]: https://github.com/learningequality/kolibri-design-system/pull/687
+
 [#625]
   - **Description:** Initial implementation of `KCard` component
   - **Products impact:** New Component

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -83,3 +83,8 @@ dt {
 dd {
   margin-left: 20px;
 }
+
+em {
+  font-style: normal;
+  font-weight: bold;
+}

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -1,0 +1,40 @@
+<template>
+
+  <DocsPageTemplate>
+
+    <DocsPageSection title="1. Install the plugin" anchor="#install-plugin">
+      <p>Kolibri Design System (KDS) is a Vue plugin. Register it in your application alongside scripts that are needed for its full functioning:</p>
+
+      <!-- eslint-disable -->
+      <DocsShowCode language="javascript">
+        import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
+        import trackInputModality from 'kolibri-design-system/lib/styles/trackInputModality';
+        import trackMediaType from 'kolibri-design-system/lib/styles/trackMediaType';
+
+        Vue.use(KThemePlugin);
+
+        trackInputModality();
+        trackMediaType();
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      This ensures the following:
+
+      <ul>
+        <li>Installs <code>$themeBrand</code>, <code>$themeTokens</code> <code>$themePalette</code>, and <code>$computedClass</code> helpers on all Vue instances.</li>
+        <li>Provides <code>$coreOutline</code>, <code>$inputModality</code>, <code>$mediaType</code>, and <code>$isPrint</code> computed properties as well as <code>$print</code> method to all Vue instances.</li>
+        <li>Globally registers all KDS Vue components.</li>
+        <li>Inserts assertive and polite ARIA live regions to your application's document body (see <DocsInternalLink href="/usekliveregion" text="useKLiveRegion" /> to understand how to utilize them).</li>
+      </ul>
+    </DocsPageSection>
+
+    <DocsPageSection title="2. Initialize theme" anchor="#initialize-theme">
+      <p>
+        Until this section is better documented (TODO link GH issue), refer to <DocsExternalLink href="https://github.com/learningequality/kolibri/blob/develop/kolibri/core/assets/src/styles/initializeTheme.js" text="Kolibri's initializeTheme.js" />.
+      </p>
+    </DocsPageSection>
+
+  </DocsPageTemplate>
+
+</template>
+

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -21,16 +21,16 @@
       This ensures the following:
 
       <ul>
-        <li>Installs <code>$themeBrand</code>, <code>$themeTokens</code> <code>$themePalette</code>, and <code>$computedClass</code> helpers on all Vue instances.</li>
+        <li>Installs <code>$themeBrand</code>, <code>$themeTokens</code> <code>$themePalette</code>, and <code>$computedClass</code> helpers on all Vue instances (see <DocsInternalLink href="/colors/#usage" text="Colors" />).</li>
         <li>Provides <code>$coreOutline</code>, <code>$inputModality</code>, <code>$mediaType</code>, and <code>$isPrint</code> computed properties as well as <code>$print</code> method to all Vue instances.</li>
         <li>Globally registers all KDS Vue components.</li>
-        <li>Inserts assertive and polite ARIA live regions to your application's document body (see <DocsInternalLink href="/usekliveregion" text="useKLiveRegion" /> to understand how to utilize them).</li>
+        <li>Inserts assertive and polite ARIA live regions to your application's document body (see <DocsInternalLink href="/usekliveregion" text="useKLiveRegion" />).</li>
       </ul>
     </DocsPageSection>
 
     <DocsPageSection title="2. Initialize theme" anchor="#initialize-theme">
       <p>
-        Until this section is better documented (TODO link GH issue), refer to <DocsExternalLink href="https://github.com/learningequality/kolibri/blob/develop/kolibri/core/assets/src/styles/initializeTheme.js" text="Kolibri's initializeTheme.js" />.
+        Until this section is better documented, refer to <DocsExternalLink href="https://github.com/learningequality/kolibri/blob/develop/kolibri/core/assets/src/styles/initializeTheme.js" text="Kolibri's initializeTheme.js" />.
       </p>
     </DocsPageSection>
 

--- a/docs/pages/kimg.vue
+++ b/docs/pages/kimg.vue
@@ -308,13 +308,3 @@
   export default {};
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  em {
-    font-style: normal;
-    font-weight: bold;
-  }
-
-</style>

--- a/docs/pages/usekliveregion.vue
+++ b/docs/pages/usekliveregion.vue
@@ -1,0 +1,123 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+
+    <DocsPageSection title="Overview" anchor="#overview">
+      <p>A composable that offers <code>sendPoliteMessage</code> and <code>sendAssertiveMessage</code> functions that send polite and assertive messages to their corresponding ARIA live regions.</p>
+    </DocsPageSection>
+
+    <DocsPageSection title="When to use live regions" anchor="#usage">
+      <p>Before sending messages to live regions, always research carefully if you really need it for the task ahead. Live regions can be <DocsExternalLink href="https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/#avoid-live-regions-if-you-can" text="buggy and inconsistent" />. There are often better alternatives, such as utilizing <DocsExternalLink href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes" text="WAI-ARIA attributes" />. A good rule of thumb is to use live regions only when there's no other way.</p>
+    </DocsPageSection>
+
+    <DocsPageSection title="Usage" anchor="#usage">
+      <p>Since polite and assertive regions are inserted to an application's document body automatically <DocsInternalLink href="/installation#install-plugin" text="during the KDS installation process" />, the only thing you need to do to deliver messages is to import and call <code>sendPoliteMessage</code> or <code>sendAssertiveMessage</code> from any place in your application.</p>
+
+      <p>These two methods are also used internally from some KDS components to provide a11y out of the box. Always check that you don't send messages to announce updates that are already being announced from KDS to prevent from duplicate announcements.</p>
+
+      <h3>Polite message</h3>
+
+      <p>Sending a polite message updates the text content of <code>aria-live="polite"</code> region. <em>Use it to send messages that can wait to be announced until the user is idle. This message should typically be the most commonly used.</em></p>
+
+      <p>Send polite messages with <code>sendPoliteMessage(message)</code>:</p>
+
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="javascript">
+        import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
+
+        export default {
+          setup() {
+            const { sendPoliteMessage } = useKLiveRegion();
+            sendPoliteMessage('Polite message');
+          }
+        };
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <h3>Assertive message</h3>
+
+      <p>Sending an assertive message updates the text content of <code>aria-live="assertive"</code> region. <em>It should be used with caution because it disrupts the user's flow. Use it only to send messages that require immediate attention, such as errors.</em></p>
+
+      <p>Send assertive messages with <code>sendAssertiveMessage(message)</code>:</p>
+
+      <!-- eslint-disable -->
+      <!-- prevent prettier from changing indentation -->
+      <DocsShowCode language="javascript">
+        import useKLiveRegion from 'kolibri-design-system/lib/composables/useKLiveRegion';
+
+        export default {
+          setup() {
+            const { sendAssertiveMessage } = useKLiveRegion();
+            sendPoliteMessage('Assertive message');
+          }
+        };
+      </DocsShowCode>
+      <!-- eslint-enable -->
+    </DocsPageSection>
+
+    <DocsPageSection title="Demo" anchor="#demo">
+      <p>Send messages below and turn on your screen reader or observe the content of <code>&lt;div id="k-live-region"&gt;</code> in the browser console.</p>
+
+      <DocsShow language="html">
+        <KTextbox label="Polite message" :value="politeMessageInput" @input="updatePoliteMessage" />
+        <KButton @click="sendPoliteMessage(politeMessageInput)">
+          Send
+        </KButton>
+      </DocsShow>
+
+      <DocsShow language="html">
+        <KTextbox label="Assertive message" :value="assertiveMessageInput" @input="updateAssertiveMessage" />
+        <KButton @click="sendAssertiveMessage(assertiveMessageInput)">
+          Send
+        </KButton>
+      </DocsShow>
+    </DocsPageSection>
+
+    <DocsPageSection title="Related" anchor="#related">
+      <ul>
+        <li>
+          <DocsInternalLink href="/installation#initialize-dom" text="KDS installation step" /> that attaches live regions to an application's DOM
+        </li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>
+
+
+<script>
+
+  import { ref } from '@vue/composition-api';
+  import useKLiveRegion from '../../lib/composables/useKLiveRegion';
+
+  export default {
+    setup() {
+      const { _mountLiveRegion, sendPoliteMessage, sendAssertiveMessage } = useKLiveRegion();
+
+      const politeMessageInput = ref('Polite hello');
+      const updatePoliteMessage = message => {
+        politeMessageInput.value = message;
+      };
+
+      const assertiveMessageInput = ref('I cannot wait');
+      const updateAssertiveMessage = message => {
+        assertiveMessageInput.value = message;
+      };
+
+      return {
+        _mountLiveRegion,
+        updatePoliteMessage,
+        politeMessageInput,
+        updateAssertiveMessage,
+        assertiveMessageInput,
+        sendPoliteMessage,
+        sendAssertiveMessage,
+      };
+    },
+    mounted() {
+      this._mountLiveRegion(this.$root.$el);
+    },
+  };
+
+</script>

--- a/docs/pages/usekliveregion.vue
+++ b/docs/pages/usekliveregion.vue
@@ -3,7 +3,7 @@
   <DocsPageTemplate apiDocs>
 
     <DocsPageSection title="Overview" anchor="#overview">
-      <p>A composable that offers <code>sendPoliteMessage</code> and <code>sendAssertiveMessage</code> functions that send polite and assertive messages to their corresponding ARIA live regions.</p>
+      <p>A composable that offers <code>sendPoliteMessage</code> and <code>sendAssertiveMessage</code> functions that send polite and assertive messages to their corresponding <DocsExternalLink href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions" text="ARIA live regions" />.</p>
     </DocsPageSection>
 
     <DocsPageSection title="When to use live regions" anchor="#usage">

--- a/docs/pages/usekliveregion.vue
+++ b/docs/pages/usekliveregion.vue
@@ -77,7 +77,7 @@
     <DocsPageSection title="Related" anchor="#related">
       <ul>
         <li>
-          <DocsInternalLink href="/installation#initialize-dom" text="KDS installation step" /> that attaches live regions to an application's DOM
+          <DocsInternalLink href="/installation#install-plugin" text="KDS installation step" /> that attaches live regions to an application's DOM
         </li>
       </ul>
     </DocsPageSection>

--- a/docs/pages/usekliveregion.vue
+++ b/docs/pages/usekliveregion.vue
@@ -57,7 +57,7 @@
     </DocsPageSection>
 
     <DocsPageSection title="Demo" anchor="#demo">
-      <p>Send messages below and turn on your screen reader or observe the content of <code>&lt;div id="k-live-region"&gt;</code> in the browser console.</p>
+      <p>Send messages below and turn on your screen reader. You could also observe the content of <code>&lt;div id="k-live-region"&gt;</code> in the browser console, but note that an announcement will be visible for just a very brief moment.</p>
 
       <DocsShow language="html">
         <KTextbox label="Polite message" :value="politeMessageInput" @input="updatePoliteMessage" />

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -69,6 +69,10 @@ export default [
         title: 'Home',
       }),
       new Page({
+        path: '/installation',
+        title: 'Installation',
+      }),
+      new Page({
         path: '/principles',
         title: 'Design principles',
       }),
@@ -179,6 +183,21 @@ export default [
         title: 'useKResponsiveWindow',
         isCode: true,
         keywords: [...compositionRelatedKeywords, 'responsive', 'window', 'breakpoint'],
+      }),
+      new Page({
+        path: '/usekliveregion',
+        title: 'useKLiveRegion',
+        isCode: true,
+        keywords: [
+          ...compositionRelatedKeywords,
+          'a11y',
+          'live',
+          'region',
+          'aria',
+          'polite',
+          'assertive',
+          'message',
+        ],
       }),
       new Page({
         path: '/usekshow',

--- a/jest.conf/setup.js
+++ b/jest.conf/setup.js
@@ -50,3 +50,31 @@ global.flushPromises = function flushPromises() {
     setImmediate(resolve);
   });
 };
+
+function removeWhitespaceFromHtml(htmlString) {
+  // https://stackoverflow.com/a/33108909
+  return htmlString.replace(/>\s+|\s+</g, function(m) {
+    return m.trim();
+  });
+}
+
+global.expect.extend({
+  // check that document.body.innerHTML includes html string
+
+  toBeInDom(received) {
+    const pass = removeWhitespaceFromHtml(document.body.innerHTML).includes(
+      removeWhitespaceFromHtml(received)
+    );
+    if (pass) {
+      return {
+        message: () => `expected ${received} not to be in the document body`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () => `expected ${received} to be in the document body`,
+        pass: false,
+      };
+    }
+  },
+});

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -1,3 +1,4 @@
+import { isNuxtServerSideRendering } from '../lib/utils';
 import computedClass from './styles/computedClass';
 
 import KBreadcrumbs from './KBreadcrumbs';
@@ -39,6 +40,10 @@ import KCard from './KCard';
 import { themeTokens, themeBrand, themePalette, themeOutlineStyle } from './styles/theme';
 import globalThemeState from './styles/globalThemeState';
 
+import useKLiveRegion from './composables/useKLiveRegion';
+
+const { _mountLiveRegion } = useKLiveRegion();
+
 require('./grids/globalStyles.js'); // global grid styles
 
 /**
@@ -46,6 +51,23 @@ require('./grids/globalStyles.js'); // global grid styles
  * Also, set up global state, listeners, and styles.
  */
 export default function KThemePlugin(Vue) {
+  // Note that if DOM live regions need to be demostrated
+  // on the KDS website, and therefore attached to the DOM,
+  // just call _mountLiveRegion() in the relevant documentation
+  // page's 'mounted' (see 'docs/pages/usekliveregio.vue' for an example)
+  if (!isNuxtServerSideRendering()) {
+    const onDomReady = () => {
+      _mountLiveRegion();
+      document.removeEventListener('DOMContentLoaded', onDomReady);
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', onDomReady);
+    } else {
+      onDomReady();
+    }
+  }
+
   Vue.mixin({
     /* eslint-disable kolibri/vue-no-unused-properties */
     computed: {

--- a/lib/composables/useKLiveRegion/__tests__/index.spec.js
+++ b/lib/composables/useKLiveRegion/__tests__/index.spec.js
@@ -1,0 +1,84 @@
+import useKLiveRegion from '../index.js';
+
+const { sendPoliteMessage, sendAssertiveMessage } = useKLiveRegion();
+function removeWhitespaceFromHtml(htmlString) {
+  // https://stackoverflow.com/a/33108909
+  return htmlString.replace(/>\s+|\s+</g, function(m) {
+    return m.trim();
+  });
+}
+
+// check that document.body.innerHTML includes html string
+function assertDocumentBodyIncludes(htmlString) {
+  expect(
+    removeWhitespaceFromHtml(document.body.innerHTML).includes(removeWhitespaceFromHtml(htmlString))
+  ).toBeTruthy();
+}
+
+describe('useKLiveRegion', () => {
+  // this is take care of by KThemePlugin.js that is already registered
+  // in the global jest setup
+  it(`document body contains live regions upon the KDS plugin initialization`, () => {
+    assertDocumentBodyIncludes(`
+      <div id="k-live-region" class="visuallyhidden">
+        <div aria-live="polite">
+        </div>
+        <div aria-live="assertive">
+        </div>
+      </div>
+    `);
+  });
+
+  it(`'sendPoliteMessage' updates the live region with the message`, async () => {
+    assertDocumentBodyIncludes(`
+      <div id="k-live-region" class="visuallyhidden">
+        <div aria-live="polite">
+        </div>
+        <div aria-live="assertive">
+        </div>
+      </div>
+    `);
+
+    sendPoliteMessage('Polite message');
+    await new Promise(resolve => setTimeout(resolve, 100));
+    assertDocumentBodyIncludes(`
+      <div id="k-live-region" class="visuallyhidden">
+        <div aria-live="polite">
+          Polite message
+        </div>
+        <div aria-live="assertive">
+        </div>
+      </div>
+    `);
+
+    // cleanup
+    sendPoliteMessage('');
+  });
+
+  it(`'sendAssertiveMessage' updates the live region with the message`, async () => {
+    assertDocumentBodyIncludes(`
+      <div id="k-live-region" class="visuallyhidden">
+        <div aria-live="polite">
+        </div>
+        <div aria-live="assertive">
+        </div>
+      </div>
+    `);
+
+    sendAssertiveMessage('Assertive message');
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    assertDocumentBodyIncludes(`
+      <div id="k-live-region" class="visuallyhidden">
+        <div aria-live="polite">
+        </div>
+        <div aria-live="assertive">
+          Assertive message
+        </div>
+      </div>
+    `);
+
+    // cleanup
+    sendAssertiveMessage('');
+  });
+});

--- a/lib/composables/useKLiveRegion/__tests__/index.spec.js
+++ b/lib/composables/useKLiveRegion/__tests__/index.spec.js
@@ -1,47 +1,34 @@
 import useKLiveRegion from '../index.js';
 
 const { sendPoliteMessage, sendAssertiveMessage } = useKLiveRegion();
-function removeWhitespaceFromHtml(htmlString) {
-  // https://stackoverflow.com/a/33108909
-  return htmlString.replace(/>\s+|\s+</g, function(m) {
-    return m.trim();
-  });
-}
-
-// check that document.body.innerHTML includes html string
-function assertDocumentBodyIncludes(htmlString) {
-  expect(
-    removeWhitespaceFromHtml(document.body.innerHTML).includes(removeWhitespaceFromHtml(htmlString))
-  ).toBeTruthy();
-}
 
 describe('useKLiveRegion', () => {
   // this is take care of by KThemePlugin.js that is already registered
   // in the global jest setup
   it(`document body contains live regions upon the KDS plugin initialization`, () => {
-    assertDocumentBodyIncludes(`
+    expect(`
       <div id="k-live-region" class="visuallyhidden">
         <div aria-live="polite">
         </div>
         <div aria-live="assertive">
         </div>
       </div>
-    `);
+    `).toBeInDom();
   });
 
   it(`'sendPoliteMessage' updates the live region with the message`, async () => {
-    assertDocumentBodyIncludes(`
+    expect(`
       <div id="k-live-region" class="visuallyhidden">
         <div aria-live="polite">
         </div>
         <div aria-live="assertive">
         </div>
       </div>
-    `);
+    `).toBeInDom();
 
     sendPoliteMessage('Polite message');
     await new Promise(resolve => setTimeout(resolve, 100));
-    assertDocumentBodyIncludes(`
+    expect(`
       <div id="k-live-region" class="visuallyhidden">
         <div aria-live="polite">
           Polite message
@@ -49,26 +36,26 @@ describe('useKLiveRegion', () => {
         <div aria-live="assertive">
         </div>
       </div>
-    `);
+    `).toBeInDom();
 
     // cleanup
     sendPoliteMessage('');
   });
 
   it(`'sendAssertiveMessage' updates the live region with the message`, async () => {
-    assertDocumentBodyIncludes(`
+    expect(`
       <div id="k-live-region" class="visuallyhidden">
         <div aria-live="polite">
         </div>
         <div aria-live="assertive">
         </div>
       </div>
-    `);
+    `).toBeInDom();
 
     sendAssertiveMessage('Assertive message');
     await new Promise(resolve => setTimeout(resolve, 100));
 
-    assertDocumentBodyIncludes(`
+    expect(`
       <div id="k-live-region" class="visuallyhidden">
         <div aria-live="polite">
         </div>
@@ -76,7 +63,7 @@ describe('useKLiveRegion', () => {
           Assertive message
         </div>
       </div>
-    `);
+    `).toBeInDom();
 
     // cleanup
     sendAssertiveMessage('');

--- a/lib/composables/useKLiveRegion/index.js
+++ b/lib/composables/useKLiveRegion/index.js
@@ -1,0 +1,88 @@
+const LIVE_REGION_WRAPPER_ID = 'k-live-region';
+const POLITE_LIVE_REGION_SELECTOR = `#${LIVE_REGION_WRAPPER_ID} [aria-live="polite"]`;
+const ASSERTIVE_LIVE_REGION_SELECTOR = `#${LIVE_REGION_WRAPPER_ID} [aria-live="assertive"]`;
+
+/**
+ * Exposes public 'sendPoliteMessage' and 'sendAssertiveMessage'
+ * functions that can be used to update polite/assertive
+ * aria-live regions.
+ *
+ * Also provides private '_mountLiveRegion'.
+ */
+export default function useKLiveRegion() {
+  /**
+   * Inserts assertive and polite live regions
+   * to an application's document body.
+   * For private use in KDS (see KThemePlugin.js)
+   */
+  function _mountLiveRegion() {
+    const politeRegionEl = document.querySelector(POLITE_LIVE_REGION_SELECTOR);
+    const assertiveRegionEl = document.querySelector(ASSERTIVE_LIVE_REGION_SELECTOR);
+
+    // Already mounted, so don't mount again,
+    // just make sure elements are available in window
+    if (politeRegionEl && assertiveRegionEl) {
+      window.politeRegionEl = politeRegionEl;
+      window.assertiveRegionEl = assertiveRegionEl;
+      return;
+    }
+
+    const newWrapperEl = document.createElement('div');
+    newWrapperEl.id = LIVE_REGION_WRAPPER_ID;
+    newWrapperEl.className = 'visuallyhidden';
+
+    const newPoliteRegionEl = document.createElement('div');
+    newPoliteRegionEl.setAttribute('aria-live', 'polite');
+
+    const newAssertiveRegionEl = document.createElement('div');
+    newAssertiveRegionEl.setAttribute('aria-live', 'assertive');
+
+    newWrapperEl.appendChild(newPoliteRegionEl);
+    newWrapperEl.appendChild(newAssertiveRegionEl);
+
+    document.body.insertBefore(newWrapperEl, document.body.firstChild);
+
+    // Save for later use so that we don't need to query
+    // every time we call the 'sendPoliteMessage'/'sendAssertiveMessage'.
+    // Storing these two elements in the variables in this file,
+    // even in the highest scope above the 'useKLiveRegion' function,
+    // is insufficient since this file can be on some occasions
+    // loaded repeatedly while live regions are already in the DOM.
+    window.politeRegionEl = newPoliteRegionEl;
+    window.assertiveRegionEl = newAssertiveRegionEl;
+  }
+
+  function _sendMessage(message, el) {
+    try {
+      el.textContent = message;
+    } catch (error) {
+      console.error('[useKLiveRegion] Could not send the message:', error);
+    } finally {
+      // empty the live region
+      // recommended in https://www.sarasoueidan.com/blog/accessible-notifications-with-aria-live-regions-part-2/
+      setTimeout(() => {
+        el.textContent = '';
+      }, 350);
+    }
+  }
+
+  /**
+   * Updates the polite aria live region with the provided message.
+   */
+  function sendPoliteMessage(message) {
+    _sendMessage(message, window.politeRegionEl);
+  }
+
+  /**
+   * Updates the assertive aria live region with the provided message.
+   */
+  function sendAssertiveMessage(message) {
+    _sendMessage(message, window.assertiveRegionEl);
+  }
+
+  return {
+    _mountLiveRegion,
+    sendPoliteMessage,
+    sendAssertiveMessage,
+  };
+}


### PR DESCRIPTION
## Description

- Adds logic that inserts ARIA live assertive and polite regions to an application's document body during KDS initialization and documents this on the new "Installation" page
- Relatedly adds `useKLiveRegion` composable with public methods for updating the live regions with assertive and polite messages. 

See "Comments" section below on why this strategy, after all.

#### Issue addressed

- Closes https://github.com/learningequality/kolibri-design-system/issues/668
  - Note that the interface is slightly different than I originally proposed. KDS takes care of inserting the live regions to DOM instead of having to have KLiveRegion. This makes things more robust and easier in consuming apps, and prepares ground for root teleport element. 

## Changelog

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- [#687]
  - **Description:** Adds logic that inserts ARIA live assertive and polite regions to an application's document body during KDS initialization and documents this on the new "Installation" page. Relatedly adds `useKLiveRegion` composable with public methods for updating the live regions with assertive and polite messages. 
  - **Products impact:** new API
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/668
  - **Components:** `useKLiveRegion`
  - **Breaking:** No
  - **Impacts a11y:** Yes. It will fix several places utilizing live regions that don't work in our applications at all. Furthemore, it follows the recommended practices that will fix major a11y issues with live regions we're having.
  - **Guidance:** Find all polite and live regions (or roles) in an application. Remove them and instead use `useKLiveRegion.sendPoliteMessage` and `useKLiveRegion.sendAssertiveMessage` to update the live regions that KDS inserted to document body during installation.

## Steps to test

- See the new [Installation docs page](https://deploy-preview-687--kolibri-design-system.netlify.app/installation/)
- See the [new useKLiveRegion docs page](https://deploy-preview-687--kolibri-design-system.netlify.app/usekliveregion/) and try [the demo at its bottom part ](https://deploy-preview-687--kolibri-design-system.netlify.app/usekliveregion/#demo)
- Try it out in Kolibri https://github.com/learningequality/kolibri/pull/12475

## Implementation notes

### At a high level, how did you implement this?

- In KThemePlugin.js insert live region elements to `document.body` via plain JavaScript when DOM is loaded
- Publicly expose `useKLiveRegion.sendPoliteMessage` and `useKLiveRegion.sendAssertiveMessage` to update the region elements

### Does this introduce any tech-debt items?

Opposite - after we use it more widely, it will fix several places utilizing live regions that don't work in our applications at all. Furthermore, it follows the recommended practices that will fix major a11y issues with live regions we're having.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [x] The changelog item has been pasted to the `CHANGELOG.md`

## Comments

I explored several approaches regarding inserting live region elements and their many combinations, some of the more important ones:

- Mounting `KLiveRegion.vue` as a Vue component
  - Makes setup complex by requiring attaching to the root Vue app element rather than simply to `document.body`
  - Its `{{ message }}` changes not being announced properly when compared to using plain JS to update elements' `textContent`

- Adding `mounted` hook to KThemePlugin's mixin, where we check if `this.$root === this` and if so, we insert the live regions to DOM at this point
  - live regions seemed to be ready fast at first, but testing https://github.com/learningequality/kolibri/pull/12475 showed that when we need to do the announcement from an element that is soon in DOM, it's not sufficient
  - as @AlexVelezLl noted, this also adds many conditions to every `mounted` to every KDS component, not just when mounted for the first time, but every time (called hundreds of times when navigating in Kolibri)

- Adjusting Vue prototype's `$mount` and some other places in a way similar to above
  - same issues as above 

- Exposing `mountLiveRegions` publicly and instructing apps to call it in the root app `mounted`
  - even though this mitigated the issue with many `mounted` conditions being executed, it really didn't help with the live regions not being ready in time when announcing very shortly after Kolibri loaded

Note that @rtibbles also mentioned some other Vue prototype places that we may want to experiment with. However, at the end of the day, since we need to update `DOM` as soon as possible, after seeing above, I can hardly imagine something faster than utilizing `document.readyState` and `DOMContentLoaded` event.

The original reason for not using this strategy was my wish to attach `KLiveRegion` as Vue component as well as a Nuxt problem. However, those can be overcome easily and I think reliability and robustness in consumer apps is the most important criteria here.