### PR TITLE
Add KSelect dropdown to the Overlay layer

### DIFF
--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -21,11 +21,7 @@
             :tabindex="0"
             role="dialog"
             aria-labelledby="modal-title"
-            :style="[
-              modalSizeStyles,
-              { background: $themeTokens.surface },
-              containsKSelect ? { overflowY: 'unset' } : { overflowY: 'auto' },
-            ]"
+            :style="[modalSizeStyles, { background: $themeTokens.surface }, { overflowY: 'auto' }]"
           >
             <!-- Modal Title -->
             <h1
@@ -65,7 +61,6 @@
                 ]"
                 :class="{
                   'scroll-shadow': scrollShadow,
-                  'contains-kselect': containsKSelect,
                 }"
               >
                 <!-- @slot Main content of modal -->
@@ -216,7 +211,6 @@
       return {
         lastFocus: null,
         maxContentHeight: '1000',
-        containsKSelect: false,
         scrollShadow: false,
         delayedEnough: false,
       };
@@ -278,9 +272,6 @@
       window.addEventListener('focus', this.focusElementTest, true);
       window.setTimeout(() => (this.delayedEnough = true), 500);
 
-      // if modal contains KSelect, special classes & styles will be applied
-      const kSelectCheck = document.querySelector('div.modal div.ui-select');
-      this.containsKSelect = !!kSelectCheck;
       this.updateContentSectionStyle();
     },
     updated() {
@@ -320,9 +311,7 @@
 
           // make sure that overflow-y won't be updated to 'auto' if this function is running
           // for the first time (otherwise Firefox would add a vertical scrollbar right away)
-          // + don't apply if modal contains KSelect
-          // (otherwise KSelect will be trapped inside modal if KSelect is opened a second time)
-          if (this.$refs.content.clientHeight !== 0 && !this.containsKSelect) {
+          if (this.$refs.content.clientHeight !== 0) {
             // add a vertical scrollbar if content doesn't fit
             if (this.$refs.content.scrollHeight > this.$refs.content.clientHeight) {
               this.$refs.content.style.overflowY = 'auto';
@@ -451,10 +440,6 @@
       100% 20px,
       100% 10px,
       100% 10px;
-  }
-
-  .contains-kselect {
-    overflow: unset;
   }
 
   .actions {

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -14,14 +14,13 @@
           @keyup.esc.stop="emitCancelEvent"
           @keyup.enter="handleEnter"
         >
-          <!-- KeenUiSelect targets modal by using div.modal selector -->
           <div
             ref="modal"
             class="modal"
             :tabindex="0"
             role="dialog"
             aria-labelledby="modal-title"
-            :style="[modalSizeStyles, { background: $themeTokens.surface }, { overflowY: 'auto' }]"
+            :style="modalStyles"
           >
             <!-- Modal Title -->
             <h1
@@ -216,11 +215,13 @@
       };
     },
     computed: {
-      modalSizeStyles() {
+      modalStyles() {
         return {
           'max-width': `${this.maxModalWidth - 32}px`,
           'max-height': `${this.windowHeight - 32}px`,
           width: this.modalWidth,
+          background: this.$themeTokens.surface,
+          overflowY: 'auto',
         };
       },
       modalWidth() {

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -7,8 +7,6 @@
    The formatting has been changed to match our linters. We may eventually
    want to simply consolidate it with our component and remove any unused
    functionality.
-
-   BELOW: KModal targets KeenUiSelect by using div.ui-select selector
   -->
   <div
     class="ui-select"

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -94,6 +94,7 @@
         <Popper
           v-if="appendToEl"
           ref="dropdownPopper"
+          closeOnScroll
           transition="ui-select-transition-fade"
           trigger="click"
           :appendToEl="appendToEl"

--- a/lib/KTooltip/Popper.vue
+++ b/lib/KTooltip/Popper.vue
@@ -33,6 +33,7 @@
 
 <script>
 
+  import debounce from 'lodash/debounce';
   import Popper from 'popper.js';
 
   function on(element, event, handler) {
@@ -115,6 +116,10 @@
         default() {
           return {};
         },
+      },
+      closeOnScroll: {
+        type: Boolean,
+        default: false,
       },
     },
 
@@ -215,6 +220,24 @@
         this.showPopper = false;
       },
 
+      doCloseOnScroll: debounce(
+        function (event) {
+          const popperEl = this.$refs.popper;
+          if (
+            !popperEl ||
+            this.elementContains(popperEl, event.target) ||
+            !this.elementContains(event.target, this.referenceElm)
+          ) {
+            return;
+          }
+
+          this.doClose();
+        },
+        100,
+        // check as soon as the event is triggered
+        { leading: true },
+      ),
+
       doDestroy() {
         if (this.showPopper) {
           return;
@@ -228,6 +251,9 @@
         if (this.isAppendedToEl) {
           this.isAppendedToEl = false;
           this.appendToEl.removeChild(this.popper.parentElement);
+        }
+        if (this.closeOnScroll) {
+          document.removeEventListener('scroll', this.doCloseOnScroll, true);
         }
       },
 
@@ -265,6 +291,10 @@
           };
 
           this.popperJS = new Popper(this.referenceElm, this.popper, this.popperOptions);
+
+          if (this.closeOnScroll) {
+            document.addEventListener('scroll', this.doCloseOnScroll, true);
+          }
         });
       },
 

