### PR TITLE
add sidebar toggle 

### DIFF
--- a/docs/common/DocsPageTemplate/Header.vue
+++ b/docs/common/DocsPageTemplate/Header.vue
@@ -1,4 +1,5 @@
 <template>
+
   <div
     class="header"
     :class="{ scrolled }"
@@ -7,8 +8,8 @@
       <h1 class="header-text">
         <KIconButton
           icon="menu"
-          @click="toggleSideNav"
           class="menu"
+          @click="toggleSideNav"
         />
         <span :class="{ code: codeStyle }">{{ title }}</span>
         <a
@@ -42,9 +43,12 @@
       </li>
     </ul>
   </div>
+
 </template>
 
+
 <script>
+
   import BranchLink from './BranchLink.vue';
 
   export default {
@@ -96,9 +100,12 @@
       },
     },
   };
+
 </script>
 
+
 <style lang="scss" scoped>
+
   @import '~/assets/definitions';
 
   .header {
@@ -167,4 +174,5 @@
       display: inline-block !important;
     }
   }
+
 </style>

--- a/docs/common/DocsPageTemplate/Header.vue
+++ b/docs/common/DocsPageTemplate/Header.vue
@@ -1,14 +1,15 @@
 <template>
-
   <div
     class="header"
     :class="{ scrolled }"
   >
     <div>
       <h1 class="header-text">
-        <span @click="toggleSideNav">
-        <KIcon icon="menu"  />
-        </span>
+        <KIconButton
+          icon="menu"
+          @click="toggleSideNav"
+          class="menu"
+        />
         <span :class="{ code: codeStyle }">{{ title }}</span>
         <a
           href="#"
@@ -41,12 +42,9 @@
       </li>
     </ul>
   </div>
-
 </template>
 
-
 <script>
-
   import BranchLink from './BranchLink.vue';
 
   export default {
@@ -98,12 +96,9 @@
       },
     },
   };
-
 </script>
 
-
 <style lang="scss" scoped>
-
   @import '~/assets/definitions';
 
   .header {
@@ -163,4 +158,13 @@
     transform: scale(1.25);
   }
 
+  .menu {
+    display: none !important;
+  }
+
+  @media (max-width: 768px) {
+    .menu {
+      display: inline-block !important;
+    }
+  }
 </style>

--- a/docs/common/DocsPageTemplate/Header.vue
+++ b/docs/common/DocsPageTemplate/Header.vue
@@ -6,6 +6,9 @@
   >
     <div>
       <h1 class="header-text">
+        <span @click="toggleSideNav">
+        <KIcon icon="menu"  />
+        </span>
         <span :class="{ code: codeStyle }">{{ title }}</span>
         <a
           href="#"
@@ -89,6 +92,9 @@
       },
       updateHighlight() {
         this.highlighed = ['', '#'].includes(window.location.hash);
+      },
+      toggleSideNav() {
+        this.$emit('update-side-nav', true); // Emit value to parent
       },
     },
   };

--- a/docs/common/DocsPageTemplate/Header.vue
+++ b/docs/common/DocsPageTemplate/Header.vue
@@ -152,6 +152,10 @@
     font-weight: 400;
   }
 
+  .header-text > * {
+    vertical-align: middle;
+  }
+
   .icon-link {
     width: 14px;
     height: 14px;

--- a/docs/common/DocsPageTemplate/SideNav/index.vue
+++ b/docs/common/DocsPageTemplate/SideNav/index.vue
@@ -14,6 +14,7 @@
             :showBackground="true"
           />
           <span class="header-text">Design System</span>
+          <span @click="closeSideNav"> <KIcon icon="close"/></span>
         </h1>
 
         <DocsFilter v-model="filterText" />
@@ -99,6 +100,9 @@
       throttleHandleScroll: throttle(function handleScroll() {
         window.sessionStorage.setItem('nav-scroll', this.$refs.links.scrollTop);
       }, 100),
+      closeSideNav() {
+        this.$emit('update-side-nav', false);
+      },
     },
   };
 
@@ -146,6 +150,7 @@
     left: 0;
     z-index: 100;
     width: $nav-width;
