### PR TITLE
Remove 'pull_request_review' event from the community contributions spreadsheet action

### DIFF
--- a/.github/workflows/update-pr-spreadsheet.yml
+++ b/.github/workflows/update-pr-spreadsheet.yml
@@ -1,11 +1,5 @@
 name: Update community pull requests spreadsheet
-on:
-  pull_request_target:
-    types: [opened, reopened, edited, closed, synchronize, assigned, unassigned, review_requested, review_request_removed]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
-  issue_comment:
-    types: [created, edited, deleted]
+on: [pull_request_target, issue_comment]
 
 jobs:
   call-update-spreadsheet:


### PR DESCRIPTION
Refer to https://github.com/learningequality/kolibri/pull/12950

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Removes `pull_request_review` event from the community contributions spreadsheet action. When triggered by this event, secrets are not available. This fixes the action failure when pull request reviewed.
  - **Products impact:** none
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
