### PR TITLE
[KModal] Fix infinite recursive error

### DIFF
--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -373,7 +373,9 @@
         // focus has escaped the modal - put it back!
         if (!this.$refs.modal.contains(target)) {
           this.$nextTick(() => {
-            // flush any pending DOM/focus updates
+            // flush any pending DOM/focus updates to prevent infinite recursion
+            // from two components fighting over focus
+            // https://github.com/learningequality/studio/issues/4772
             this.focusModal();
           });
         }

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -372,7 +372,10 @@
         }
         // focus has escaped the modal - put it back!
         if (!this.$refs.modal.contains(target)) {
-          this.focusModal();
+          this.$nextTick(() => {
+            // flush any pending DOM/focus updates
+            this.focusModal();
+          });
         }
       },
     },


### PR DESCRIPTION
## Description

Fix `RangeError: Maximum call stack size exceeded` error that was appearing in the Inherit Modal in Studio https://github.com/learningequality/studio/issues/4772.

This error was caused because in the Studio Edit Modal, we had an autocomplete VTextField component from Vuetify whose internal implementation was stealing the focus from the modal to the input. The thing is that the <input> element itself had a `@focus="onFocus"` handler, so when Vuetify does $refs.input.focus(), the `@focus` event was triggered again, but as we have a global focus listener in KModal, the KModal listener was executed first, and the VTextField onFocus was triggered just after the KModal had get the focus, so when VTextField tried to execute the `onFocus` method again, it was again stealing the focus from KModal executing again the `$refs.input.focus()`, and so on, and so forth.

This solution makes that KModal waits for this handler call to happen before requesting the focus to KModal.

#### Issue addressed
Closes #228

And once KDS is updated in Studio, it will close https://github.com/learningequality/studio/issues/4772

### Before/after screenshots

Before:

https://github.com/user-attachments/assets/53102806-d8c8-46ad-8010-3c6a49136da4

After:

https://github.com/user-attachments/assets/3f06e79b-3261-49b5-af46-0ae67ac0fff7




## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Fixes infinite recursive error when KModal request the focus.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/studio/issues/4772, https://github.com/learningequality/kolibri-design-system/issues/228.
  - **Components:** KModal.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .
 
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

You can checkout this [commit ](https://github.com/AlexVelezLl/kolibri-design-system/commit/5d1af35d0d0b1161079bab903baef69944345b9f) in Studio that was created from a commit before the nodejs upgrade.

1. Checkout that commit
2. Yarn link KDS to Studio
3. Replicate https://github.com/learningequality/studio/issues/4772

## Implementation notes

Havent found any other place where this error is happening to test if this solution works in all cases.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
