### PR TITLE
Pin node and yarn versions

### DIFF
--- a/dev_docs/01_getting_started.md
+++ b/dev_docs/01_getting_started.md
@@ -4,8 +4,7 @@ The design system has two primary parts, the UI component library [`/lib`](../li
 
 ## Prerequisites
 
-- Node.js 18.x (see [Node Version Manager](https://github.com/nvm-sh/nvm))
-- Yarn >=1.22.22
+The project requires `Node 18.X` as the runtime and `Yarn >= 1.22.X` as the package manager. We make use of [`Volta`](https://docs.volta.sh/guide/getting-started) to manage the same automatically. Please make sure you have volta installed and your shell configured to use volta.
 
 ## Troubleshooting
 
@@ -43,7 +42,7 @@ yarn lint-fix    # run the linter and auto-formatter once
 yarn lint-watch  # run the linter in watch mode, without the auto-formatter
 ```
 
-You're now ready to code! 
+You're now ready to code!
 
 ## Next steps
 
@@ -52,6 +51,7 @@ You're now ready to code!
 - If you'd like to update the component library, continue to [How to update the component library](./03_how_to_update_library.md).
 
 The guidelines referenced above should be sufficient for the most common tasks. There are a few additional developer documentation pages available. However, these pages contain information that is more internal in nature or related to specialized tasks:
+
 - [Visual Testing](./07_visual_testing_guide.md)
 - [How to update the documentation website](./04_how_to_update_docs.md)
 - [Icons](./05_icons.md)

--- a/package.json
+++ b/package.json
@@ -90,5 +90,9 @@
   },
   "browserslist": [
     "extends browserslist-config-kolibri"
-  ]
+  ],
+  "volta": {
+    "node": "18.20.6",
+    "yarn": "1.22.22"
+  }
 }


### PR DESCRIPTION
## Description  
Pin Node.js and Yarn versions for KDS using Volta to ensure consistency across development environments. Updated developer documentation to reflect these changes.  

#### Issue addressed  
Closes #902  

## Changelog  
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->  

- **Description:** Pinned Node.js (18.20.6) and Yarn (1.22.22) versions using Volta.  
- **Products impact:** none (internal updates).  
- **Addresses:** Compatibility issues with Node.js and Yarn versions across contributors' environments.  
- **Components:** Documentation updates for KDS setup.  
- **Breaking:** no.  
- **Impacts a11y:** no.  
- **Guidance:** Developers need to install Volta if not already installed and ensure they follow the updated setup instructions in the documentation.  

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->  

## Reviewer Guidance  
- [ ] Verify Node.js and Yarn versions are correctly pinned using Volta.  
- [ ] Confirm the documentation changes are clear and easy to follow for new contributors.  
- [ ] Ensure no unintended changes to other components.  

---

## Comments  
Let me know if further adjustments are needed!  
