### PR TITLE
Add Margins to Empty Table Message for Consistent Spacing

### DIFF
--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -1,4 +1,5 @@
 <template>
+
   <div
     ref="tableWrapper"
     class="k-table-wrapper"
@@ -62,28 +63,25 @@
                 v-if="isColumnSortable(index)"
                 class="sort-icon"
               >
-                <span v-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_ASC"
-                  ><KIcon
-                    icon="dropup"
-                    :color="
-                      isColumnSortActive(index)
-                        ? $themeBrand.primary.v_600
-                        : $themePalette.grey.v_800
-                    "
+                <span v-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_ASC"><KIcon
+                  icon="dropup"
+                  :color="
+                    isColumnSortActive(index)
+                      ? $themeBrand.primary.v_600
+                      : $themePalette.grey.v_800
+                  "
                 /></span>
-                <span v-else-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_DESC"
-                  ><KIcon
-                    icon="dropdown"
-                    :color="
-                      isColumnSortActive(index)
-                        ? $themeBrand.primary.v_600
-                        : $themePalette.grey.v_800
-                    "
+                <span v-else-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_DESC"><KIcon
+                  icon="dropdown"
+                  :color="
+                    isColumnSortActive(index)
+                      ? $themeBrand.primary.v_600
+                      : $themePalette.grey.v_800
+                  "
                 /></span>
-                <span v-else
-                  ><KIcon
-                    icon="sortColumn"
-                    :color="$themePalette.grey.v_800"
+                <span v-else><KIcon
+                  icon="sortColumn"
+                  :color="$themePalette.grey.v_800"
                 /></span>
               </span>
             </th>
@@ -143,9 +141,12 @@
       </div>
     </template>
   </div>
+
 </template>
 
+
 <script>
+
   import { ref, computed, watch } from 'vue';
   import useSorting, {
     SORT_ORDER_ASC,
@@ -621,9 +622,12 @@
       },
     },
   };
+
 </script>
 
+
 <style scoped>
+
   .k-table-wrapper {
     position: relative;
     height: auto;
@@ -667,4 +671,5 @@
     margin-top: 16px;
     margin-bottom: 16px;
   }
+
 </style>

--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -1,5 +1,4 @@
 <template>
-
   <div
     ref="tableWrapper"
     class="k-table-wrapper"
@@ -63,25 +62,28 @@
                 v-if="isColumnSortable(index)"
                 class="sort-icon"
               >
-                <span v-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_ASC"><KIcon
-                  icon="dropup"
-                  :color="
-                    isColumnSortActive(index)
-                      ? $themeBrand.primary.v_600
-                      : $themePalette.grey.v_800
-                  "
+                <span v-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_ASC"
+                  ><KIcon
+                    icon="dropup"
+                    :color="
+                      isColumnSortActive(index)
+                        ? $themeBrand.primary.v_600
+                        : $themePalette.grey.v_800
+                    "
                 /></span>
-                <span v-else-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_DESC"><KIcon
-                  icon="dropdown"
-                  :color="
-                    isColumnSortActive(index)
-                      ? $themeBrand.primary.v_600
-                      : $themePalette.grey.v_800
-                  "
+                <span v-else-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_DESC"
+                  ><KIcon
+                    icon="dropdown"
+                    :color="
+                      isColumnSortActive(index)
+                        ? $themeBrand.primary.v_600
+                        : $themePalette.grey.v_800
+                    "
                 /></span>
-                <span v-else><KIcon
-                  icon="sortColumn"
-                  :color="$themePalette.grey.v_800"
+                <span v-else
+                  ><KIcon
+                    icon="sortColumn"
+                    :color="$themePalette.grey.v_800"
                 /></span>
               </span>
             </th>
@@ -141,12 +143,9 @@
       </div>
     </template>
   </div>
-
 </template>
 
-
 <script>
-
   import { ref, computed, watch } from 'vue';
   import useSorting, {
     SORT_ORDER_ASC,
@@ -622,12 +621,9 @@
       },
     },
   };
-
 </script>
 
-
 <style scoped>
-
   .k-table-wrapper {
     position: relative;
     height: auto;
@@ -667,4 +663,8 @@
     cursor: pointer;
   }
 
+  .empty-message {
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
 </style>


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This PR resolves the issue of inconsistent margins when an empty table message is displayed. Previously, the empty message lacked the margin-top and margin-bottom spacing that is present when the table contains data, resulting in a visual inconsistency.

#### Issue addressed
<!-- Only necessary if applicable -->
Closes #881 

Addresses #881 

### Before/after screenshots
<!-- Insert images here if applicable -->
![Before Image](https://github.com/user-attachments/assets/f132d7c2-6d78-4ecd-928c-8f9533127bd4)
![After Image](https://github.com/user-attachments/assets/5431b718-e514-40ff-a2d3-4c43344b6bc2)


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->
  - **Description:** Added `margin-top: 16px` and `margin-bottom: 16px` to the empty table message to ensure consistent spacing with the table header and data rows.  
  - **Products impact:** bugfix  
  - **Addresses:** -  #881 
  - **Components:** KTable  
  - **Breaking:** no  
  - **Impacts a11y:** no
  - **Guidance:**

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->


## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
