### PR TITLE
Improve the reverse navigation order of focusable elements within KTable cells

### DIFF
--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -535,7 +535,7 @@
         if (!cell) return [];
         const focusableSelectors = ['button', 'a', 'input', 'select', 'textarea'];
         return focusableSelectors.flatMap(selector =>
-          Array.from(cell.getElementsByTagName(selector))
+          Array.from(cell.getElementsByTagName(selector)),
         );
       },
 


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This pull request addresses an issue with the **Shift+Tab** key navigation behavior in the **KTable** component (follow-up to issue **#795**). Previously, pressing **Shift+Tab** to navigate backward through table cells did not follow the expected reverse order of focusable elements, leading to an unintuitive and confusing user experience.
#### Issue addressed
Closes #837 

Addresses #*PR# HERE*
#795

### Before/after videos:
Before:
[View actual behavior video](https://github.com/user-attachments/assets/d8d695e9-f35a-4723-8381-c7580ea102be)

After:
[View expected behavior video](https://github.com/user-attachments/assets/48f0b9da-4167-4795-badd-ad9b99d679c5)
<!-- Insert images here if applicable -->

### **Example:**

Given a table with the following structure:

- **Row 1**:
  - **Cell 1**
  - **Cell 2**
  - **Cell 3** containing:
    - **Button 1**
    - **Button 2**

- **Row 2**:
  - **Cell 1** (current focus)
  - **Cell 2**
  - **Cell 3** containing:
    - **Button 1**
    - **Button 2**

### **Expected Behavior:**
- When using **Shift+Tab**, the focus should move backward through the focusable elements within each table cell in reverse DOM order.
- For example, if the focus is on **Cell 1** in **Row 2**, pressing **Shift+Tab** should move the focus to **Button 2** inside **Cell 3** of **Row 1**, then to **Button 1**, then to **Cell 3**, and so on.

### **Changes Made:**
- Modified the **handleTabKey** function to ensure that **Shift+Tab** navigation moves the focus through focusable elements in reverse DOM order.
- Corrected the behavior to ensure that pressing **Shift+Tab** from a focusable element moves focus to the previous focusable element within the cell, and continues navigating through the table cells in reverse order.
- Removed the unintended **Cell 4** from the example in the associated issue description for clarity.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Corrected **Shift+Tab** navigation behavior to follow the expected reverse order of focusable elements within cells.  
  - **Products impact:** bugfix 
  - **Addresses:** #837 #804 
  - **Components:** KTable
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** No special guidance required for consumers.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

### **Steps to Test:**
1. Open the **KTable** component with multiple rows and focusable elements within cells (e.g., buttons).
2. Focus on a cell (e.g., **Cell 1** of **Row 2**).
3. Press **Shift+Tab** and verify that the focus moves to the correct previous focusable element (e.g., **Button 2** inside **Cell 3** of **Row 1**).
4. Continue pressing **Shift+Tab** and verify that focus correctly moves through the elements in reverse order, respecting the DOM structure.

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->
Initially `focusCell` in `updateFocusState` method was causing diffculty in implementation of the ideal navigation. It can be tackled by introducing a third parameter in `updateFocusState` to check if `focusCell` is necessary or not.
## Code

```js
      updateFocusState(nextRowIndex, nextColIndex, shouldFocusCell = true) {
        this.focusedRowIndex = nextRowIndex === -1 ? null : nextRowIndex;
        this.focusedColIndex = nextColIndex;
        this.highlightHeader(nextColIndex);

        if (shouldFocusCell) {
          this.focusCell(nextRowIndex, nextColIndex);
        }
      },
``` 

```js
            const prevCellAndFocusableElements = [prevCell, ...prevFocusableElements];
            prevCellAndFocusableElements[prevCellAndFocusableElements.length - 1].focus();
            this.updateFocusState(nextRowIndex, nextColIndex, false);
            event.preventDefault();
``` 
### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