+    transition: transform 0.3s ease;
   }
 
   .sidenav {

--- a/docs/common/DocsPageTemplate/SideNav/index.vue
+++ b/docs/common/DocsPageTemplate/SideNav/index.vue
@@ -1,5 +1,4 @@
 <template>
-
   <div class="nav-wrapper">
     <nav
       ref="links"
@@ -8,13 +7,17 @@
     >
       <template if="loaded">
         <h1 class="header">
+          <KIconButton
+            icon="close"
+            @click="closeSideNav"
+            class="close-icon"
+          />
           <KLogo
             altText="Design System"
             size="60"
             :showBackground="true"
           />
           <span class="header-text">Design System</span>
-          <span @click="closeSideNav"> <KIcon icon="close"/></span>
         </h1>
 
         <DocsFilter v-model="filterText" />
@@ -32,12 +35,9 @@
     <!-- used to help indicate that there is more to see if one scrolls down -->
     <div class="bottom-gradient"></div>
   </div>
-
 </template>
 
-
 <script>
-
   import throttle from 'lodash/throttle';
   import NavSectionList from './NavSectionList';
   import { termList, matches } from '~/common/DocsFilter/utils';
@@ -105,12 +105,9 @@
       },
     },
   };
-
 </script>
 
-
 <style lang="scss" scoped>
-
   @import '~/assets/definitions';
 
   .header {
@@ -170,4 +167,13 @@
     margin-top: 16px;
   }
 
+  .close-icon {
+    display: none !important;
+  }
+
+  @media (max-width: 768px) {
+    .close-icon {
+      display: block !important;
+    }
+  }
 </style>

--- a/docs/common/DocsPageTemplate/SideNav/index.vue
+++ b/docs/common/DocsPageTemplate/SideNav/index.vue
@@ -1,4 +1,5 @@
 <template>
+
   <div class="nav-wrapper">
     <nav
       ref="links"
@@ -9,8 +10,8 @@
         <h1 class="header">
           <KIconButton
             icon="close"
-            @click="closeSideNav"
             class="close-icon"
+            @click="closeSideNav"
           />
           <KLogo
             altText="Design System"
@@ -35,9 +36,12 @@
     <!-- used to help indicate that there is more to see if one scrolls down -->
     <div class="bottom-gradient"></div>
   </div>
+
 </template>
 
+
 <script>
+
   import throttle from 'lodash/throttle';
   import NavSectionList from './NavSectionList';
   import { termList, matches } from '~/common/DocsFilter/utils';
@@ -105,9 +109,12 @@
       },
     },
   };
+
 </script>
 
+
 <style lang="scss" scoped>
+
   @import '~/assets/definitions';
 
   .header {
@@ -176,4 +183,5 @@
       display: block !important;
     }
   }
+
 </style>

--- a/docs/common/DocsPageTemplate/index.vue
+++ b/docs/common/DocsPageTemplate/index.vue
@@ -1,12 +1,13 @@
 <template>
 
   <div class="content-wrapper">
-    <SideNav />
+    <SideNav :class="{ show: isSideNavVisible, 'side-nav': true }" @update-side-nav="handleSideNavUpdate"/>
     <Header
       :sections="pageSections"
       :title="page.title"
       :codeStyle="page.isCode"
       class="floating-header"
+      @update-side-nav="handleSideNavUpdate"
     />
     <div class="border">
       <!-- second header used as a spacer -->
@@ -79,6 +80,16 @@
       apiDocs: {
         type: Boolean,
         default: false,
+      },
+    },
+    data() {
+    return {
+      isSideNavVisible: false, // Track state received from child
+      };
+    },
+    methods: {
+    handleSideNavUpdate(visible) {
+      this.isSideNavVisible = visible; // Update parent state
       },
     },
     computed: {
@@ -171,12 +182,42 @@
     top: 0;
     right: 0;
     left: $nav-width;
-    z-index: 100;
+    z-index: 99;
   }
+
+  @media screen and (max-width: 768px) {
+    .floating-header {
+      left: 0;
+
+    }
+    
+  }
+
+.side-nav {
+  // display: block; 
+  transform: translateX(0);
+}
+
+@media (max-width: 768px) {
+  .side-nav {
+    // display: none; 
+    transform: translateX(-100%);
+  }
+
+  .side-nav.show {
+    transform: translateX(0);
+  }
+}
 
   .content-wrapper {
     margin-left: $nav-width;
   }
+
+  @media (max-width: 768px) { 
+  .content-wrapper {
+    margin-left: 0;
+  }
+}
 
   .border {
     border-left: 1px solid $border-color;

--- a/docs/common/DocsPageTemplate/index.vue
+++ b/docs/common/DocsPageTemplate/index.vue
@@ -250,10 +250,4 @@
     background: rgba(0, 0, 0, 0.7);
   }
 
-  @media (min-width: 768px) {
-    .overlay {
-      display: none;
-    }
-  }
-
 </style>

