### PR TITLE
Add labelDir to KCheckbox and KRadioButton

### DIFF
--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -45,7 +45,7 @@
       </div>
 
       <label
-        dir="auto"
+        :dir="labelDir"
         class="k-checkbox-label"
         :for="id"
         :class="{ 'visuallyhidden': !showLabel }"
@@ -83,6 +83,14 @@
       label: {
         type: String,
         default: null,
+      },
+      /**
+       * RTL dir of the text label
+       * Options: 'auto', 'ltr', 'rtl', null.
+       */
+      labelDir: {
+        type: String,
+        default: 'auto',
       },
       /**
        * Whether or not to show the label

--- a/lib/KRadioButton.vue
+++ b/lib/KRadioButton.vue
@@ -36,7 +36,7 @@
       </div>
 
       <label
-        dir="auto"
+        :dir="labelDir"
         class="k-radio-button-label"
         :for="id"
         :class="{ 'visuallyhidden': !showLabel }"
@@ -95,6 +95,14 @@
       showLabel: {
         type: Boolean,
         default: true,
+      },
+      /**
+       * RTL dir of the text label
+       * Options: 'auto', 'ltr', 'rtl', null.
+       */
+      labelDir: {
+        type: String,
+        default: 'auto',
       },
       /**
        * Component `data` with which to associate this radio button and its siblings


### PR DESCRIPTION
## Description

Add labelDir to KCheckbox and KRadioButton to fix cases when the label dir is different from the user dir preferences.

#### Issue addressed

Needed to close https://github.com/learningequality/studio/issues/4728.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Add `labelDir` prop to control rtl direction of label.
  - **Products impact:** new API.
  - **Addresses:** https://github.com/learningequality/studio/issues/4728.
  - **Components:** KCheckbox, KRadioButton.
  - **Breaking:** no
  - **Impacts a11y:** no.
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