--- a/lib/KTooltip/Popper.vue
+++ b/lib/KTooltip/Popper.vue
@@ -201,10 +201,16 @@
         }
       },
 
+      /**
+       * @public
+       */
       doShow() {
         this.showPopper = true;
       },
 
+      /**
+       * @public
+       */
       doClose() {
         this.showPopper = false;
       },

--- a/lib/KTooltip/index.vue
+++ b/lib/KTooltip/index.vue
@@ -34,8 +34,7 @@
 
   import isArray from 'lodash/isArray';
   import _useOverlay from '../composables/_useOverlay';
-  import Popper from './Popper';
-
+  import Popper from '../_Popper';
   /**
    * Used to create a tooltip.
    */

--- a/lib/_Popper.vue
+++ b/lib/_Popper.vue
@@ -9,6 +9,7 @@
      - Allow for appending to a chosen element rather than to body,
        typically to the overlay container element #k-overlay.
        'appendToBody' prop changedto 'appendToEl' and related changes.
+     - Add 'closeOnScroll' prop to close the popper on scroll.
   -->
 
   <span>
@@ -220,12 +221,16 @@
         this.showPopper = false;
       },
 
+      // Debouncing as we don't need to check this on every scroll event on a
+      // "scroll session", just the first one, and although very unlikely, the last one
       doCloseOnScroll: debounce(
         function (event) {
           const popperEl = this.$refs.popper;
           if (
             !popperEl ||
+            // ignore scrolls inside the popper
             this.elementContains(popperEl, event.target) ||
+            // ignore scrolls unrelated to the popper reference, just from the ancestors
             !this.elementContains(event.target, this.referenceElm)
           ) {
             return;


### PR DESCRIPTION
## Description
Finally, a robust solution is proposed to the many known issues with the KSelect dropdown by teleporting KSelect dropdown to the Overlay layer using Popper.

#### Issue addressed

Addresses #324 and #690.

### Before/after screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/491ae279-65bd-4cda-8367-7e97125ebe6b) | ![image](https://github.com/user-attachments/assets/6063fd0a-f25e-4488-907b-a77835aa3140) | 
| ![image](https://github.com/user-attachments/assets/36b5a073-4d57-4dea-9b87-b4e97c956b45) | ![image](https://github.com/user-attachments/assets/9d5e2d60-3fcd-42e4-bb96-26eb23816cba) |
| ![image](https://github.com/user-attachments/assets/a57367f7-2bcd-48d6-8712-84d2d2e4b79b) | ![image](https://github.com/user-attachments/assets/dde0437c-455d-4c2e-86b5-5fa3b08be54e) |
| If a modal had a long form, it bugged because of the `overflowY: unset` set because the Modal check for KSelects | Now, we can have scrollables modals even if it has a KSelect inside |
| ![image](https://github.com/user-attachments/assets/eb821c04-3812-4833-accb-8bf770b8bb6a) | ![Screenshot from 2024-12-26 16-01-41](https://github.com/user-attachments/assets/3178e935-62e9-4caa-9361-38219f1e733a) |

Screencast showing the behaviour of KSelect in a long modal:

https://github.com/user-attachments/assets/aea8ecd2-9d4c-437c-8762-be8a083f3f73


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Teleport KSelect dropdown to the Overlay layer using Popper.
  - **Products impact:** bugfix.
  - **Addresses:**https://github.com/learningequality/kolibri-design-system/issues/324, https://github.com/learningequality/kolibri-design-system/issues/690.
  - **Components:** KSelect.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

  - **Description:** Removes internal KModal calculations to modify its content height if it had a KSelect inside.
  - **Products impact:** bugfix.
  - **Addresses:**https://github.com/learningequality/kolibri-design-system/issues/324.
  - **Components:** KModal.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.


<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Step 1
2. Step 2
3. ...

## (optional) Implementation notes

### At a high level, how did you implement this?

I have decided to close the dropdown on scroll, just like the KDropdownMenu, to avoid situations like this:

![image](https://github.com/user-attachments/assets/b65fdca0-5818-431e-8649-d06389048c31)

Otherwise we would need to be querying scrollable ancestors elements, and taking into account the height of any absolute/fixed elements like the topbar to automaticlly close the dropdown.



### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
