### PR TITLE
Adding title attribute in k breadcrumbs for truncated texts#839

### DIFF
--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -68,10 +68,16 @@
               :title="crumb.text"
             >
               <template #text="{ text }">
-                <span class="breadcrumbs-crumb-text" :title="text">{{ text }}</span>
+                <span
+                  class="breadcrumbs-crumb-text"
+                  :title="text"
+                >{{ text }}</span>
               </template>
             </KRouterLink>
-            <span v-else :title="crumb.text" >{{ crumb.text }}</span>
+            <span
+              v-else
+              :title="crumb.text"
+            >{{ crumb.text }}</span>
           </li>
 
           <li
@@ -83,7 +89,7 @@
               class="breadcrumbs-crumb-text"
               :style="{ maxWidth: lastBreadcrumbMaxWidth }"
               dir="auto"
-               :title="crumb.text"
+              :title="crumb.text"
             >
               {{ crumb.text }}
             </span>

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -83,6 +83,7 @@
               class="breadcrumbs-crumb-text"
               :style="{ maxWidth: lastBreadcrumbMaxWidth }"
               dir="auto"
+               :title="crumb.text"
             >
               {{ crumb.text }}
             </span>

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -65,12 +65,13 @@
               :text="crumb.text"
               :to="crumb.link"
               dir="auto"
+              :title="crumb.text"
             >
               <template #text="{ text }">
-                <span class="breadcrumbs-crumb-text">{{ text }}</span>
+                <span class="breadcrumbs-crumb-text" :title="text">{{ text }}</span>
               </template>
             </KRouterLink>
-            <span v-else>{{ crumb.text }}</span>
+            <span v-else :title="crumb.text" >{{ crumb.text }}</span>
           </li>
 
           <li


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
It adds title attribute in KBreadcrumbs component which enable us read the truncated texts anywhere in KBreadcrumbs.

#### Issue addressed 
Closes #208

Addresses #*PR# HERE*

### Before/after screenshots
![image](https://github.com/user-attachments/assets/05bedcaa-c8e4-4102-93bc-726b5b6f3800)


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Adds the global title attribute to `KBreadcrumbs` so that the truncated text can be seen fully when a breadcrumb item is hovered.
  - **Products impact:** UX/UI update
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/208
  - **Components:** `KBreadcrumbs`
  - **Breaking:**  no
  - **Impacts a11y:** Yes. Improves experience for sighted users.
  - **Guidance:**  -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1)Add title attribute in breadcrumbs-visible-items
2)Add title attribute in breadcrumbs-dropdown-wrapper
3) **Please refer PR #839** 


## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
Now the truncated texts which were not visible completely , can be seen easily .
Please refer PR #839 for reviews , code .
Reviewers:
![image](https://github.com/user-attachments/assets/446fb472-f6c1-4e04-90e3-c3a890b348f1)


