### PR TITLE
docs: allow `DocsShow` to automatically parse SFC's and display their source and output

### DIFF
--- a/docs/common/DocsShow.vue
+++ b/docs/common/DocsShow.vue
@@ -5,6 +5,24 @@
       class="show"
       :style="style"
     >
+      <!-- Code blocks display -->
+      <div v-if="loadExample && codeBlocks.length">
+        <DocsShowCode
+          v-for="(codeBlock, index) in codeBlocks"
+          :key="index"
+          :language="codeBlock.language"
+        >
+          {{ codeBlock.content }}
+        </DocsShowCode>
+      </div>
+
+      <!-- Rendered example output when showOutput is true -->
+      <component
+        :is="componentToRender"
+        v-if="showOutput && componentToRender"
+      />
+
+      <!-- Usual slots -->
       <slot></slot>
     </div>
   </div>
@@ -17,6 +35,26 @@
   export default {
     name: 'DocsShow',
     props: {
+      /**
+       * Path to the Vue component file to load and display.
+       * The path should be relative to the project root.
+       * @example 'examples/KComponent/FileName.vue'
+       */
+      loadExample: {
+        type: String,
+        required: false,
+        default: null,
+      },
+      /**
+       * Controls whether to render the actual component example.
+       * When true, displays both the code and the rendered output.
+       * When false, only displays the code.
+       */
+      showOutput: {
+        type: Boolean,
+        required: false,
+        default: true,
+      },
       block: {
         type: Boolean,
         default: false,
@@ -25,13 +63,16 @@
         type: Boolean,
         default: true,
       },
-      /**
-       * Toggles dark background
-       */
       dark: {
         type: Boolean,
         required: false,
       },
+    },
+    data() {
+      return {
+        codeBlocks: [],
+        componentToRender: null,
+      };
     },
     computed: {
       style() {
@@ -40,6 +81,63 @@
           padding: this.padding ? '8px 24px' : null,
           backgroundColor: this.dark ? this.$themePalette.grey.v_700 : undefined,
         };
+      },
+    },
+    async created() {
+      if (this.loadExample) {
+        await this.loadComponentContent();
+        await this.importComponent();
+      }
+    },
+    methods: {
+      /**
+       * Loads the content of the component file using raw-loader.
+       * Parses the content into separate code blocks for template, script, and style.
+       * @throws {Error} If the component content cannot be loaded
+       */
+      async loadComponentContent() {
+        try {
+          const content = await import(`!!raw-loader!@/${this.loadExample}?raw`);
+          this.codeBlocks = this.parseTemplate(content.default);
+        } catch (error) {
+          throw new Error(`Failed to load component content: ${error}`);
+        }
+      },
+      /**
+       * Dynamically imports the component for rendering
+       */
+      async importComponent() {
+        try {
+          const component = await import(`../${this.loadExample}`);
+          this.componentToRender = component.default;
+        } catch (error) {
+          throw new Error(`Failed to import component: ${error}`);
+        }
+      },
+      parseTemplate(content) {
+        const codeBlocks = [];
+        const template = content.match(/<template>([\s\S]*?)<\/template>/);
+        if (template) {
+          codeBlocks.push({
+            language: 'html',
+            content: template[1].trim(),
+          });
+        }
+        const script = content.match(/<script>([\s\S]*?)<\/script>/);
+        if (script) {
+          codeBlocks.push({
+            language: 'javascript',
+            content: script[1].trim(),
+          });
+        }
+        const style = content.match(/<style[\s\S]*?>([\s\S]*?)<\/style>/);
+        if (style) {
+          codeBlocks.push({
+            language: 'scss',
+            content: style[1].trim(),
+          });
+        }
+        return codeBlocks;
       },
     },
   };

--- a/docs/common/DocsShow.vue
+++ b/docs/common/DocsShow.vue
@@ -114,27 +114,47 @@
           throw new Error(`Failed to import component: ${error}`);
         }
       },
