### PR TITLE
KCheckbox: Remove local state management, rely on given props

### DIFF
--- a/docs/pages/kcheckbox.vue
+++ b/docs/pages/kcheckbox.vue
@@ -7,11 +7,13 @@
       <DocsShow>
         <KCheckbox
           label="Some label"
-          :checked="true"
+          :checked="checked1"
+          @change="checked1 = !checked1"
         />
         <KCheckbox
           label="Another label"
-          :checked="false"
+          :checked="checked2"
+          @change="checked2 = !checked2"
         />
       </DocsShow>
     </DocsPageSection>
@@ -39,7 +41,9 @@
       <DocsShow>
         <KCheckbox
           label="Topic is selected"
-          :indeterminate="true"
+          :indeterminate="indeterminate3"
+          :checked="checked3"
+          @change="handle3"
         />
       </DocsShow>
       <p>
@@ -53,11 +57,11 @@
       <!-- eslint-disable -->
       <!-- prevent prettier from changing indentation -->
       <DocsShowCode language="html">
-        <KCheckbox label="First lesson" />;
+        <KCheckbox label="First lesson" />
       </DocsShowCode>
       <!-- eslint-enable -->
       <DocsShow>
-        <KCheckbox label="First lesson" />
+        <KCheckbox label="First lesson" :checked="checked4" @change="checked4 = !checked4" />
       </DocsShow>
 
       In more complex situations, for example when another component is responsible for rendering the label, the default slot can be used:
@@ -71,7 +75,7 @@
       </DocsShowCode>
       <!-- eslint-enable -->
       <DocsShow>
-        <KCheckbox>
+        <KCheckbox :checked="checked5" @change="checked5 = !checked5">
           <KLabeledIcon icon="lesson" label="First lesson" />
         </KCheckbox>
       </DocsShow>
@@ -97,3 +101,27 @@
   </DocsPageTemplate>
 
 </template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        checked1: true,
+        checked2: false,
+        checked3: false,
+        indeterminate3: true,
+        checked4: false,
+        checked5: false,
+      };
+    },
+    methods: {
+      handle3() {
+        this.checked3 = !this.checked3;
+        this.indeterminate3 = false;
+      },
+    },
+  };
+
+</script>

--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -14,8 +14,8 @@
           type="checkbox"
           class="k-checkbox-input"
           :aria-checked="ariaChecked"
-          :checked="isCurrentlyChecked"
-          :indeterminate.prop="isCurrentlyIndeterminate"
+          :checked="checked"
+          :indeterminate.prop="indeterminate"
           :disabled="disabled"
           @click.stop="toggleCheck"
           @focus="isActive = true"
@@ -24,13 +24,13 @@
         >
 
         <KIcon
-          v-if="isCurrentlyIndeterminate"
+          v-if="indeterminate"
           :style="notBlank"
           class="checkbox-icon"
           icon="indeterminateCheck"
         />
         <KIcon
-          v-else-if="!isCurrentlyIndeterminate && isCurrentlyChecked"
+          v-else-if="!indeterminate && checked"
           :style="[ notBlank, activeOutline ]"
           class="checkbox-icon"
           icon="checked"
@@ -122,13 +122,11 @@
       },
     },
     data: () => ({
-      isCurrentlyChecked: false,
-      isCurrentlyIndeterminate: false,
       isActive: false,
     }),
     computed: {
       ariaChecked() {
-        return this.isCurrentlyIndeterminate ? 'mixed' : this.isCurrentlyChecked ? 'true' : 'false';
+        return this.indeterminate ? 'mixed' : this.checked ? 'true' : 'false';
       },
       id() {
         return `k-checkbox-${this._uid}`;
@@ -152,28 +150,14 @@
         };
       },
     },
-    watch: {
-      checked(newCheckedState) {
-        this.isCurrentlyChecked = newCheckedState;
-      },
-      indeterminate(newIndeterminateState) {
-        this.isCurrentlyIndeterminate = newIndeterminateState;
-      },
-    },
-    created() {
-      this.isCurrentlyChecked = this.checked;
-      this.isCurrentlyIndeterminate = this.indeterminate;
-    },
     methods: {
       toggleCheck(event) {
         if (!this.disabled) {
-          this.isCurrentlyChecked = !this.isCurrentlyChecked;
           this.$refs.kCheckboxInput.focus();
-          this.isCurrentlyIndeterminate = false;
           /**
            * Emits change event
            */
-          this.$emit('change', this.isCurrentlyChecked, event);
+          this.$emit('change', !this.checked, event);
         }
       },
       markInactive() {


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

KCheckbox had local data which are initialized to the given props for `indeterminate` and `checked` and then updated in a watcher. This resulted in that clicking a checkbox would always toggle it's `isCurrentlyChecked` value and setting `isCurrentlyIndeterminate` to false.

The changes here instead have KCheckbox simply use the given prop values and does nothing to manage any internal state around whether it shows `indeterminate` and/or `checked`.

This results in users of KCheckbox needing to be mindful of how they manage the values they pass into KCheckbox's props as the component will now reflect their values at all time.

#### Issue addressed

This permits Studio's clipboard to have the ability to tell KCheckbox what it should be looking like.



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->
<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Removes internal state management for checked & indeterminate in KCheckbox.
  - **Products impact:** Updated API
  - **Addresses:** https://github.com/learningequality/studio/issues/4636
  - **Components:** KCheckbox
  - **Breaking:** No
  - **Impacts a11y:** No
  - **Guidance:** If you use KCheckbox, it is your responsibility to handle the `change` event and update whether or not the given `checked` and `indeterminate` props reflect the reality that you expect.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

Click all of the checkboxes and the states of indeterminacy vs checked-ness -- particularly in nested situations.

The most common in Kolibri is content selection. In Studio, this issue was found while debugging a problem with the Clipboard.

KOLIBRI:

- Resource selection during import
- During Quiz creation
- During Lesson creation

STUDIO:

- Clipboard
- Channel editor


## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## After review

- [ ] The changelog item has been pasted to the `CHANGELOG.md`

## Comments
<!-- Any additional notes you'd like to add -->
