### PR TITLE
Remove unnecessary scrollbar when using KCircularLoader (#210)

### DIFF
--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -276,8 +276,9 @@
 
   .ui-progress-circular--transition-fade-enter-active,
   .ui-progress-circular--transition-fade-leave-active {
-    transition: opacity 0.3s ease;
-    transform: 0.3s ease;
+    transition:
+      opacity 0.3s ease,
+      transform 0.3s ease;
   }
 
   .ui-progress-circular--transition-fade-enter,

--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -235,9 +235,10 @@
   .ui-progress-circular {
     position: relative;
     margin: 0 auto;
+    overflow: hidden;
     animation: fade-in;
-    animation-fill-mode: backwards;
     animation-duration: 0s;
+    animation-fill-mode: backwards;
   }
 
   .ui-progress-circular-determinate {
@@ -275,9 +276,8 @@
 
   .ui-progress-circular--transition-fade-enter-active,
   .ui-progress-circular--transition-fade-leave-active {
-    transition:
-      opacity 0.3s ease,
-      transform 0.3s ease;
+    transition: opacity 0.3s ease;
+    transform: 0.3s ease;
   }
 
   .ui-progress-circular--transition-fade-enter,


### PR DESCRIPTION
## Description  
Fixes #210 where `KModal` displays an unnecessary vertical scrollbar when used with `KCircularLoader`, even when there is enough space in the modal/page.  

#### Issue addressed  
Addresses #210   

### Demo Video 
(https://github.com/user-attachments/assets/f086ab15-6b47-4241-8cab-5b99d52ee4c6)  

## Changelog  
<!-- [DO NOT REMOVE - USED BY GH ACTION] CHANGELOG START -->  

- **Description:** Prevents unwanted vertical scrollbar in `KModal` when using `KCircularLoader`.  
- **Products impact:** bugfix  
- **Addresses:** #210   
- **Components:**  `KCircularLoader`  
- **Breaking:** no  
- **Impacts a11y:** no  
- **Guidance:** No action required from consumers. The fix applies automatically.  

<!-- [DO NOT REMOVE - USED BY GH ACTION] CHANGELOG END -->  

## Steps to test  

1. Open a `KModal` that contains a `KCircularLoader`.  
2. Ensure no vertical scrollbar appears when there is sufficient space.  
3. Verify modal content remains scrollable when needed.  

## Implementation Notes  
### How was this implemented?  
- Adjusted the styling of `KCircularLoader` to prevent forced overflow behavior.  

### Does this introduce any tech debt?  
No new tech debt introduced.  

## Testing Checklist  

- [ ] Contributor has tested the PR manually.  
- [ ] Verified that no vertical scrollbar appears unnecessarily.  
- [ ] Included before/after screenshots if applicable.  
- [ ] Ensured no regressions in modal scrolling behavior.  

## Reviewer Guidance  

- [ ] Does the fix properly prevent unwanted scrolling?  
- [ ] Is the modal still fully functional with varying content sizes?  

## Comments  
<!-- Any additional notes you'd like to add -->  
