### PR TITLE
update dropshadow to the latest guidelines

### DIFF
--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -318,7 +318,7 @@
   }
 
   .breadcrumbs-dropdown {
-    @extend %dropshadow-8dp;
+    @extend %dropshadow-2dp;
 
     position: absolute;
     z-index: 8;

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -385,7 +385,7 @@
 
   // TODO: margins for stacked buttons.
   .modal {
-    @extend %dropshadow-16dp;
+    @extend %dropshadow-6dp;
 
     position: absolute;
     top: 50%;

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -1065,6 +1065,8 @@
   }
 
   .ui-select-dropdown {
+    @extend %dropshadow-2dp;
+
     position: absolute;
     z-index: $z-index-dropdown;
     display: block;
@@ -1075,7 +1077,6 @@
     margin-bottom: rem-calc(8px);
     list-style-type: none;
     outline: none;
-    box-shadow: 1px 2px 8px $md-grey-600;
   }
 
   .ui-select-options {

--- a/lib/KSwitch.vue
+++ b/lib/KSwitch.vue
@@ -185,6 +185,7 @@
 
 
 <style lang="scss">
+
   @import './styles/definitions';
   $k-switch-height: 32px !default;
   $k-switch-thumb-size: 20px !default;
@@ -255,6 +256,7 @@
 
   .k-switch-thumb {
     @extend %dropshadow-1dp;
+
     position: absolute;
     z-index: 1;
     width: $k-switch-thumb-size;

--- a/lib/KSwitch.vue
+++ b/lib/KSwitch.vue
@@ -185,7 +185,7 @@
 
 
 <style lang="scss">
-
+  @import './styles/definitions';
   $k-switch-height: 32px !default;
   $k-switch-thumb-size: 20px !default;
   $k-switch-thumb-color: #f5f5f5 !default;
@@ -254,13 +254,13 @@
   }
 
   .k-switch-thumb {
+    @extend %dropshadow-1dp;
     position: absolute;
     z-index: 1;
     width: $k-switch-thumb-size;
     height: $k-switch-thumb-size;
     background-color: $k-switch-thumb-color;
     border-radius: 50%;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
     transition-timing-function: ease;
     transition-duration: 0.2s;
     transition-property: background-color, transform;

--- a/lib/keen/UiAutocomplete.vue
+++ b/lib/keen/UiAutocomplete.vue
@@ -440,6 +440,7 @@
 <style lang="scss">
 
   @import './styles/imports';
+  @import '../styles/definitions';
 
   .ui-autocomplete {
     position: relative;
@@ -600,6 +601,7 @@
   }
 
   .ui-autocomplete__suggestions {
+    @extend %dropshadow-1dp; 
     position: absolute;
     z-index: $z-index-dropdown;
     display: block;
@@ -610,7 +612,7 @@
     color: $primary-text-color;
     list-style-type: none;
     background-color: white;
-    box-shadow: 1px 2px 8px $md-grey-600;
+   
   }
 
   .ui-autocomplete__feedback {

--- a/lib/keen/UiButton.vue
+++ b/lib/keen/UiButton.vue
@@ -211,7 +211,7 @@
 </script>
 
 <style lang="scss">
-
+  @import '../styles/definitions';
   @import './styles/imports';
 
   .ui-button {
@@ -261,12 +261,12 @@
     }
 
     &.is-raised {
-      box-shadow: 0 0 2px rgba(black, 0.12), 0 2px 2px rgba(black, 0.2);
+      @extend %dropshadow-2dp;
       transition: box-shadow 0.3s ease;
 
       &.has-focus-ring:focus,
       body[modality='keyboard'] &:focus {
-        box-shadow: 0 0 5px rgba(black, 0.22), 0 3px 6px rgba(black, 0.3);
+        @extend %dropshadow-2dp;
       }
     }
 

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -128,6 +128,7 @@
 
   /* stylelint-disable */
 
+  @import '../styles/definitions';
   @import './styles/imports';
 
   .ui-menu {
@@ -145,10 +146,9 @@
     outline: none;
 
     &.is-raised {
+      @extend %dropshadow-2dp;
       border: none;
-      box-shadow: 0 2px 4px -1px rgba(black, 0.2), 0 4px 5px 0 rgba(black, 0.14),
-        0 1px 10px 0 rgba(black, 0.12);
-    }
+  }
 
     &.has-secondary-text {
       min-width: rem(240px);

--- a/lib/keen/UiPopover.vue
+++ b/lib/keen/UiPopover.vue
@@ -351,13 +351,14 @@
 
   /* stylelint-disable */
 
+  @import '../styles/definitions';
   @import './styles/imports';
   //@import './styles/tippy/tippy';
 
   .ui-popover {
     &.is-raised {
-      box-shadow: 0 2px 4px -1px rgba(black, 0.2), 0 4px 5px 0 rgba(black, 0.14),
-        0 1px 10px 0 rgba(black, 0.12);
+      @extend %dropshadow-2dp;
+    
     }
 
     .ui-menu {

--- a/lib/keen/UiSnackbar.vue
+++ b/lib/keen/UiSnackbar.vue
@@ -84,7 +84,7 @@
 <style lang="scss" scoped>
 
   /* stylelint-disable */
-
+  
   @import '../styles/definitions';
   @import './styles/imports';
 
@@ -92,6 +92,7 @@
   $ui-snackbar-font-size: rem(14px) !default;
 
   .ui-snackbar {
+    @extend  %dropshadow-2dp;
     @include font-family-noto;
 
     display: inline-flex;
@@ -102,7 +103,6 @@
     padding: rem(14px 24px);
     background-color: $ui-snackbar-background-color;
     border-radius: $ui-default-border-radius;
-    box-shadow: 0 1px 3px rgba(black, 0.12), 0 1px 2px rgba(black, 0.24);
   }
 
   .ui-snackbar-message {

--- a/lib/keen/UiToolbar.vue
+++ b/lib/keen/UiToolbar.vue
@@ -125,7 +125,7 @@
 </script>
 
 <style lang="scss">
-
+  @import '../styles/definitions';
   @import './styles/imports';
 
   $ui-toolbar-font-size: rem(18px) !default;
@@ -144,7 +144,7 @@
     font-size: $ui-toolbar-font-size;
 
     &.is-raised {
-      box-shadow: 0 0 2px rgba(black, 0.12), 0 2px 2px rgba(black, 0.2);
+      @extend %dropshadow-2dp;
     }
 
     &:not(.is-raised).ui-toolbar--type-default {


### PR DESCRIPTION
## Description
updating dropshadow according to the latest guidelines and replacing box-shadow eith appropriate dropshadow

#### updated the elemnts in the kds repo to use the dropshadows according to the latest guidelines and replace other elements like boxshadows with appropriate dropshadow.


Addresses #724



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:**  Updates dropshadows to the latest design guidelines
  - **Products impact:**  Visual
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/724
  - **Components:** All components with dropshadows
  - **Breaking:**  no
  - **Impacts a11y:**  no
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