+      /*
+        * Parses the content of the component file into separate code blocks for template, script, and style.
+        * @param {string} content - The content of the component file
+        * @returns {Array} An array of code blocks
+      */
       parseTemplate(content) {
         const codeBlocks = [];
-        const template = content.match(/<template>([\s\S]*?)<\/template>/);
+
+        const applyRegex = (target) => {
+          const pattern = new RegExp(`(<${target}(\\s[^>]*)?>)([\\w\\W]*)(<\\/${target}>)`, 'g');
+          const parsed = pattern.exec(content);
+
+          if (!parsed) {
+            return null;
+          }
+
+          // Extract the content between the first opening and the last closing tags
+          return parsed[3].trim();
+        };
+
+        const template = applyRegex('template')
         if (template) {
           codeBlocks.push({
             language: 'html',
-            content: template[1].trim(),
+            content: template,
           });
         }
-        const script = content.match(/<script>([\s\S]*?)<\/script>/);
+
+        const script = applyRegex('script')
         if (script) {
           codeBlocks.push({
             language: 'javascript',
-            content: script[1].trim(),
+            content: script,
           });
         }
-        const style = content.match(/<style[\s\S]*?>([\s\S]*?)<\/style>/);
+
+        const style = applyRegex('style')
         if (style) {
           codeBlocks.push({
             language: 'scss',
-            content: style[1].trim(),
+            content: style[1],
           });
         }
         return codeBlocks;

--- a/docs/common/DocsShow.vue
+++ b/docs/common/DocsShow.vue
@@ -154,7 +154,7 @@
         if (style) {
           codeBlocks.push({
             language: 'scss',
-            content: style[1],
+            content: style,
           });
         }
         return codeBlocks;

--- a/docs/common/DocsShow.vue
+++ b/docs/common/DocsShow.vue
@@ -83,10 +83,10 @@
         };
       },
     },