--- a/docs/common/DocsPageTemplate/index.vue
+++ b/docs/common/DocsPageTemplate/index.vue
@@ -1,7 +1,17 @@
 <template>
 
   <div class="content-wrapper">
-    <SideNav :class="{ show: isSideNavVisible, 'side-nav': true }" @update-side-nav="handleSideNavUpdate"/>
+    <SideNav
+      :class="{ show: isSideNavVisible, 'side-nav': true }"
+      @update-side-nav="handleSideNavUpdate"
+    />
+
+    <div
+      v-if="isSideNavVisible"
+      class="overlay"
+      @click="handleSideNavUpdate(false)"
+    ></div>
+
     <Header
       :sections="pageSections"
       :title="page.title"
@@ -9,6 +19,7 @@
       class="floating-header"
       @update-side-nav="handleSideNavUpdate"
     />
+
     <div class="border">
       <!-- second header used as a spacer -->
       <Header
@@ -83,14 +94,9 @@
       },
     },
     data() {
-    return {
-      isSideNavVisible: false, // Track state received from child
+      return {
+        isSideNavVisible: false, // Track state received from child
       };
-    },
-    methods: {
-    handleSideNavUpdate(visible) {
-      this.isSideNavVisible = visible; // Update parent state
-      },
     },
     computed: {
       page() {
@@ -163,6 +169,11 @@
         return sections;
       },
     },
+    methods: {
+      handleSideNavUpdate(visible) {
+        this.isSideNavVisible = visible; // Update parent state
+      },
+    },
     head() {
       return {
         title: this.fullTitle,
@@ -176,48 +187,46 @@
 <style lang="scss" scoped>
 
   @import '~/assets/definitions';
+  @import '../../../lib/styles/definitions';
 
   .floating-header {
     position: fixed;
     top: 0;
     right: 0;
     left: $nav-width;
-    z-index: 99;
+    z-index: 95;
   }
 
   @media screen and (max-width: 768px) {
     .floating-header {
       left: 0;
-
     }
-    
   }
 
-.side-nav {
-  // display: block; 
-  transform: translateX(0);
-}
-
-@media (max-width: 768px) {
   .side-nav {
-    // display: none; 
-    transform: translateX(-100%);
+    transform: translateX(0);
+    @extend %dropshadow-2dp;
   }
 
-  .side-nav.show {
-    transform: translateX(0);
+  @media (max-width: 768px) {
+    .side-nav {
+      transform: translateX(-100%);
+    }
+
+    .side-nav.show {
+      transform: translateX(0);
+    }
   }
-}
 
   .content-wrapper {
     margin-left: $nav-width;
   }
 
-  @media (max-width: 768px) { 
-  .content-wrapper {
-    margin-left: 0;
+  @media (max-width: 768px) {
+    .content-wrapper {
+      margin-left: 0;
+    }
   }
-}
 
   .border {
     border-left: 1px solid $border-color;
@@ -227,6 +236,24 @@
     padding-right: 32px;
     padding-bottom: 400px;
     padding-left: 32px;
+  }
+
+  .overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 98;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+  }
+
+  @media (min-width: 768px) {
+    .overlay {
+      display: none;
+    }
   }
 
 </style>


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

This PR fixes sidebar view problem by using a menu icon to open it in smaller devices and close button to close the sidebar as well. On larger screens, both main content as well as sidebar is visible. .

#### Issue addressed
<!-- Only necessary if applicable -->
This PR addresses issue #107 

Addresses #*PR# HERE*

### Before/after screenshots
<!-- Insert images here if applicable -->

For Smaller Screens:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/82cbe2d8-dc22-46c8-9dbf-fed221d2895c">

<img width="398" alt="image" src="https://github.com/user-attachments/assets/6f4bdac2-3cf9-4fd4-b4ba-30c23c6c86e7">

For larger screens:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8ab2650b-44c4-47df-894f-c3c3ae15ca52">

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->
 
  - **Description:** Improves docs mobile responsiveness by adding a menu hamburguer to open docs sidenav on mobile devices.

  - **Products impact:** bugfix

  - **Addresses:** N/A

  - **Components:** KDS Docs: SideNav, Header

  - **Breaking:** no

  - **Impacts a11y:** no

  - **Guidance:** 
    - The new toggle functionality allows users to show and hide the side navigation bar, with a close button to close it manually.
    - The overlay provides a better user experience by dimming the content when the sidebar is open in mobile view.
    - No breaking changes were introduced, so this update can be safely merged into existing applications.
  
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->


## Steps to test

1. Go to home page
2. Reduce window screen size
3. Try to toggle using menu bar and close icon

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->



### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
