### PR TITLE
More flexible KCard click event handling

### DIFF
--- a/docs/pages-components/DocsKCard.vue
+++ b/docs/pages-components/DocsKCard.vue
@@ -24,8 +24,8 @@
       <slot name="aboveTitle"></slot>
     </template>
 
-    <template v-if="$slots.title" #title>
-      <slot name="title"></slot>
+    <template v-if="$scopedSlots.title" #title="{ titleText }">
+      <slot name="title" :titleText="titleText"></slot>
     </template>
 
     <template v-if="$slots.belowTitle" #belowTitle>
@@ -151,9 +151,6 @@
       cardTitle() {
         if (this.title) {
           return this.title;
-        }
-        if (this.$slots.title) {
-          return null;
         }
 
         return `${this.prependTitle} Learn everything about hummingbirds: their habitats, feeding patterns, and stunning flight abilities`;

--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -48,7 +48,7 @@
           { text: 'KCard and KCardGrid', href: '#k-card-and-grid' },
           { text: 'Title', href: '#title' },
           { text: 'Accessibility', href: '#a11y' },
-          { text: 'Navigation', href: '#navigation' },
+          { text: 'Click event and navigation', href: '#click-navigation' },
           { text: 'Layout', href: '#layout' },
           { text: 'Responsiveness', href: '#responsiveness' },
           { text: 'Content slots', href: '#content-slots' },
@@ -214,28 +214,56 @@
       <p><em>Always test semantics, accessibility, and right-to-left of the final cards.</em></p>
 
       <h3>
-        Navigation
-        <DocsAnchorTarget anchor="#navigation" />
+        Click event and navigation
+        <DocsAnchorTarget anchor="#click-navigation" />
       </h3>
 
-      <p><code>KCard</code>'s entire area is clickable, navigating to a target provided via the <code>to</code> prop as a regular Vue route object. <DocsToggleButton contentId="more-navigation" /></p>
+      <p><code>KCard</code>'s entire area is clickable.</p>
 
-      <DocsToggleContent id="more-navigation">
-        <!-- eslint-disable -->
-        <DocsShowCode language="html">
-          <KCardGrid ...>
-            <KCard
-              :to="{ name: 'NamedRoute' }"
-              ...
-            />
-            <KCard
-              :to="{ path: '/kcard' }"
-              ...
-            />
-          </KCardGrid>
-        </DocsShowCode>
-        <!-- eslint-enable -->
-      </DocsToggleContent>
+      <p>You can use the <code>to</code> prop to navigate to a URL when the card is clicked.</p>
+
+      <DocsShowCode language="html">
+        <KCardGrid ...>
+          <KCard
+            ...
+            :to="{ name: 'NamedRoute' }"
+          />
+          <KCard
+            ...
+            :to="{ path: '/kcard' }"
+          />
+        </KCardGrid>
+      </DocsShowCode>
+
+      <p>Listen to the <code>click</code> event to perform a custom action (whether or not the <code>to</code> prop is used).</p>
+
+      <DocsShowCode language="html">
+        <KCardGrid ...>
+          <KCard
+            ...
+            @click="onClick"
+          />
+          <KCard
+            ...
+            :to="{ path: '/kcard' }"
+            @click="onClick"
+          />
+        </KCardGrid>
+      </DocsShowCode>
+
+      <!-- eslint-disable -->
+      <DocsShowCode language="javascript">
+        export default {
+          methods() {
+            onClick() {
+              console.log('Card clicked');
+            }
+          },
+        };
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <p>Note that long clicks are ignored to allow for text selection.</p>
 
       <p>See <DocsInternalLink text="Interactive elements" href="#interactive-elements" /> to learn how to disable card navigation in favor of a custom handler when elements like buttons are rendered within a card.</p>
 
@@ -563,7 +591,7 @@
         <DocsAnchorTarget anchor="#interactive-elements" />
       </h3>
 
-      <p>When adding interactive elements like buttons to a card via slots, apply the <code>.stop</code> event modifier to their <code>@click</code> event to prevent the card from navigating away when clicked.</p>
+      <p>When adding interactive elements like buttons to a card via slots, apply the <code>.stop</code> event modifier to their <code>@click</code> event to prevent the card <DocsInternalLink text="click event and navigation" href="#click-navigation" />.</p>
 
       <p><em>This applies to all slot content, but considering accessibility is especially important with interactive elements.</em> For instance, <code>ariaLabel</code> is applied to the bookmark icon button in the following example so that screenreaders can communicate its purpose. In production, more work would be needed to indicate the bookmark's toggled state. Always assess on a case-by-case basis.</p>
 

--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -17,7 +17,7 @@
             :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
             thumbnailDisplay="large"
             thumbnailAlign="right"
-            prependTitle="(2)"
+            prependTitle="(1)"
             showProgressInFooter
           />
         </KCardGrid>
@@ -33,6 +33,7 @@
         </li>
         <li>Set a correct heading level (<DocsInternalLink text="Title" href="#title" />)</li>
         <li>Ensure each card title is unique within a card grid (<DocsInternalLink text="Title" href="#title" />)</li>
+        <li>Do not use a heading element within the <code>title</code> slot</li>
         <li>Ensure content provided via slots is accessible (<DocsInternalLink text="Accessibility" href="#a11y" />)</li>
         <li>Even if a thumbnail image is available, provide a placeholder element (<DocsInternalLink text="Placeholder" href="#thumbnail-placeholder" />)</li>
         <li>If using selection controls, use pre-defined labels (<DocsInternalLink text="Selection controls" href="#selection-controls" />)</li>
@@ -148,7 +149,7 @@
         <DocsAnchorTarget anchor="#title" />
       </h3>
 
-      <p><em>Use the <code>title</code> prop to assign an unique title to each card in a grid, and the <code>headingLevel</code> prop to set the heading level on it. The level needs to correspond to the surrounding context.</em> <DocsToggleButton contentId="more-heading-level" /></p>
+      <p><em>Always use the <code>title</code> prop to assign an unique title to each card in a grid, and the <code>headingLevel</code> prop to set the heading level on it. The level needs to correspond to the surrounding context.</em> <DocsToggleButton contentId="more-heading-level" /></p>
 
       <DocsToggleContent id="more-heading-level">
         <p>Examples:</p>
@@ -159,40 +160,79 @@
         </ul>
       </DocsToggleContent>
 
-      <p>The <code>titleMaxLines</code> prop can be used to truncate the title to a set number of lines.</p>
+      <p>The scoped <code>title</code> slot with its <code>titleText</code> attribute can be used to customize the title.</p>
 
-      <p>For more customization, the <code>title</code> slot can be used. Provide only a title text to the slot without wrapping it in a heading element to avoid duplicate headings in the markup output. <DocsToggleButton contentId="more-title-slot" /></p>
+      <DocsShow block :style="{ maxWidth: '600px' }">
+        <KCardGrid
+          layout="1-1-1"
+          :skeletonsConfig="skeletonsConfig9"
+          :loading="loading"  
+        >
+          <DocsKCard
+            :headingLevel="3"
+            orientation="horizontal"
+            thumbnailDisplay="small"
+            thumbnailAlign="right"
+            prependTitle="(1)"
+            hideFooter
+          >
+            <template #title="{ titleText }">
+              <KLabeledIcon icon="readSolid">
+                <KTextTruncator
+                  :text="titleText"
+                  :maxLines="1"
+                />
+              </KLabeledIcon>
+            </template>
+          </DocsKCard>
+        </KCardGrid>
+      </DocsShow>
+
+      <!-- eslint-disable -->
+      <DocsShowCode language="html">
+        <template>
+          <KCardGrid>
+            <KCard
+              :headingLevel="3"
+              title="(1) Learn everything about hummingbirds: their habitats, feeding patterns, and stunning flight abilities"
+              ...
+            >
+              <template #title="{ titleText }">
+                <KLabeledIcon icon="readSolid">
+                  <KTextTruncator
+                    :text="titleText"
+                    :maxLines="1"
+                  />
+                </KLabeledIcon>
+              </template>
+            </KCard>
+          </KCardGrid>
+        </template>
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <p><em>Do not use a heading element within the <code>title</code> slot to avoid duplicate headings in the markup output.</em><code>KCard</code> already handles a heading element internally.<DocsToggleButton contentId="more-title-slot" /></p>
 
       <DocsToggleContent id="more-title-slot">
         <DocsDoNot>
-          <template #do>
-            <!-- eslint-disable -->
-            <DocsShowCode language="html">
-              <template>
-                <KCardGrid>
-                  <KCard
-                    :headingLevel="3"
-                    ...
-                  >
-                    <template #title>
-                      Card title
-                    </template>
-                  </KCard>
-                </KCardGrid>
-              </template>
-            </DocsShowCode>
-            <!-- eslint-enable -->
-          </template>
           <template #not>
             <DocsShowCode language="html">
               <template>
                 <KCardGrid>
                   <KCard
                     :headingLevel="3"
+                    title="(1) Learn everything about hummingbirds"
                     ...
                   >
-                    <template #title>
-                      <h3>Card title</h3>
+                    <template #title="{ titleText }">
+                      <h3>
+                        <KLabeledIcon icon="readSolid">
+                          <KTextTruncator
+                            :text="titleText"
+                            :maxLines="2"
+                          />
+                        </KLabeledIcon>
+                      </h3>
                     </template>
                   </KCard>
                 </KCardGrid>
@@ -201,6 +241,8 @@
           </template>
         </DocsDoNot>
       </DocsToggleContent>
+
+      <p>The <code>titleMaxLines</code> prop can be used to truncate the title to a set number of lines.</p>
 
       <h3>
         Accessibility
@@ -887,6 +929,15 @@
             orientation: 'horizontal',
             thumbnailAlign: 'right',
             height: '180px',
+          },
+        ],
+        skeletonsConfig9: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'horizontal',
+            thumbnailDisplay: 'small',
+            thumbnailAlign: 'right',
+            height: '130px',
           },
         ],
       };