-    async created() {
+    created() {
       if (this.loadExample) {
-        await this.loadComponentContent();
-        await this.importComponent();
+        this.loadComponentContent();
+        this.importComponent();
       }
     },
     methods: {
@@ -115,14 +115,14 @@
         }
       },
       /*
-        * Parses the content of the component file into separate code blocks for template, script, and style.
-        * @param {string} content - The content of the component file
-        * @returns {Array} An array of code blocks
-      */
+       * Parses the content of the component file into separate code blocks for template, script, and style.
+       * @param {string} content - The content of the component file
+       * @returns {Array} An array of code blocks
+       */
       parseTemplate(content) {
         const codeBlocks = [];
 
-        const applyRegex = (target) => {
+        const applyRegex = target => {
           const pattern = new RegExp(`(<${target}(\\s[^>]*)?>)([\\w\\W]*)(<\\/${target}>)`, 'g');
           const parsed = pattern.exec(content);
 
@@ -134,7 +134,7 @@
           return parsed[3].trim();
         };
 
-        const template = applyRegex('template')
+        const template = applyRegex('template');
         if (template) {
           codeBlocks.push({
             language: 'html',
@@ -142,7 +142,7 @@
           });
         }
 
-        const script = applyRegex('script')
+        const script = applyRegex('script');
         if (script) {
           codeBlocks.push({
             language: 'javascript',
@@ -150,7 +150,7 @@
           });
         }
 
-        const style = applyRegex('style')
+        const style = applyRegex('style');
         if (style) {
           codeBlocks.push({
             language: 'scss',

--- a/docs/examples/KTable/Base.vue
+++ b/docs/examples/KTable/Base.vue
@@ -1,0 +1,34 @@
+<template>
+
+  <KTable
+    :headers="headers"
+    :rows="rows"
+    caption="Non Sortable Table"
+  />
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        headers: [
+          { label: 'Name', dataType: 'string', columnId: 'name' },
+          { label: 'Age', dataType: 'number', columnId: 'age' },
+          { label: 'City', dataType: 'string', columnId: 'city' },
+        ],
+        rows: [
+          ['John Doe', 28, 'New York'],
+          ['Jane Smith', 34, 'Los Angeles'],
+          ['Samuel Green', 22, 'Chicago'],
+          ['Alice Johnson', 30, 'Houston'],
+          ['Michael Brown', 45, 'Phoenix'],
+          ['Emily Davis', 27, 'Philadelphia'],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/docs/examples/KTable/CustomWidth.vue
+++ b/docs/examples/KTable/CustomWidth.vue
@@ -1,0 +1,47 @@
+<template>
+
+  <KTable
+    :headers="headersWithCustomWidths"
+    :rows="customRows"
+    caption="Table showing columns with custom widths"
+    sortable
+  />
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        headersWithCustomWidths: [
+          { label: 'Name', dataType: 'string', minWidth: '20px', width: '2%', columnId: 'name' },
+          { label: 'Age', dataType: 'number', minWidth: '100px', width: '33%', columnId: 'age' },
+          { label: 'City', dataType: 'string', minWidth: '200px', width: '25%', columnId: 'city' },
+          {
+            label: 'Joined',
+            dataType: 'date',
+            minWidth: '150px',
+            width: '20%',
+            columnId: 'joined',
+          },
+          {
+            label: 'Misc',
+            dataType: 'undefined',
+            minWidth: '100px',
+            width: '20%',
+            columnId: 'misc',
+          },
+        ],
+        customRows: [
+          ['John Doe', 28, 'New York', '2022-01-15T00:00:00Z', 'N/A'],
+          ['Jane Smith', 34, 'Los Angeles', '2021-12-22T00:00:00Z', 'N/A'],
+          ['Samuel Green', 22, 'Chicago', '2023-03-10T00:00:00Z', 'N/A'],
+          ['Alice Johnson', 30, 'Houston', '2020-07-18T00:00:00Z', 'N/A'],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/docs/examples/KTable/DefaultSort.vue
+++ b/docs/examples/KTable/DefaultSort.vue
@@ -1,0 +1,47 @@
+<template>
+
+  <div>
+    <h4>Sortable table with rows sorted by 'Age' column</h4>
+    <KTable
+      :headers="headers"
+      :rows="rows"
+      caption="Sortable Table with Rows Sorted by 'Age' Column"
+      sortable
+      :defaultSort="{ columnId: 'age', direction: 'asc' }"
+    />
+
+    <h4>Unsortable table with rows sorted by 'Age' column</h4>
+    <KTable
+      :headers="headers"
+      :rows="rows"
+      caption="Unsortable Table with Rows Sorted by 'Age' Column"
+      :defaultSort="{ columnId: 'age', direction: 'asc' }"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        headers: [
+          { label: 'Name', dataType: 'string', columnId: 'name' },
+          { label: 'Age', dataType: 'number', columnId: 'age' },
+          { label: 'City', dataType: 'string', columnId: 'city' },
+        ],
+        rows: [
+          ['John Doe', 28, 'New York'],
+          ['Jane Smith', 34, 'Los Angeles'],
+          ['Samuel Green', 22, 'Chicago'],
+          ['Alice Johnson', 30, 'Houston'],
+          ['Michael Brown', 45, 'Phoenix'],
+          ['Emily Davis', 27, 'Philadelphia'],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/docs/examples/KTable/DisableBuiltinSorting.vue
+++ b/docs/examples/KTable/DisableBuiltinSorting.vue
@@ -1,0 +1,43 @@
+<template>
+
+  <KTable
+    :headers="headers"
+    :rows="rows"
+    caption="Disable Builtin Sorting Example"
+    sortable
+    disableDefaultSorting
+    @changeSort="changeSortHandler"
+  />
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        headers: [
+          { label: 'Name', dataType: 'string', columnId: 'name' },
+          { label: 'Age', dataType: 'number', columnId: 'age' },
+          { label: 'City', dataType: 'string', columnId: 'city' },
+        ],
+        rows: [
+          ['John Doe', 28, 'New York'],
+          ['Jane Smith', 34, 'Los Angeles'],
+          ['Samuel Green', 22, 'Chicago'],
+          ['Alice Johnson', 30, 'Houston'],
+          ['Michael Brown', 45, 'Phoenix'],
+          ['Emily Davis', 27, 'Philadelphia'],
+        ],
+      };
+    },
+    methods: {
+      changeSortHandler(index, sortOrder) {
+        // eslint-disable-next-line no-console
+        console.log(`changeSort event emitted with index: ${index} and sortOrder: ${sortOrder}`);
+      },
+    },
+  };
+
+</script>

--- a/docs/examples/KTable/Slots.vue
+++ b/docs/examples/KTable/Slots.vue
@@ -1,0 +1,44 @@
+<template>
+
+  <KTable
+    :headers="headers"
+    :rows="rows"
+    caption="Table showing use of slots"
+    sortable
+  >
+    <template #header="{ header }">
+      <span>{{ header.label }} (Local)</span>
+    </template>
+    <template #cell="{ content, colIndex }">
+      <span v-if="colIndex === 1">{{ content }} years old</span>
+      <span v-else-if="colIndex === 4"><KButton>Test</KButton></span>
+      <span v-else>{{ content }}</span>
+    </template>
+  </KTable>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        headers: [
+          { label: 'Name', dataType: 'string', columnId: 'name' },
+          { label: 'Age', dataType: 'number', columnId: 'age' },
+          { label: 'City', dataType: 'string', columnId: 'city' },
+        ],
+        rows: [
+          ['John Doe', 28, 'New York'],
+          ['Jane Smith', 34, 'Los Angeles'],
+          ['Samuel Green', 22, 'Chicago'],
+          ['Alice Johnson', 30, 'Houston'],
+          ['Michael Brown', 45, 'Phoenix'],
+          ['Emily Davis', 27, 'Philadelphia'],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/docs/examples/KTable/Sortable.vue
+++ b/docs/examples/KTable/Sortable.vue
@@ -1,0 +1,35 @@
+<template>
+
+  <KTable
+    :headers="headers"
+    :rows="rows"
+    caption="In-built Sortable Table"
+    sortable
+  />
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        headers: [
+          { label: 'Name', dataType: 'string', columnId: 'name' },
+          { label: 'Age', dataType: 'number', columnId: 'age' },
+          { label: 'City', dataType: 'string', columnId: 'city' },
+        ],
+        rows: [
+          ['John Doe', 28, 'New York'],
+          ['Jane Smith', 34, 'Los Angeles'],
+          ['Samuel Green', 22, 'Chicago'],
+          ['Alice Johnson', 30, 'Houston'],
+          ['Michael Brown', 45, 'Phoenix'],
+          ['Emily Davis', 27, 'Philadelphia'],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/docs/pages/ktable.vue
+++ b/docs/pages/ktable.vue
@@ -29,45 +29,10 @@
         This is an example to show how <code>KTable</code> can be used without any sorting
         functionality, as a simple table.
       </p>
-
-      <DocsShowCode language="html">
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Non Sortable Table"
-        />
-      </DocsShowCode>
-
-      <!-- eslint-disable-->
-      <!-- prettier-ignore -->
-      <DocsShowCode language="javascript">
-        data() {
-          return {
-            headers: [
-              { label: 'Name', dataType: 'string', columnId: 'name' },
-              { label: 'Age', dataType: 'number', columnId: 'age' },
-              { label: 'City', dataType: 'string', columnId: 'city' },
-            ],
-            rows: [
-                ['John Doe', 28, 'New York'],
-                ['Jane Smith', 34, 'Los Angeles'],
-                ['Samuel Green', 22, 'Chicago'],
-                ['Alice Johnson', 30, 'Houston'],
-                ['Michael Brown', 45, 'Phoenix'],
-                ['Emily Davis', 27, 'Philadelphia'],
-              ]
-            };
-        },
-      </DocsShowCode>
-      <!-- eslint-enable -->
-
-      <DocsShow block>
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Non-sortable table"
-        />
-      </DocsShow>
+      <DocsShow
+        loadExample="examples/KTable/Base"
+        block
+      />
 
       <!-- Frontend Sorting Example-->
       <h3>Table with sorting</h3>
@@ -83,46 +48,10 @@
         of ascending, descending, and unsorted.
       </p>
 
-      <DocsShowCode language="html">
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Table with built-in sorting"
-          sortable
-        />
-      </DocsShowCode>
-
-      <!-- eslint-disable -->
-      <!-- prettier-ignore -->
-      <DocsShowCode language="javascript">
-        data() {
-          return {
-            headers: [
-              { label: 'Name', dataType: 'string', columnId: 'name' },
-              { label: 'Age', dataType: 'number', columnId: 'age' },
-              { label: 'City', dataType: 'string', columnId: 'city' },
-            ],
-            rows: [
-              ['John Doe', 28, 'New York'],
-              ['Jane Smith', 34, 'Los Angeles'],
-              ['Samuel Green', 22, 'Chicago'],
-              ['Alice Johnson', 30, 'Houston'],
-              ['Michael Brown', 45, 'Phoenix'],
-              ['Emily Davis', 27, 'Philadelphia'],
-            ]
-          };
-        },
-      </DocsShowCode>
-      <!-- eslint-enable -->
-
-      <DocsShow block>
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="In-Built Sorting Table"
-          sortable
-        />
-      </DocsShow>
+      <DocsShow
+        loadExample="examples/KTable/Sortable"
+        block
+      />
 
       <!--Table showing use of slots-->
       <h3>Table showing use of slots</h3>
@@ -132,64 +61,10 @@
         the table header and cell content respectively.
       </p>
 
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <KTable
-          :headers="slotHeaders"
-          :rows="slotRows"
-          caption="Table showing use of slots"
-          sortable
-        >
-          <template #header="{ header, colindex }">
-            <span>{ header.label } (Local)</span>
-          </template>
-          <template #cell="{ content, rowIndex, colIndex }">
-            <span v-if="colIndex === 1">{ content } years old</span>
-            <span v-else-if="colIndex === 4"><KButton>Test</KButton></span>
-            <span v-else>{ content }</span>
-          </template>
-        </KTable>
-      </DocsShowCode>
-
-      <!-- prettier-ignore -->
-      <DocsShowCode language="javascript">
-        data() {
-          return {
-            slotHeaders: [
-              { label: 'Name', dataType: 'string', columnId: 'name' },
-              { label: 'Age', dataType: 'number', columnId: 'age' },
-              { label: 'City', dataType: 'string', columnId: 'city' },
-              { label: 'Joined', dataType: 'date', columnId: 'joined' },
-              { label: 'Misc', dataType: 'undefined', columnId: 'misc' },
-            ],
-            slotRows: [
-              ['John Doe', 28, 'New York', '2022-01-15T00:00:00Z', 'N/A'],
-              ['Jane Smith', 34, 'Los Angeles', '2021-12-22T00:00:00Z', 'N/A'],
-              ['Samuel Green', 22, 'Chicago', '2023-03-10T00:00:00Z', 'N/A'],
-              ['Alice Johnson', 30, 'Houston', '2020-07-18T00:00:00Z', 'N/A'],
-            ],
-          };
-        },
-      </DocsShowCode>
-
-      <DocsShow block>
-        <KTable
-          :headers="slotHeaders"
-          :rows="slotRows"
-          caption="Table showing use of slots"
-          sortable
-        >
-          <template #header="{ header, colindex }">
-            <span>{{ header.label }} (Local)</span>
-          </template>
-          <template #cell="{ content, rowIndex, colIndex }">
-            <span v-if="colIndex === 1">{{ content }} years old</span>
-            <span v-else-if="colIndex === 4"><KButton>Test</KButton></span>
-            <span v-else>{{ content }}</span>
-          </template>
-        </KTable>
-      </DocsShow>
-      <!-- eslint-enable -->
+      <DocsShow
+        loadExample="examples/KTable/Slots"
+        block
+      />
 
       <!--Table with custom column widths-->
       <h3>Table with custom column widths</h3>
@@ -223,66 +98,10 @@
         <code>disableBuiltinSorting</code> attribute is not set to <code>true</code>.
       </p>
 
-      <DocsShowCode language="html">
-        <h4>Sortable table with rows sorted by 'Age' column</h4>
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Sortable Table with Rows Sorted by 'Age' Column"
-          sortable
-          :defaultSort="{ columnId: 'age', direction: 'asc' }"
-        />
-
-        <h4>Unsortable table with rows sorted by 'Age' column</h4>
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Unsortable Table with Rows Sorted by 'Age' Column"
-          :defaultSort="{ columnId: 'age', direction: 'asc' }"
-        />
-      </DocsShowCode>
-
-      <!-- eslint-disable -->
-      <!-- prettier-ignore -->
-      <DocsShowCode language="javascript">
-        data() {
-          return {
-            headers: [
-              { label: 'Name', dataType: 'string', columnId: 'name' },
-              { label: 'Age', dataType: 'number', columnId: 'age' },
-              { label: 'City', dataType: 'string', columnId: 'city' },
-            ],
-            rows: [
-              ['John Doe', 28, 'New York'],
-              ['Jane Smith', 34, 'Los Angeles'],
-              ['Samuel Green', 22, 'Chicago'],
-              ['Alice Johnson', 30, 'Houston'],
-              ['Michael Brown', 45, 'Phoenix'],
-              ['Emily Davis', 27, 'Philadelphia'],
-            ]
-          };
-        },
-      </DocsShowCode>
-      <!-- eslint-enable -->
-
-      <DocsShow block>
-        <h4>Sortable Table with Rows Sorted by 'Age' Column</h4>
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Sortable Table with Rows Sorted by 'Age' Column"
-          sortable
-          :defaultSort="{ columnId: 'age', direction: 'asc' }"
-        />
-
-        <h4>Unsortable Table with Rows Sorted by 'Age' Column</h4>
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Unsortable Table with Rows Sorted by 'Age' Column"
-          :defaultSort="{ columnId: 'age', direction: 'asc' }"
-        />
-      </DocsShow>
+      <DocsShow
+        loadExample="examples/KTable/DefaultSort"
+        block
+      />
 
       <!-- Disable built-in sorting -->
       <h3>Disable built-in sorting</h3>
@@ -303,55 +122,10 @@
         notify the parent component to handle the sorting logic.
       </p>
 
-      <DocsShowCode language="html">
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Disable Builtin Sorting Example"
-          sortable
-          disableDefaultSorting
-          @changeSort="changeSortHandler"
-        />
-      </DocsShowCode>
-
-      <!-- eslint-disable -->
-      <!-- prettier-ignore -->
-      <DocsShowCode language="javascript">
-        data() {
-          return {
-            headers: [
-              { label: 'Name', dataType: 'string', columnId: 'name' },
-              { label: 'Age', dataType: 'number', columnId: 'age' },
-              { label: 'City', dataType: 'string', columnId: 'city' },
-            ],
-            rows: [
-              ['John Doe', 28, 'New York'],
-              ['Jane Smith', 34, 'Los Angeles'],
-              ['Samuel Green', 22, 'Chicago'],
-              ['Alice Johnson', 30, 'Houston'],
-              ['Michael Brown', 45, 'Phoenix'],
-              ['Emily Davis', 27, 'Philadelphia'],
-            ]
-          };
-        },
-        methods: {
-          changeSortHandler(index, sortOrder) {
-            console.log(`changeSort event emitted with index: ${index} and sortOrder: ${sortOrder}`);
-          },
-        },
-      </DocsShowCode>
-      <!-- eslint-enable -->
-
-      <DocsShow block>
-        <KTable
-          :headers="headers"
-          :rows="rows"
-          caption="Disable Builtin Sorting Example"
-          sortable
-          disableBuiltinSorting
-          @changeSort="changeSortHandler"
-        />
-      </DocsShow>
+      <DocsShow
+        loadExample="examples/KTable/DisableBuiltinSorting"
+        block
+      />
     </DocsPageSection>
   </DocsPageTemplate>
 
@@ -362,42 +136,6 @@
 
   export default {
     name: 'DocsKTable',
-    data() {
-      return {
-        headers: [
-          { label: 'Name', dataType: 'string', columnId: 'name' },
-          { label: 'Age', dataType: 'number', columnId: 'age' },
-          { label: 'City', dataType: 'string', columnId: 'city' },
-        ],
-        rows: [
-          ['John Doe', 28, 'New York'],
-          ['Jane Smith', 34, 'Los Angeles'],
-          ['Samuel Green', 22, 'Chicago'],
-          ['Alice Johnson', 30, 'Houston'],
-          ['Michael Brown', 45, 'Phoenix'],
-          ['Emily Davis', 27, 'Philadelphia'],
-        ],
-        slotHeaders: [
-          { label: 'Name', dataType: 'string', columnId: 'name' },
-          { label: 'Age', dataType: 'number', columnId: 'age' },
-          { label: 'City', dataType: 'string', columnId: 'city' },
-          { label: 'Joined', dataType: 'date', columnId: 'joined' },
-          { label: 'Misc', dataType: 'undefined', columnId: 'misc' },
-        ],
-        slotRows: [
-          ['John Doe', 28, 'New York', '2022-01-15T00:00:00Z', 'N/A'],
-          ['Jane Smith', 34, 'Los Angeles', '2021-12-22T00:00:00Z', 'N/A'],
-          ['Samuel Green', 22, 'Chicago', '2023-03-10T00:00:00Z', 'N/A'],
-          ['Alice Johnson', 30, 'Houston', '2020-07-18T00:00:00Z', 'N/A'],
-        ],
-      };
-    },
-    methods: {
-      changeSortHandler(index, sortOrder) {
-        // eslint-disable-next-line no-console
-        console.log(`changeSort event emitted with index: ${index} and sortOrder: ${sortOrder}`);
-      },
-    },
   };
 
 </script>

--- a/docs/pages/ktable.vue
+++ b/docs/pages/ktable.vue
@@ -201,58 +201,7 @@
         shrink.
       </p>
 
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <KTable
-          :headers="headersWithCustomWidths"
-          :rows="customRows"
-          caption="Table showing columns with custom widths"
-          sortable
-        />
-      </DocsShowCode>
-
-      <!-- prettier-ignore -->
-      <DocsShowCode language="javascript">
-        data() {
-          return {
-            headersWithCustomWidths: [
-              { label: 'Name', dataType: 'string', minWidth: '20px', width: '2%', columnId: 'name' },
-              { label: 'Age', dataType: 'number', minWidth: '100px', width: '33%', columnId: 'age' },
-              { label: 'City', dataType: 'string', minWidth: '200px', width: '25%', columnId: 'city' },
-              {
-                label: 'Joined',
-                dataType: 'date',
-                minWidth: '150px',
-                width: '20%',
-                columnId: 'joined',
-              },
-              {
-                label: 'Misc',
-                dataType: 'undefined',
-                minWidth: '100px',
-                width: '20%',
-                columnId: 'misc',
-              },
-            ],
-            customRows: [
-              ['John Doe', 28, 'New York', '2022-01-15T00:00:00Z', 'N/A'],
-              ['Jane Smith', 34, 'Los Angeles', '2021-12-22T00:00:00Z', 'N/A'],
-              ['Samuel Green', 22, 'Chicago', '2023-03-10T00:00:00Z', 'N/A'],
-              ['Alice Johnson', 30, 'Houston', '2020-07-18T00:00:00Z', 'N/A'],
-            ],
-          };
-        },
-      </DocsShowCode>
-
-      <DocsShow block>
-        <KTable
-          :headers="headersWithCustomWidths"
-          :rows="customRows"
-          caption="Table showing columns with custom widths"
-          sortable
-        />
-      </DocsShow>
-      <!-- eslint-enable -->
+      <DocsShow loadExample="examples/KTable/CustomWidth" />
 
       <!--Table with default sort-->
       <h3>Table with default sort</h3>
@@ -436,31 +385,6 @@
           { label: 'Misc', dataType: 'undefined', columnId: 'misc' },
         ],
         slotRows: [
-          ['John Doe', 28, 'New York', '2022-01-15T00:00:00Z', 'N/A'],
-          ['Jane Smith', 34, 'Los Angeles', '2021-12-22T00:00:00Z', 'N/A'],
-          ['Samuel Green', 22, 'Chicago', '2023-03-10T00:00:00Z', 'N/A'],
-          ['Alice Johnson', 30, 'Houston', '2020-07-18T00:00:00Z', 'N/A'],
-        ],
-        headersWithCustomWidths: [
-          { label: 'Name', dataType: 'string', minWidth: '20px', width: '2%', columnId: 'name' },
-          { label: 'Age', dataType: 'number', minWidth: '100px', width: '33%', columnId: 'age' },
-          { label: 'City', dataType: 'string', minWidth: '200px', width: '25%', columnId: 'city' },
-          {
-            label: 'Joined',
-            dataType: 'date',
-            minWidth: '150px',
-            width: '20%',
-            columnId: 'joined',
-          },
-          {
-            label: 'Misc',
-            dataType: 'undefined',
-            minWidth: '100px',
-            width: '20%',
-            columnId: 'misc',
-          },
-        ],
-        customRows: [
           ['John Doe', 28, 'New York', '2022-01-15T00:00:00Z', 'N/A'],
           ['Jane Smith', 34, 'Los Angeles', '2021-12-22T00:00:00Z', 'N/A'],
           ['Samuel Green', 22, 'Chicago', '2023-03-10T00:00:00Z', 'N/A'],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -57,6 +57,13 @@ export default {
         test: /rstIconReplacements.txt/,
         loader: 'raw-loader',
       });
+
+      config.module.rules.push({
+        resourceQuery: /raw/,
+        loader: 'raw-loader',
+        include: /examples/,
+      });
+
       config.devtool = 'source-map';
     },
     cssSourceMap: true,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -58,10 +58,12 @@ export default {
         loader: 'raw-loader',
       });
 
+      // Allow raw files of `.vue` file from `/docs/examples` directory
+      // to be imported as strings with `?raw` query
       config.module.rules.push({
         resourceQuery: /raw/,
         loader: 'raw-loader',
-        include: /examples/,
+        test: /examples\/.*\.vue$/,
       });
 
       config.devtool = 'source-map';

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
   },
   "browserslist": [
     "extends browserslist-config-kolibri"
-  ]
+  ],
+  "volta": {
+    "node": "18.20.6"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -83,8 +83,5 @@
   },
   "browserslist": [
     "extends browserslist-config-kolibri"
-  ],
-  "volta": {
-    "node": "18.20.6"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "normalize.css": "^8.0.1",
     "nuxt": "2.18.1",
     "prismjs": "^1.27.0",
-    "raw-loader": "0.5.1",
+    "raw-loader": "^4.0.2",
     "sass-loader": "^10.5.2",
     "svg-icon-inline-loader": "^3.1.0",
     "svgo": "^1.3.2",
@@ -83,5 +83,8 @@
   },
   "browserslist": [
     "extends browserslist-config-kolibri"
-  ]
+  ],
+  "volta": {
+    "node": "18.20.6"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11100,10 +11100,13 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-loader@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz"
-  integrity sha1-DD0L6u2KAclm2Xh793goElKpeao=
+raw-loader@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
+  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 rc9@^2.1.1, rc9@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## Description
The PR modifies the `DocsShow` component to accept two new arguments: 
- `loadExample`: The path to the component that needs to be shown to the user. When passed, the component is loaded dynamically, and its source code is parsed into three separate `DocsShowCode` blocks. 
- `showOutput`: Controls whether the example component is to be rendered in the documentation. Defaults to `true`.

All the examples must be in the `/docs/examples` directory to be loaded correctly. `DocsShow` still accepts a default slot, so the user can use it to render a custom component with or without the example. This functionality should (probably) be migrated to the `DocsExample` component when ready. The `loadExample` prop is set to be `null` by default so that it does not cause any regressions or changes in it's existing usage across the documentation pages. 

I have also migrated the `KTable` documentation to use this new feature (as that is the component that I am most familiar with & believe could really benefit from this new API).

#### Issue addressed
Fixes #861 

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Added automatic parsing of examples from files for `DocsShow` component
  - **Products impact:** none
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/861
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Implementation notes

### At a high level, how did you implement this?
Used the `raw-loader` plugin with Webpack to configure the loading of components.

### Does this introduce any tech-debt items?
No

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [X] Critical and brittle code paths are covered by unit tests
- [X] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_