### PR TITLE
Improve accessibility by using tooltip as fallback for ariaLabel in KIconButton

### DIFF
--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -10,6 +10,7 @@
     text=""
     v-on="$listeners"
   >
+    <!-- if no "position" is passed as a prop, defaults to bottom, as previously -->
     <UiTooltip
       v-if="tooltip"
       :zIndex="24"
@@ -18,11 +19,14 @@
     >
       {{ tooltip }}
     </UiTooltip>
+    <!-- UiIconButton used flexbox - 7px is the magic centering number -->
     <KIcon :icon="icon" :color="color" :style="iconStyles" />
+    <!-- @slot Pass sub-components into the button, typically `KDropdownMenu` -->
     <slot name="menu"></slot>
   </KButton>
 
 </template>
+
 
 <script>
 
@@ -32,38 +36,65 @@
     name: 'KIconButton',
     components: { UiTooltip },
     props: {
+      /**
+       * Name of icon to display
+       */
       icon: {
         type: String,
         required: true,
       },
+      /**
+       * Button appearance: `'raised-button'` or `'flat-button'`
+       */
       appearance: {
         type: String,
         default: 'flat-button',
       },
+      /**
+       * Optional hex or rgb[a] color for the button background
+       */
       color: {
         type: String,
         default: null,
       },
+      /**
+       * Whether or not button is disabled
+       */
       disabled: {
         type: Boolean,
         default: false,
       },
+      /**
+       * HTML button `type` attribute (e.g. `'submit'`, `'reset'`)
+       */
       buttonType: {
         type: String,
         default: 'button',
       },
+      /**
+       * Button size: `'mini'`, `'small'`, `'regular'`, or `'large'`
+       */
       size: {
         type: String,
         default: 'regular',
       },
+      /**
+       * `aria-label` attribute
+       */
       ariaLabel: {
         type: String,
-        default: null,
+        default: null, // https://github.com/learningequality/kolibri-design-system/issues/168
       },
+      /**
+       * Tooltip label
+       */
       tooltip: {
         type: String,
-        default: null,
+        default: null, // https://github.com/learningequality/kolibri-design-system/issues/168
       },
+      /**
+       * Tooltip position: `'top', 'right', 'bottom', 'left'`
+       */
       tooltipPosition: {
         type: String,
         default: 'bottom',
@@ -75,8 +106,11 @@
           this.appearance === 'flat-button' ? { backgroundColor: 'rgba(0,0,0,.1)' } : {};
         return {
           ...this.sizeStyles,
+          // Circle
           borderRadius: '50%',
+          // Added minWidth to prevent squished/oval effect
           minWidth: '32px',
+          // Remove minHeight & padding
           minHeight: '0px',
           padding: '0',
           ':hover': hover,
@@ -112,5 +146,6 @@
   };
 
 </script>
+
 
 <style lang="scss" scoped></style>

--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -6,11 +6,10 @@
     :appearance="appearance"
     :appearanceOverrides="appearanceOverrides"
     :type="buttonType"
-    :aria-label="ariaLabel"
+    :aria-label="computedAriaLabel"
     text=""
     v-on="$listeners"
   >
-    <!-- if no "position" is passed as a prop, defaults to bottom, as previously -->
     <UiTooltip
       v-if="tooltip"
       :zIndex="24"
@@ -19,14 +18,11 @@
     >
       {{ tooltip }}
     </UiTooltip>
-    <!-- UiIconButton used flexbox - 7px is the magic centering number -->
     <KIcon :icon="icon" :color="color" :style="iconStyles" />
-    <!-- @slot Pass sub-components into the button, typically `KDropdownMenu` -->
     <slot name="menu"></slot>
   </KButton>
 
 </template>
-
 
 <script>
 
@@ -36,65 +32,38 @@
     name: 'KIconButton',
     components: { UiTooltip },
     props: {
-      /**
-       * Name of icon to display
-       */
       icon: {
         type: String,
         required: true,
       },
-      /**
-       * Button appearance: `'raised-button'` or `'flat-button'`
-       */
       appearance: {
         type: String,
         default: 'flat-button',
       },
-      /**
-       * Optional hex or rgb[a] color for the button background
-       */
       color: {
         type: String,
         default: null,
       },
-      /**
-       * Whether or not button is disabled
-       */
       disabled: {
         type: Boolean,
         default: false,
       },
-      /**
-       * HTML button `type` attribute (e.g. `'submit'`, `'reset'`)
-       */
       buttonType: {
         type: String,
         default: 'button',
       },
-      /**
-       * Button size: `'mini'`, `'small'`, `'regular'`, or `'large'`
-       */
       size: {
         type: String,
         default: 'regular',
       },
-      /**
-       * `aria-label` attribute
-       */
       ariaLabel: {
         type: String,
-        default: null, // https://github.com/learningequality/kolibri-design-system/issues/168
+        default: null,
       },
-      /**
-       * Tooltip label
-       */
       tooltip: {
         type: String,
-        default: null, // https://github.com/learningequality/kolibri-design-system/issues/168
+        default: null,
       },
-      /**
-       * Tooltip position: `'top', 'right', 'bottom', 'left'`
-       */
       tooltipPosition: {
         type: String,
         default: 'bottom',
@@ -106,11 +75,8 @@
           this.appearance === 'flat-button' ? { backgroundColor: 'rgba(0,0,0,.1)' } : {};
         return {
           ...this.sizeStyles,
-          // Circle
           borderRadius: '50%',
-          // Added minWidth to prevent squished/oval effect
           minWidth: '32px',
-          // Remove minHeight & padding
           minHeight: '0px',
           padding: '0',
           ':hover': hover,
@@ -139,10 +105,12 @@
             return { ...sizes, top: '7px' };
         }
       },
+      computedAriaLabel() {
+        return this.ariaLabel || this.tooltip;
+      },
     },
   };
 
 </script>
-
 
 <style lang="scss" scoped></style>


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This PR addresses an accessibility issue in the `KIconButton` component. Previously, the `ariaLabel` and `tooltip` props were treated independently, and it was possible for a developer to omit the `ariaLabel` prop while setting a `tooltip`. This could lead to accessibility issues, as `ariaLabel` is essential for screen readers, but the `tooltip` is not.

#### Issue addressed
<!-- Only necessary if applicable -->
#793 

Addresses 
It is resolved by the adding a new custom computed property `computedAriaLabel` which will dynamically sets the `ariaLabel` and `tooltip` props.

### Before/after screenshots
<!-- Insert images here if applicable -->

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->
  - **Description:**  Adds custom computed property `computedAriaLabel` that dynamically sets the `ariaLabel` for `KIconButton` based on the `tooltip` prop when `ariaLabel` is not provided.
  - **Products impact:** none 
  - **Addresses:** #793 
  - **Components:** `KIconButton`
  - **Breaking:** no
  - **Impacts a11y:** Improves accessibility in places where we have tooltips but no aria- label attribute set for `KIconbutton`.
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
