### PR TITLE
Skip sync projects job if the owner is not LearningEquality

### DIFF
--- a/.github/workflows/sync_kds_roadmap_statuses.yml
+++ b/.github/workflows/sync_kds_roadmap_statuses.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync-projects:
+    if: github.repository_owner == 'learningequality'
     runs-on: ubuntu-latest
     permissions: write-all
 


### PR DESCRIPTION
## Description
Skip sync projects job if the owner is not LearningEquality

#### Issue addressed

Closes #906

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Skip sync projects job if the owner is not LearningEquality
  - **Products impact:**  -.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/906.
  - **Components:** -.
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

