### PR TITLE
Mount overlay layer if it needed on getOverlayEl

### DIFF
--- a/lib/composables/_useOverlay/index.js
+++ b/lib/composables/_useOverlay/index.js
@@ -1,3 +1,5 @@
+import { isNuxtServerSideRendering } from '../../utils';
+
 const OVERLAY_EL_ID = 'k-overlay';
 
 /**
@@ -41,17 +43,16 @@ export default function _useOverlay() {
    * @returns {HTMLElement} The overlay container element #k-overlay
    */
   function getOverlayEl() {
+    if (isNuxtServerSideRendering()) {
+      return;
+    }
     // do not query DOM for performance reasons
     const overlayEl = window.overlayEl;
     // unlikely to happen, but just in case
     if (!overlayEl) {
-      // eslint-disable-next-line no-console
-      console.error(
-        '[KDS] The overlay container element #k-overlay is missing. KDS initialization failed?',
-      );
-      return;
+      mountOverlay();
     }
-    return overlayEl;
+    return window.overlayEl;
   }
 
   return {


### PR DESCRIPTION
## Description
Even though we mount the overlay layer on DOMContentLoad, there are some ocasions where we need to query the overlay el even before DOMContentLoad has been triggered. See #878.


#### Issue addressed


Addresses #878


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Adds logic to mount overlay layer if it needed when we call getOverlayEl.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/878.
  - **Components:** useKOverlay.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