--- a/lib/cards/KCard.vue
+++ b/lib/cards/KCard.vue
@@ -484,11 +484,12 @@
       onThumbnailError() {
         this.thumbnailError = true;
       },
-      clickHandler() {
+      clickHandler(event) {
         /**
-         * Emitted when a card is clicked
+         * Emitted when a card is clicked or pressed with enter.
+         * Contains the DOM event in the payload.
          */
-        this.$emit('click');
+        this.$emit('click', event);
         if (this.to) {
           this.$router.push(this.to);
         }
@@ -505,13 +506,13 @@
          */
         this.$emit('hover', e);
       },
-      onEnter() {
-        this.clickHandler();
+      onEnter(event) {
+        this.clickHandler(event);
       },
       onMouseDown() {
         this.mouseDownTime = new Date().getTime();
       },
-      onClick() {
+      onClick(event) {
         if (this.isSkeleton) {
           return;
         }
@@ -524,7 +525,7 @@
         // which is not typically interpreted as a click event so do not run
         // the click handler.
         if (mouseUpTime - this.mouseDownTime < 200) {
-          this.clickHandler();
+          this.clickHandler(event);
         } else {
           return;
         }

--- a/lib/cards/SkeletonCard.vue
+++ b/lib/cards/SkeletonCard.vue
@@ -9,6 +9,7 @@
     isSkeleton
     aria-hidden="true"
     class="skeleton-card"
+    title="_"
     :style="{ height: height }"
     :orientation="orientation"
     :thumbnailDisplay="thumbnailDisplay"

--- a/lib/cards/SkeletonCard.vue
+++ b/lib/cards/SkeletonCard.vue
@@ -5,7 +5,6 @@
     Their logic is disabled in skeleton mode.
   -->
   <KCard
-    :to="{ path: null }"
     :headingLevel="2"
     isSkeleton
     aria-hidden="true"

--- a/lib/cards/__tests__/KCard.spec.js
+++ b/lib/cards/__tests__/KCard.spec.js
@@ -13,44 +13,6 @@ function makeWrapper({ propsData = {}, slots = {} } = {}) {
   return mount(KCard, { router, propsData, slots, localVue });
 }
 
-/*
-  Checks the expected card markup:
-
-  <li>
-    <div>
-      <h[2-6]>
-        <a href="/some-link">Test Title</a>
-      </h[2-6]>
-    </div>
-
-    all other content
-  </li>
-  
-  "li > h[2-6] > a > title text" structure that comes before
-  all other content is crucial to ensure accessibility.
-*/
-function checkExpectedCardMarkup({ wrapper, headingLevel, title }) {
-  const firstElement = wrapper.find(':first-child');
-  expect(firstElement.exists()).toBe(true);
-  expect(firstElement.element.tagName.toLowerCase()).toBe('li');
-
-  const secondElement = wrapper.find('li > :first-child');
-  expect(secondElement.exists()).toBe(true);
-  expect(secondElement.element.tagName.toLowerCase()).toBe('div');
-
-  const thirdElement = wrapper.find('li > div > :first-child');
-  expect(thirdElement.exists()).toBe(true);
-  expect(thirdElement.element.tagName.toLowerCase()).toBe(`h${headingLevel}`);
-
-  const fourthElement = wrapper.find(`li > div > h${headingLevel} > :first-child`);
-  expect(fourthElement.exists()).toBe(true);
-  expect(fourthElement.element.tagName.toLowerCase()).toBe('span');
-  expect(fourthElement.element.classList.contains('title')).toBeTruthy();
-
-  const linkText = fourthElement.text();
-  expect(linkText).toBe(title);
-}
-
 describe('KCard', () => {
   it('renders passed header level', () => {
     const wrapper = makeWrapper({
@@ -61,35 +23,93 @@ describe('KCard', () => {
     expect(heading.exists()).toBe(true);
   });
 
-  it(`renders the title text as span when 'to' is not provided`, () => {
+  it(`renders the correct accessibility structure when card is link`, () => {
     const wrapper = makeWrapper({
-      propsData: { headingLevel: 4, title: 'sample title' },
+      propsData: { to: { path: '/some-link' }, title: 'Test Title', headingLevel: 4 },
     });
-    expect(wrapper.find('.title').element.tagName.toLowerCase()).toBe('span');
+
+    // Check for:
+    //
+    // li
+    //  |-- div
+    //       |--span (visually hidden title text)
+    //       |-- h[2-6]
+    //           |--a (with aria-labelledby pointing to the span above)
+    //                |-- span (with aria-hidden)
+    //
+    const el1 = wrapper.find(':first-child');
+    expect(el1.exists()).toBe(true);
+    expect(el1.element.tagName.toLowerCase()).toBe('li');
+
+    const el2 = wrapper.find('li > :first-child');
+    expect(el2.exists()).toBe(true);
+    expect(el2.element.tagName.toLowerCase()).toBe('div');
+
+    const el3 = wrapper.find('li > div > :nth-child(1)');
+    expect(el3.exists()).toBe(true);
+    expect(el3.element.tagName.toLowerCase()).toBe('span');
+    expect(el3.classes()).toContain('visuallyhidden');
+    expect(el3.text()).toBe('Test Title');
+    const spanId = el3.attributes('id');
+
+    const el4 = wrapper.find('li > div > :nth-child(2)');
+    expect(el4.exists()).toBe(true);
+    expect(el4.element.tagName.toLowerCase()).toBe('h4');
+
+    const el5 = wrapper.find(`li > div > h4 > :first-child`);
+    expect(el5.exists()).toBe(true);
+    expect(el5.element.tagName.toLowerCase()).toBe('a');
+    expect(el5.attributes('aria-labelledby')).toBe(spanId);
+
+    const el6 = wrapper.find(`li > div > h4 > a > :first-child`);
+    expect(el6.exists()).toBe(true);
+    expect(el6.element.tagName.toLowerCase()).toBe('span');
+    expect(el6.attributes('aria-hidden')).toBe('true');
   });
 
-  it(`renders the title text as link when 'to' is provided`, () => {
+  it(`renders the correct accessibility structure when card is not link`, () => {
     const wrapper = makeWrapper({
-      propsData: { to: { path: '/some-link' }, headingLevel: 4, title: 'sample title' },
+      propsData: { title: 'Test Title', headingLevel: 4 },
     });
-    expect(wrapper.find('.title').element.tagName.toLowerCase()).toBe('a');
-  });
 
-  it('renders the correct accessibility structure when title passed via slot', () => {
-    const wrapper = makeWrapper({
-      propsData: { headingLevel: 4 },
-      slots: {
-        title: 'Test Title',
-      },
-    });
-    checkExpectedCardMarkup({ wrapper, headingLevel: 4, title: 'Test Title' });
-  });
+    // Check for:
+    //
+    // li
+    //  |-- div
+    //       |--span (visually hidden title text)
+    //       |-- h[2-6]
+    //           |--span (focusable and with aria-labelledby pointing to the span above)
+    //                |-- span (with aria-hidden)
+    //
+    const el1 = wrapper.find(':first-child');
+    expect(el1.exists()).toBe(true);
+    expect(el1.element.tagName.toLowerCase()).toBe('li');
 
-  it('renders the correct accessibility structure when title passed via prop', () => {
-    const wrapper = makeWrapper({
-      propsData: { headingLevel: 4, title: 'Test Title' },
-    });
-    checkExpectedCardMarkup({ wrapper, headingLevel: 4, title: 'Test Title' });
+    const el2 = wrapper.find('li > :first-child');
+    expect(el2.exists()).toBe(true);
+    expect(el2.element.tagName.toLowerCase()).toBe('div');
+
+    const el3 = wrapper.find('li > div > :nth-child(1)');
+    expect(el3.exists()).toBe(true);
+    expect(el3.element.tagName.toLowerCase()).toBe('span');
+    expect(el3.classes()).toContain('visuallyhidden');
+    expect(el3.text()).toBe('Test Title');
+    const spanId = el3.attributes('id');
+
+    const el4 = wrapper.find('li > div > :nth-child(2)');
+    expect(el4.exists()).toBe(true);
+    expect(el4.element.tagName.toLowerCase()).toBe('h4');
+
+    const el5 = wrapper.find(`li > div > h4 > :first-child`);
+    expect(el5.exists()).toBe(true);
+    expect(el5.element.tagName.toLowerCase()).toBe('span');
+    expect(el5.attributes('aria-labelledby')).toBe(spanId);
+    expect(el5.attributes('tabindex')).toBe('0');
+
+    const el6 = wrapper.find(`li > div > h4 > span > :first-child`);
+    expect(el6.exists()).toBe(true);
+    expect(el6.element.tagName.toLowerCase()).toBe('span');
+    expect(el6.attributes('aria-hidden')).toBe('true');
   });
 
   describe('on long click', () => {

--- a/lib/cards/__tests__/KCard.spec.js
+++ b/lib/cards/__tests__/KCard.spec.js
@@ -43,8 +43,9 @@ function checkExpectedCardMarkup({ wrapper, headingLevel, title }) {
   expect(thirdElement.element.tagName.toLowerCase()).toBe(`h${headingLevel}`);
 
   const fourthElement = wrapper.find(`li > div > h${headingLevel} > :first-child`);
-  expect(fourthElement.element.tagName.toLowerCase()).toBe('a');
   expect(fourthElement.exists()).toBe(true);
+  expect(fourthElement.element.tagName.toLowerCase()).toBe('span');
+  expect(fourthElement.element.classList.contains('title')).toBeTruthy();
 
   const linkText = fourthElement.text();
   expect(linkText).toBe(title);
@@ -53,16 +54,30 @@ function checkExpectedCardMarkup({ wrapper, headingLevel, title }) {
 describe('KCard', () => {
   it('renders passed header level', () => {
     const wrapper = makeWrapper({
-      propsData: { headingLevel: 4, title: 'sample title prop', to: { path: '/some-link' } },
+      propsData: { headingLevel: 4, title: 'sample title prop' },
     });
 
     const heading = wrapper.find('h4');
     expect(heading.exists()).toBe(true);
   });
 
+  it(`renders the title text as span when 'to' is not provided`, () => {
+    const wrapper = makeWrapper({
+      propsData: { headingLevel: 4, title: 'sample title' },
+    });
+    expect(wrapper.find('.title').element.tagName.toLowerCase()).toBe('span');
+  });
+
+  it(`renders the title text as link when 'to' is provided`, () => {
+    const wrapper = makeWrapper({
+      propsData: { to: { path: '/some-link' }, headingLevel: 4, title: 'sample title' },
+    });
+    expect(wrapper.find('.title').element.tagName.toLowerCase()).toBe('a');
+  });
+
   it('renders the correct accessibility structure when title passed via slot', () => {
     const wrapper = makeWrapper({
-      propsData: { to: { path: '/some-link' }, headingLevel: 4 },
+      propsData: { headingLevel: 4 },
       slots: {
         title: 'Test Title',
       },
@@ -72,38 +87,57 @@ describe('KCard', () => {
 
   it('renders the correct accessibility structure when title passed via prop', () => {
     const wrapper = makeWrapper({
-      propsData: { to: { path: '/some-link' }, headingLevel: 4, title: 'Test Title' },
+      propsData: { headingLevel: 4, title: 'Test Title' },
     });
     checkExpectedCardMarkup({ wrapper, headingLevel: 4, title: 'Test Title' });
   });
 
-  it('should not navigate on long click to allow for text selection', async () => {
-    const wrapper = makeWrapper({
-      propsData: { to: { path: '/some-link' }, title: 'sample title prop' },
-    });
+  describe('on long click', () => {
+    it('should not emit a click event or navigate to allow for text selection', async () => {
+      const wrapper = makeWrapper({
+        propsData: { to: { path: '/some-link' }, title: 'sample title ' },
+      });
 
-    await wrapper.find('li').trigger('mousedown');
-    await new Promise(resolve => setTimeout(resolve, 500));
-    await wrapper.find('li').trigger('click');
-    expect(wrapper.vm.$router.currentRoute.path).not.toBe('/some-link');
+      await wrapper.find('li').trigger('mousedown');
+      await new Promise(resolve => setTimeout(resolve, 500));
+      await wrapper.find('li').trigger('click');
+
+      expect(wrapper.emitted().click).toBeFalsy();
+      expect(wrapper.vm.$router.currentRoute.path).not.toBe('/some-link');
+    });
   });
 
-  it('should navigate on quick click', async () => {
-    const wrapper = makeWrapper({
-      propsData: { to: { path: '/some-link' }, title: 'sample title ' },
+  describe('on short click', () => {
+    it('should emit a click event', async () => {
+      const wrapper = makeWrapper({
+        propsData: { title: 'sample title ' },
+      });
+
+      await wrapper.find('li').trigger('mousedown');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      await wrapper.find('li').trigger('click');
+
+      expect(wrapper.emitted().click).toBeTruthy();
     });
 
-    await wrapper.find('li').trigger('mousedown');
-    await new Promise(resolve => setTimeout(resolve, 100));
-    await wrapper.find('li').trigger('click');
+    it(`when 'to' provided, should both navigate and emit a click event`, async () => {
+      const wrapper = makeWrapper({
+        propsData: { to: { path: '/some-link' }, title: 'sample title ' },
+      });
 
-    expect(wrapper.vm.$router.currentRoute.path).toBe('/some-link');
+      await wrapper.find('li').trigger('mousedown');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      await wrapper.find('li').trigger('click');
+
+      expect(wrapper.emitted().click).toBeTruthy();
+      expect(wrapper.vm.$router.currentRoute.path).toBe('/some-link');
+    });
   });
 
   describe('it renders slotted content', () => {
     it('renders slotted content with aboveTitle slot', () => {
       const wrapper = makeWrapper({
-        propsData: { to: { path: '/some-link' }, title: 'sample title ' },
+        propsData: { title: 'sample title ' },
         slots: {
           aboveTitle: 'above title',
         },
@@ -116,7 +150,7 @@ describe('KCard', () => {
 
     it('renders slotted content with belowTitle slot', () => {
       const wrapper = makeWrapper({
-        propsData: { to: { path: '/some-link' }, title: 'sample title ' },
+        propsData: { title: 'sample title ' },
         slots: {
           belowTitle: 'below title',
         },
@@ -129,7 +163,7 @@ describe('KCard', () => {
 
     it('renders slotted content with footer slot', () => {
       const wrapper = makeWrapper({
-        propsData: { to: { path: '/some-link' }, title: 'sample title ' },
+        propsData: { title: 'sample title ' },
         slots: {
           footer: 'footer slot content goes here',
         },
@@ -144,7 +178,6 @@ describe('KCard', () => {
     it('preserves space when preserve prop is true and slot is not empty', () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           preserveAboveTitle: true,
@@ -168,7 +201,6 @@ describe('KCard', () => {
     it('preserves space when preserve prop is true and slot is empty', () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           preserveAboveTitle: true,
@@ -188,7 +220,6 @@ describe('KCard', () => {
     it('removes space when preserve prop is false and slot is empty', () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           preserveAboveTitle: false,
@@ -208,7 +239,6 @@ describe('KCard', () => {
     it('show slots content regardless of whether the preserve prop is true', () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           preserveAboveTitle: true,
@@ -234,7 +264,6 @@ describe('KCard', () => {
     it('is not displayed for thumbnail display none', () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           thumbnailDisplay: 'none',
@@ -249,7 +278,6 @@ describe('KCard', () => {
     it('is displayed when a thumbnail image source is not provided', () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           thumbnailSrc: null,
@@ -266,7 +294,6 @@ describe('KCard', () => {
     it('is displayed when a thumbnail image could not be loaded', async () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           thumbnailSrc: '/thumbnail-img.jpg',
@@ -287,7 +314,6 @@ describe('KCard', () => {
     it('is not displayed when a thumbnail image is available', () => {
       const wrapper = makeWrapper({
         propsData: {
-          to: { path: '/some-link' },
           title: 'sample title ',
           headingLevel: 4,
           thumbnailSrc: '/thumbnail-img.jpg',


### PR DESCRIPTION
## Description

`KCard` is updated for more flexible click event handling. Previously, its title text was always `router-link`, `to` prop was required, and the card would navigate to the target on click. The new behavior is:

- `click` event is always emitted on card click
- `to` prop is not required
- when `to` is provided, the title text is `router-link`, and the card navigates to the target
- when `to` is not provided, the title text is `span`, and the card doesn't navigate anywhere

Contains related a11y changes that increase screen reader reliability overall:

- Make title prop required and allow title customization via a scoped slot
- Ensure reliable screen readers announcements no matter whether card is link or no, and no matter whether the title is customized via the title slot.

#### Issue addressed

A new use-case in Studio that @akolson works on in https://github.com/learningequality/studio/pull/4803 where a side panel needs to be toggled on card click without navigating to a new URL.

![Screenshot from 2024-11-13 16-33-50](https://github.com/user-attachments/assets/895c7406-b46d-4c59-afd2-1a0404095c8c)

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Make the `title` prop required
  - **Products impact:** updated API
  - **Addresses:** A new use-case in Studio in https://github.com/learningequality/studio/pull/4803 where a side panel needs to be toggled on card click without changing URL.
  - **Components:** KCard
  - **Breaking:** yes
  - **Impacts a11y:** no
  - **Guidance:** Even if you use the `title` slot, pass the title text via the `title` prop.

  - **Description:** Change the `title` slot into a scoped slot
  - **Products impact:** updated API
  - **Addresses:** A new use-case in Studio in https://github.com/learningequality/studio/pull/4803 where a side panel needs to be toggled on card click without changing URL.
  - **Components:** KCard
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:**  Consider using the slot's `textTitle` attribute to achieve more intuitive code when customizing the title.

  - **Description:** Emit `click` event when card is clicked.
  - **Products impact:** updated API
  - **Addresses:** A new use-case in Studio in https://github.com/learningequality/studio/pull/4803 where a side panel needs to be toggled on card click without changing URL.
  - **Components:** KCard
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

  - **Description:** Make `to` prop optional and when not provided, do not render the title text as `router-link` but rather as `span`.
  - **Products impact:** updated API
  - **Addresses:** A new use-case in Studio in https://github.com/learningequality/studio/pull/4803 where a side panel needs to be toggled on card click without changing URL.
  - **Components:** KCard
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

  - **Description:** Ensure reliable screen readers announcements no matter whether card is link or no, and no matter whether the title is customized via the title slot
  - **Products impact:** bugfix
  - **Addresses:** A new use-case in Studio in https://github.com/learningequality/studio/pull/4803 where a side panel needs to be toggled on card click without changing URL.
  - **Components:** KCard
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

- You could run the devserver, play around with `to` and `@click` on the [DocsKCard](https://github.com/learningequality/kolibri-design-system/blob/develop/docs/pages-components/DocsKCard.vue#L3-L11) and preview live example on `KCard` docs page.
- Is [the updated documentation section](https://deploy-preview-825--kolibri-design-system.netlify.app/kcard/#click-navigation) clear?
- Can you see any functional, markup, or a11y regressions?

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
