### PR TITLE
make ui menu accept maxWidth to avoid text truncation 

### DIFF
--- a/lib/KDropdownMenu.vue
+++ b/lib/KDropdownMenu.vue
@@ -21,6 +21,7 @@
         ref="menu"
         :options="options"
         :hasIcons="hasIcons"
+        :maxWidth="maxWidth"
         @select="handleSelection"
       />
     </UiPopover>
@@ -82,6 +83,11 @@
       hasIcons: {
         type: Boolean,
         default: false,
+      },
+      /** Maximum width for the dropdown menu*/
+      maxWidth: {
+        type: [Number, String],
+        default: null,
       },
       /**
        * The position of the dropdown relative to the button

--- a/lib/keen/UiMenu.vue
+++ b/lib/keen/UiMenu.vue
@@ -8,6 +8,7 @@
     lazy
 
     :class="classes"
+    :style="getWidth"
   >
     <UiMenuOption
       v-for="(option, index) in options"
@@ -59,6 +60,10 @@
         type: Boolean,
         default: false,
       },
+      maxWidth: {
+        type: [Number,String],
+        default: null,
+      },
       iconProps: Object,
       hasSecondaryText: {
         type: Boolean,
@@ -100,6 +105,15 @@
           'has-icons': this.hasIcons,
           'has-secondary-text': this.hasSecondaryText,
         };
+      },
+      getWidth() {
+        if (this.maxWidth){
+          return {
+            maxWidth: this.maxWidth && 
+              (typeof this.maxWidth === 'number' ? `${this.maxWidth}px` : this.maxWidth)
+          };
+        }
+        return {};
       },
       activeOutline() {
         return this.isActive ? this.$coreOutline : {};


### PR DESCRIPTION
## Description
override the max-width set by this component [UiMenu](https://github.com/learningequality/kolibri-design-system/blob/777ad2f2cbdef9d180550aed431c9550400c9d28/lib/keen/UiMenu.vue#L5). And for this, we will need to update our [KDropdownMenu](https://github.com/learningequality/kolibri-design-system/blob/777ad2f2cbdef9d180550aed431c9550400c9d28/lib/KDropdownMenu.vue#L1) component to accept a new prop maxWidth that will then be passed to the UiMenu component.

#### Issue addressed
https://github.com/learningequality/kolibri/issues/5557

Addresses  https://github.com/learningequality/kolibri/issues/5557



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** remove text truncation for the download button
  - **Products impact:** Choose from - none
  - **Addresses:** https://github.com/learningequality/kolibri/issues/5557
  - **Components:** KDropdownMenu,UiMenu
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

