### PR TITLE
Fix resize observer error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Changelog is rather internal in nature. See release notes for the public overvie
 ## Version 4.x.x (`release-v4` branch)
 
 
+- [#717]
+  - **Description:** Fix ResizeOserver errors when KListWithOverflow resize very quickly.
+  - **Products impact:** bugfix.
+  - **Addresses:** Sentry error.
+  - **Components:** KListWithOverflow.
+  - **Breaking:** no.
+  - **Impacts a11y:** no.
+  - **Guidance:** -.
+
+[#717]: https://github.com/learningequality/kolibri-design-system/pull/717
+
 - [#680]
   - **Description:** Adds boolean `appendToRoot` prop to teleport the modal to the body element if true.
   - **Products impact:** new API.

--- a/docs/pages/klistwithoverflow.vue
+++ b/docs/pages/klistwithoverflow.vue
@@ -231,6 +231,7 @@
   }
 
   .divider-wrapper {
+    align-self: stretch;
     padding: 8px 12px;
   }
 

--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -104,7 +104,9 @@
 
       // Add resize observer to watch inner list items size changes
       if (typeof window !== 'undefined' && window.ResizeObserver) {
-        this.resizeObserver = new ResizeObserver(this.throttledSetOverflowItems);
+        this.resizeObserver = new ResizeObserver(() =>
+          requestAnimationFrame(this.throttledSetOverflowItems)
+        );
         this.resizeObserver.observe(this.$refs.list);
       }
     },


### PR DESCRIPTION
## Description

Fix ResizeOserver errors: "ResizeObserver loop limit exceeded" and "ResizeObserver loop completed with undelivered notifications".

Before:

https://github.com/user-attachments/assets/ea53e26d-12dc-4e2c-8a22-9fe72ff73f11


After:

https://github.com/user-attachments/assets/e746031a-3b04-401b-a1a9-47aa6e363aa4

## Changelog

- [#717]
  - **Description:** Fix ResizeOserver errors when KListWithOverflow resize very quickly.
  - **Products impact:** bugfix.
  - **Addresses:** Sentry error.
  - **Components:** KListWithOverflow.
  - **Breaking:** no.
  - **Impacts a11y:** no.
  - **Guidance:** -.

[#717]: https://github.com/learningequality/kolibri-design-system/pull/717

## Implementation notes

### At a high level, how did you implement this?

The resize observer in charge of observing inner item sizes was causing a resize on itself when the recalculation ended in a new overflowed item (it doesnt caused an infinite loop because on the second execution we normally wouldnt be updating any more overflowed items), the recommended solution was to use a `requestAnimationFrame` before executing the resizeObserver callback and with this, this error isnt throwing anymore.



## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [x] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
