### PR TITLE
Add KDS Workflows to keep KDS Roadmap statuses updated

### DIFF
--- a/.github/GithubAPI.js
+++ b/.github/GithubAPI.js
@@ -1,0 +1,264 @@
+module.exports = class GithubAPI {
+  constructor(owner, github) {
+    this.owner = owner;
+    this.github = github;
+  }
+
+  async getSourceAndTargetProjects({ sourceNumber, targetNumber }) {
+    const projectSubquery = `
+      id
+      title
+      fields(first: 30) {
+        nodes {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options {
+              id
+              name
+            }
+          }
+        }
+      }
+    `;
+    const query = `
+      query getSourceAndTargetProjectsIds($owner: String!, $source: Int!, $target: Int!) {
+        organization (login: $owner) {
+          source: projectV2(number: $source) {
+            ${projectSubquery}
+          }
+          target: projectV2(number: $target) {
+            ${projectSubquery}
+          }
+        }
+      }
+    `;
+
+    const response = await this.github.graphql(query, {
+      owner: this.owner,
+      source: sourceNumber,
+      target: targetNumber,
+    });
+
+    const { source, target } = response.organization;
+
+    if (!source) {
+      throw new Error(`Source project not found: ${sourceNumber}`);
+    }
+
+    if (!target) {
+      throw new Error(`Target project not found: ${targetNumber}`);
+    }
+
+    return {
+      sourceProject: source,
+      targetProject: target
+    };
+  }
+
+  async getProject (projectNumber) {
+    const query = `
+      query GetProject($owner: String!, $projectNumber: Int!) {
+        organization(login: $owner) {
+          projectV2(number: $projectNumber) {
+            id
+            status: field(name: "Status") {
+              ... on ProjectV2SingleSelectField {
+                id
+                options {
+                  id
+                  name
+                }
+              }
+            }
+            releasedIn: field(name: "Released in") {
+              ... on ProjectV2Field {
+                id
+              }
+            }
+          }
+        }
+      }
+    `;
+    const response = await this.github.graphql(query, {
+      owner: this.owner,
+      projectNumber
+    });
+
+    return response.organization.projectV2;
+  }
+
+  async getProjectItems(projectId) {
+    const statusSubquery = `
+      status: fieldValueByName(name: "Status") {
+        ... on ProjectV2ItemFieldSingleSelectValue {
+          vaueId: id
+          value: name
+          valueOptionId: optionId
+        }
+      }
+    `;
+    // Subquery to get info about the status of the issue/PR on each project it belongs to
+    const projectItemsSubquery = `
+      projectItems(first: 10) {
+        nodes {
+          id
+          ${ statusSubquery }
+          project {
+            id
+            title
+          }
+        }
+      }
+    `;
+    const query = `
+      query GetProjectItems($projectId: ID!, $cursor: String) {
+        node(id: $projectId) {
+          ... on ProjectV2 {
+            items(first: 50, after: $cursor) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              nodes {
+                id
+                ${ statusSubquery }
+                content {
+                  __typename
+                  ... on Issue {
+                    id
+                    title
+                    url
+                    ${ projectItemsSubquery }
+                  }
+                  ... on PullRequest {
+                    id
+                    title
+                    url
+                    ${ projectItemsSubquery }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const _getProjectItems = async (cursor = null, items = []) => {
+      const response = await this.github.graphql(query, {
+        projectId,
+        cursor
+      });
+
+      const { nodes, pageInfo } = response.node.items;
+
+      items.push(...nodes);
+
+      if (pageInfo.hasNextPage) {
+        return _getProjectItems(pageInfo.endCursor, items);
+      }
+
+      return items;
+    };
+
+    return _getProjectItems();
+  }
+
+
+  async getPRsWithLinkedIssues(prNumbers, repo) {
+    const getPRKey = (prNumber) => `PR_${prNumber}`;
+    const getPRQuery = (prNumber) => {
+      const projectItemsSubquery = `
+        projectItems(first: 20) {
+          nodes{
+            id
+            releasedIn: fieldValueByName(name: "Released in"){
+              ... on ProjectV2ItemFieldTextValue {
+                text
+              }
+            }
+            project {
+              id
+              number
+            }
+          }
+        }
+      `;
+      return `
+        ${getPRKey(prNumber)}: pullRequest(number: ${prNumber}) {
+          id
+          number
+          ${ projectItemsSubquery }
+          closingIssuesReferences(first: 20) {
+            nodes {
+              id
+              ${ projectItemsSubquery }
+            }
+          }
+        }
+      `;
+    };
+    const query = `
+      query GetLinkedIssuesFromPRs($owner: String!, $repo: String!) {
+        repository(name: $repo, owner: $owner) {
+          ${ prNumbers.map(getPRQuery).join('\n') }
+        }
+      }
+    `;
+    const response = await this.github.graphql(query, {
+      owner: this.owner,
+      repo,
+    });
+
+    return prNumbers.map(prNumber => {
+      return response.repository[getPRKey(prNumber)];
+    });
+  }
+
+  async addContentToProject(projectId, contentId) {
+    const query = `
+      mutation AddContentToProject($projectId: ID!, $contentId: ID!) {
+        addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+          item {
+            id
+          }
+        }
+      }
+    `;
+
+    const response = await this.github.graphql(query, { projectId, contentId });
+    return response.addProjectV2ItemById.item.id;
+  }
+
+  async updateProjectItemsFields(items) {
+    const query = `
+      mutation UpdateProjectItemField($projectId: ID!, $itemId: ID!, $fieldId: ID!, $newValue: ProjectV2FieldValue!) {
+        updateProjectV2ItemFieldValue(input: {
+          projectId: $projectId,
+          itemId: $itemId,
+          fieldId: $fieldId,
+          value: $newValue
+        }) {
+          projectV2Item {
+            id
+          }
+        }
+      }
+    `;
+
+    const BATCH_SIZE = 10;
+    for (let i = 0; i < items.length; i += BATCH_SIZE) {
+      const batch = items.slice(i, i + BATCH_SIZE);
+
+      await Promise.all(batch.map(item => (
+        this.github.graphql(query, {
+          projectId: item.projectId,
+          itemId: item.projectItemId,
+          fieldId: item.fieldId,
+          newValue: item.newValue
+        })
+      )));
+    }
+  }
+}

--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -1,8 +1,5 @@
 const GithubAPI = require('./GithubAPI');
 
-const ITERATION_BACKLOG_PROJECT_NUMBER = 15;
-const KDS_ROADMAP_PROJECT_NUMBER = 29;
-
 /**
  * Will synchronize the KDS Roadmap project statuses synced
  * with the Iteration backlog project items statuses. So if an issue belongs to
@@ -11,9 +8,7 @@ const KDS_ROADMAP_PROJECT_NUMBER = 29;
  * 
  * All issues in KDS Roadmap that already had a status of "RELEASED" will be ignored.
  */
-const synchronizeProjectsStatuses = async (context, github) => {
-  const sourceNumber = ITERATION_BACKLOG_PROJECT_NUMBER;
-  const targetNumber = KDS_ROADMAP_PROJECT_NUMBER;
+const synchronizeProjectsStatuses = async ({context, github, sourceNumber, targetNumber}) => {
   const getTargetStatus = (sourceStatus) => {
     const statusMap = {
       "IN REVIEW": "IN REVIEW",
@@ -107,7 +102,7 @@ const extractPullRequestNumbers = (releaseBody, owner) => {
  * If an issue or a PR doesnt belong to the KDS Roadmap project, it will be added to the project.
  * 
  */
-const updateReleasedItemsStatuses = async (context, github) => {
+const updateReleasedItemsStatuses = async ({context, github, projectNumber}) => {
   const body = context.payload.release.body;
   const owner = context.payload.repository.owner.login;
   const repo = context.payload.repository.name;
@@ -121,7 +116,7 @@ const updateReleasedItemsStatuses = async (context, github) => {
 
   const githubAPI = new GithubAPI(owner, github);
   const prs = await githubAPI.getPRsWithLinkedIssues(prNumbers, repo);
-  const project = await githubAPI.getProject(KDS_ROADMAP_PROJECT_NUMBER); 
+  const project = await githubAPI.getProject(projectNumber); 
 
   const contentItemsToAddToProject = [];
   const projectItemsToUpdate = [];

--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -1,0 +1,185 @@
+const GithubAPI = require('./GithubAPI');
+
+const ITERATION_BACKLOG_PROJECT_NUMBER = 15;
+const KDS_ROADMAP_PROJECT_NUMBER = 29;
+
+const synchronizeProjectsStatuses = async (context, github) => {
+  const sourceNumber = ITERATION_BACKLOG_PROJECT_NUMBER;
+  const targetNumber = KDS_ROADMAP_PROJECT_NUMBER;
+  const getTargetStatus = (sourceStatus) => {
+    const statusMap = {
+      "IN REVIEW": "IN REVIEW",
+      "IN PROGRESS": "IN PROGRESS",
+      "NEEDS QA": "IN REVIEW",
+      "DONE": "DONE",
+      // All other statuses are mapped to "BACKLOG"
+    };
+
+    const targetStatus = Object.keys(statusMap).find((key) =>
+      sourceStatus.toUpperCase().includes(key)
+    );
+
+    return targetStatus ? statusMap[targetStatus] : "BACKLOG";
+  }
+
+  const githubAPI = new GithubAPI(context.repo.owner, github);
+  const { sourceProject, targetProject } = await githubAPI.getSourceAndTargetProjects({ sourceNumber, targetNumber });
+
+  const targetStatusField = targetProject.fields.nodes.find((field) => field.name === "Status");
+
+  const targetProjectItems = await githubAPI.getProjectItems(targetProject.id);
+  const itemsToUpdate = targetProjectItems.filter((item) => {
+    const statusToByPass = "RELEASED";
+    const currentTargetStatusName = item.status?.value;
+    if (currentTargetStatusName?.toUpperCase().includes(statusToByPass)) {
+      return false;
+    }
+
+    const sourceProjectItem = item.content.projectItems?.nodes.find((sourceItem) => (
+      sourceItem.project.id === sourceProject.id
+    ));
+    const sourceStatus = sourceProjectItem?.status?.value;
+    if (!sourceStatus) {
+      return false;
+    }
+
+    const newTargetStatus = getTargetStatus(sourceStatus);
+    const newTargetStatusId = targetStatusField.options.find((option) => option.name.toUpperCase().includes(newTargetStatus))?.id;
+
+    if (!newTargetStatusId) {
+      return false;
+    }
+
+    item.newStatusId = newTargetStatusId;
+
+    const currentTargetStatusId = item.status?.valueOptionId;
+    return newTargetStatusId !== currentTargetStatusId;
+  });
+
+  if (itemsToUpdate.length === 0) {
+    return;
+  }
+
+  const itemsPayload = itemsToUpdate.map(item => ({
+    projectId: targetProject.id,
+    projectItemId: item.id,
+    fieldId: targetStatusField.id,
+    newValue: {
+      singleSelectOptionId: item.newStatusId
+    },
+    url: item.content.url
+  }))
+
+  await githubAPI.updateProjectItemsFields(itemsPayload);
+  console.log(`${itemsToUpdate.length} items updated: `, itemsPayload.map(item => item.url));
+}
+
+const extractPullRequestNumbers = (releaseBody, owner) => {
+  const prRegex = new RegExp(`github\\.com/${owner}/[a-zA-Z0-9-_]+/pull/(\\d+)`, "g");
+  const prNumbers = [];
+  let match;
+  while ((match = prRegex.exec(releaseBody)) !== null) {
+    prNumbers.push(parseInt(match[1]));
+  }
+
+  const uniquePrNumbers = [...new Set(prNumbers)];
+  return uniquePrNumbers;
+};
+
+const updateReleasedItemsStatuses = async (context, github) => {
+  const body = context.payload.release.body;
+  const owner = context.payload.repository.owner.login;
+  const repo = context.payload.repository.name;
+  const release = context.payload.release.name;
+  const prNumbers = extractPullRequestNumbers(body, owner);
+
+  if (prNumbers.length === 0) {
+    console.log("No PRs found in release body");
+    return;
+  }
+
+  const githubAPI = new GithubAPI(owner, github);
+  const prs = await githubAPI.getPRsWithLinkedIssues(prNumbers, repo);
+  const project = await githubAPI.getProject(KDS_ROADMAP_PROJECT_NUMBER); 
+
+  const contentItemsToAddToProject = [];
+  const projectItemsToUpdate = [];
+
+  prs.forEach((pr) => {
+    const closingIssues = pr.closingIssuesReferences.nodes;
+    if (closingIssues.length === 0) {
+      const prProjectItems = pr.projectItems.nodes;
+      const projectItem = prProjectItems.find((item) => item.project.id === project.id);
+      if (!projectItem) {
+        contentItemsToAddToProject.push({
+          contentId: pr.id,
+        });
+        return;
+      }
+      projectItemsToUpdate.push(projectItem);
+      return;
+    }
+
+    closingIssues.forEach((issue) => {
+      const issueProjectItems = issue.projectItems.nodes;
+      const projectItem = issueProjectItems.find((item) => item.project.id === project.id);
+      if (!projectItem) {
+        contentItemsToAddToProject.push({
+          contentId: issue.id,
+        });
+        return;
+      }
+      projectItemsToUpdate.push(projectItem);
+    });
+  });
+
+  if (contentItemsToAddToProject.length > 0) {
+    await Promise.all(contentItemsToAddToProject.map(async ({ contentId }) => {
+      const projectItemId = await githubAPI.addContentToProject(project.id, contentId);
+      projectItemsToUpdate.push({ id: projectItemId });
+    }));
+  }
+
+  const projectItemsChanges = [];
+
+  if (projectItemsToUpdate.length > 0) {
+    const releasedInFieldId = project.releasedIn.id;
+    const statusFieldId = project.status.id;
+    const statusReleasedOption = project.status.options.find((option) => option.name === "Released");
+    const statusReleasedId = statusReleasedOption.id;
+
+    projectItemsToUpdate.map(async (item) => {
+      // Update "Released in" field with the release version
+      const releasedIn = item.releasedIn?.text;
+      const releasedInValue = releasedIn ? `${releasedIn},${release}` : release;
+      projectItemsChanges.push({
+        projectId: project.id,
+        projectItemId: item.id,
+        fieldId: releasedInFieldId,
+        newValue: {
+          text: releasedInValue,
+        },
+      });
+
+      // Update status field to "Released"
+      projectItemsChanges.push({
+        projectId: project.id,
+        projectItemId: item.id,
+        fieldId: statusFieldId,
+        newValue: {
+          singleSelectOptionId: statusReleasedId,
+        },
+      });
+    });
+  }
+
+  if (projectItemsChanges.length > 0) {
+    await githubAPI.updateProjectItemsFields(projectItemsChanges);
+  }
+}
+
+
+module.exports = {
+  synchronizeProjectsStatuses,
+  updateReleasedItemsStatuses,
+};

--- a/.github/workflows/sync_kds_roadmap_statuses.yml
+++ b/.github/workflows/sync_kds_roadmap_statuses.yml
@@ -27,8 +27,13 @@ jobs:
 
       - name: Check and Sync Project Statuses
         uses: actions/github-script@v7
+        env:
+          ITERATION_BACKLOG_PROJECT_NUMBER: ${{ secrets.ITERATION_BACKLOG_PROJECT_NUMBER }}
+          KDS_ROADMAP_PROJECT_NUMBER: ${{ secrets.KDS_ROADMAP_PROJECT_NUMBER }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { synchronizeProjectsStatuses } = require('./.github/githubUtils.js');
-            synchronizeProjectsStatuses(context, github);
+            const sourceNumber = process.env.ITERATION_BACKLOG_PROJECT_NUMBER;
+            const targetNumber = process.env.KDS_ROADMAP_PROJECT_NUMBER;
+            synchronizeProjectsStatuses({context, github, sourceNumber, targetNumber});

--- a/.github/workflows/sync_kds_roadmap_statuses.yml
+++ b/.github/workflows/sync_kds_roadmap_statuses.yml
@@ -1,0 +1,34 @@
+name: Sync KDS Roadmap Project Statuses
+
+on:
+  schedule:
+    - cron: "0 * * * *" # Run every hour
+  workflow_dispatch:
+
+jobs:
+  sync-projects:
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.LE_BOT_APP_ID }}
+          private_key: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+
+      - name: Check and Sync Project Statuses
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const { synchronizeProjectsStatuses } = require('./.github/githubUtils.js');
+            synchronizeProjectsStatuses(context, github);

--- a/.github/workflows/update_project_items_on_release.yml
+++ b/.github/workflows/update_project_items_on_release.yml
@@ -1,13 +1,8 @@
-name: Update Issues statuses on Release
+name: Update KDS Roadmap project statuses on Release
 
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      context:
-        description: 'The simulated context of the release'
-        required: true
 
 jobs:
   update-issues-statuses:

--- a/.github/workflows/update_project_items_on_release.yml
+++ b/.github/workflows/update_project_items_on_release.yml
@@ -29,11 +29,4 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { updateReleasedItemsStatuses } = require('./.github/githubUtils.js');
-            let ghContext; // get context from input if its a workflow_dispatch event
-            if (context.payload.release) {
-              ghContext = context;
-            } else {
-              ghContext = context.payload.inputs.context;
-              ghContext = JSON.parse(ghContext);
-            }
-            updateReleasedItemsStatuses(ghContext, github);
+            updateReleasedItemsStatuses(context, github);

--- a/.github/workflows/update_project_items_on_release.yml
+++ b/.github/workflows/update_project_items_on_release.yml
@@ -1,0 +1,44 @@
+name: Update Issues statuses on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      context:
+        description: 'The simulated context of the release'
+        required: true
+
+jobs:
+  update-issues-statuses:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.LE_BOT_APP_ID }}
+          private_key: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+
+      - name: Update Issues statuses
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const { updateReleasedItemsStatuses } = require('./.github/githubUtils.js');
+            let ghContext; // get context from input if its a workflow_dispatch event
+            if (context.payload.release) {
+              ghContext = context;
+            } else {
+              ghContext = context.payload.inputs.context;
+              ghContext = JSON.parse(ghContext);
+            }
+            updateReleasedItemsStatuses(ghContext, github);

--- a/.github/workflows/update_project_items_on_release.yml
+++ b/.github/workflows/update_project_items_on_release.yml
@@ -25,8 +25,11 @@ jobs:
 
       - name: Update Issues statuses
         uses: actions/github-script@v7
+        env:
+          KDS_ROADMAP_PROJECT_NUMBER: ${{ secrets.KDS_ROADMAP_PROJECT_NUMBER }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const { updateReleasedItemsStatuses } = require('./.github/githubUtils.js');
-            updateReleasedItemsStatuses(context, github);
+            const projectNumber = process.env.KDS_ROADMAP_PROJECT_NUMBER;
+            updateReleasedItemsStatuses({context, github, projectNumber});


### PR DESCRIPTION
## Description
Adds two workflows to keep KDS Roadmap statuses updated:
1. Sync KDS Roadmap Project Statuses: Sets up a cronjob to keep KDS Roadmap project statuses synced with the Iteration backlog project items status. 
2. Update KDS Roadmap project statuses on Release: When we have a new kds release, this workflow will check all released PRs and will set their statuses to `Released` and will update the `released in` field to the release version.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Adds Adds two workflows to keep KDS Roadmap statuses updated
  - **Products impact:** none.
  - **Addresses:** -.
  - **Components:** -.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

I have tested these actions in the https://github.com/learningequality/test-actions repo. We can dispatch:
* https://github.com/learningequality/test-actions/actions/workflows/sync_kds_roadmap_statuses.yml: For this, we will need to go to the KDS Roadmap project and simulate a situation where we have an updated status in the Iteration Backlog, but not in the KDS Roadmap project.
* https://github.com/learningequality/test-actions/actions/workflows/update_project_items_on_release.yml: For this, we will need to simulate a release adding to the context input an object like this:
  ```{ "payload": { "action": "published", "release": { "body": "Some release notes https://github.com/learningequality/kolibri-design-system/pull/783", "name": "v0.0.1"}, "repository": { "name": "kolibri-design-system", "owner": { "login": "learningequality" } } }, "eventName": "release"}``` 
