### PR TITLE
updated drop shadow according to the latest guidelines

### DIFF
--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -38,7 +38,7 @@
         @import '~kolibri-design-system/lib/styles/definitions'
 
         .box {
-          @extend %dropshadow-4dp;
+          @extend %dropshadow-2dp;
 
           border-radius: $radius;
           text-align: center;
@@ -105,7 +105,7 @@
         @import '~kolibri-design-system/lib/styles/definitions'
 
         .more-shadow {
-          @extend %dropshadow-12dp;
+          @extend %dropshadow-6dp;
         }
       </DocsShowCode>
       <!-- eslint-enable -->
@@ -155,7 +155,7 @@
         @import '~kolibri-design-system/lib/styles/definitions'
 
         .ease:hover {
-          @extend %dropshadow-8dp;
+          @extend %dropshadow-6dp;
           @extend %md-standard-func;
 
           cursor: pointer;
@@ -183,7 +183,7 @@
   @import '~~/lib/styles/definitions';
 
   .box {
-    @extend %dropshadow-4dp;
+    @extend %dropshadow-2dp;
 
     display: inline-block;
     min-width: 150px;
@@ -195,17 +195,17 @@
   }
 
   .more-shadow {
-    @extend %dropshadow-12dp;
+    @extend %dropshadow-6dp;
   }
 
   .immediate:hover {
-    @extend %dropshadow-8dp;
+    @extend %dropshadow-6dp;
 
     cursor: pointer;
   }
 
   .ease:hover {
-    @extend %dropshadow-8dp;
+    @extend %dropshadow-6dp;
     @extend %md-standard-func;
 
     cursor: pointer;

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -318,7 +318,7 @@
   }
 
   .breadcrumbs-dropdown {
-    @extend %dropshadow-8dp;
+    @extend %-2dp;
 
     position: absolute;
     z-index: 8;

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -318,7 +318,7 @@
   }
 
   .breadcrumbs-dropdown {
-    @extend %-2dp;
+    @extend %dropshadow-2dp;
 
     position: absolute;
     z-index: 8;

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -391,7 +391,7 @@
 
   // TODO: margins for stacked buttons.
   .modal {
-    @extend %dropshadow-16dp;
+    @extend %-16dp;
 
     position: absolute;
     top: 50%;


### PR DESCRIPTION
replaced redundant dropshadows with most relavent version out of dropshadow(1,2,6)

<!-- Please remove any unused sections -->

## Description
this pr replaces the dropshadow element(1-24) with drop shadow 1,2,6
#### Issue addressed
new guidelines for dropshadows

