### PR TITLE
Fix KDateRange confusing selection states and end date reset after selecting start date via keyboard

### DIFF
--- a/lib/KDateRange/KDateCalendar.vue
+++ b/lib/KDateRange/KDateCalendar.vue
@@ -243,14 +243,14 @@
        * default value of selected start date
        */
       selectedStartDate: {
-        type: [Date, null],
+        type: Date,
         default: null,
       },
       /**
        * default value of selected end date
        */
       selectedEndDate: {
-        type: [Date, null],
+        type: Date,
         default: null,
       },
       /**
@@ -276,7 +276,6 @@
           end: this.selectedStartDate && this.selectedEndDate ? this.selectedEndDate : null,
         },
         numOfDays: 7,
-        isFirstChoice: this.selectedStartDate == null ? true : false,
         activeMonth:
           this.lastAllowedDate.getMonth() - 1 == -1 ? 11 : this.lastAllowedDate.getMonth() - 1,
         activeYearStart: this.lastAllowedDate.getFullYear(),
@@ -319,6 +318,21 @@
         }
         return this.activeYearStart;
       },
+      isFirstChoice() {
+        // True if there is no start date OR if there is an end date
+        // False if there is a start date but no end date
+        return !this.dateRange.start || !!this.dateRange.end;
+      },
+    },
+    watch: {
+      // Update local dateRange.start whenever selectedStartDate is set
+      selectedStartDate(newVal) {
+        this.dateRange.start = newVal;
+      },
+      // Update local dateRange.end whenever selectedEndDate is set
+      selectedEndDate(newVal) {
+        this.dateRange.end = newVal;
+      },
     },
     created() {
       if (this.activeMonth === 11) this.activeYearStart = this.activeYearStart - 1;
@@ -345,7 +359,6 @@
       getNewDateRange(result, activeMonth, activeYear) {
         const resultDate = new Date(activeYear, activeMonth, result);
         if (!this.isFirstChoice && resultDate < this.dateRange.start) {
-          this.isFirstChoice = false;
           return { start: resultDate };
         }
         const newData = {};
@@ -355,8 +368,6 @@
         } else {
           newData.end = null;
         }
-        // toggle first choice
-        this.isFirstChoice = !this.isFirstChoice;
         newData[key] = resultDate;
         return newData;
       },

--- a/lib/KDateRange/index.vue
+++ b/lib/KDateRange/index.vue
@@ -299,8 +299,19 @@
       },
       /** Updates start date with input from textbox */
       setStartDate(newVal) {
-        this.dateRange = { start: newVal, end: null };
-        this.validationMachine.send('REVALIDATE', { startDate: newVal, endDate: null });
+        // If new start date is later than the current end date, end date should be null
+        const start = this.createDate(newVal);
+        const end = this.createDate(this.dateRange.end);
+        const startAfterEnd = end && start > end;
+        // Update date range and send dates to validation machine
+        this.dateRange = {
+          start: newVal,
+          end: startAfterEnd ? null : this.dateRange.end,
+        };
+        this.validationMachine.send('REVALIDATE', {
+          startDate: newVal,
+          endDate: startAfterEnd ? null : this.dateRange.end,
+        });
       },
       /** Updates end date with input from textbox */
       setEndDate(newVal) {


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This pull request addresses the KDateRange bug in which, after initially setting a Start Date in the textbox using the keyboard, selecting another date on the calendar results in the Start Date being reset.

This pull request also clears the End Date after selecting a Start Date, but only if the Start Date is after the End Date. 
**This feature is not replicated when using mouse clicks to select dates on the calendar view, as it would make it difficult to remove or restart the date range values.**


#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #817 

### Before/after screenshots
<!-- Insert images here if applicable -->
After:
Setting a start date in the text box, then clicking to select the end date on the calendar:

https://github.com/user-attachments/assets/af4b0d99-76c3-46a0-a85f-9a86b391d864

Selecting a start date that is before and after the end date:

https://github.com/user-attachments/assets/1d32a122-a78d-469c-8e7d-b931c22f676c


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Updates KDateRange logic so that end date is cleared only if start date is after end date; users can now set start date via keyboard, then select end date using the calendar view.
  - **Products impact:** none
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/817
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Open the KDateRange component and select a Start Date in the textbox using the keyboard.
2. Select a End Date on the calendar view using the mouse. The End Date should be updated as expected.
3. Select a Start and End date on the calendar, then input a new Start Date in the textbox with a date that is before the End Date.
4. The Start Date should be updated, while the End Date remains unchanged.
5. Input a new Start Date in the textbox with a date that is after the End Date.
6. The Start Date should be updated, and the End Date should be reset.

## (optional) Implementation notes

### At a high level, how did you implement this?
The logic within `setStartDate()` was updated so that if the start date is after the end date, the end date is `null`, otherwise, it is unchanged.

Within `KDateCalendar.vue`, a watcher has been added for the props `selectedStartDate` and `selectedEndDate`, which will update the local `dateRange` object values, so that the calendar dates are consistent with the updates made to the dates in the KDateRange textboxes. `isFirstChoice` has been converted into a computed property and its value is updated based on changes to the dateRange object values.
 

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_
