### PR TITLE
Fix glob sync query

### DIFF
--- a/utils/extractApi.js
+++ b/utils/extractApi.js
@@ -1,7 +1,7 @@
 const path = require('node:path');
 const fs = require('node:fs');
 const docGenAPI = require('vue-docgen-api');
-const { GlobSync } = require('glob');
+const glob = require('glob');
 const consola = require('consola');
 
 /***********************************/
@@ -21,7 +21,7 @@ function notTest(filePath) {
 
 async function writeApi() {
   const componentFolder = path.resolve('./lib/');
-  const simpleFiles = Array.from(GlobSync('**/K*.{vue,js}', { cwd: componentFolder }));
+  const simpleFiles = Array.from(glob.sync('**/K*.{vue,js}', { cwd: componentFolder }));
   const output = {};
 
   for (const filename of simpleFiles.filter(notTest)) {
@@ -34,7 +34,7 @@ async function writeApi() {
     }
   }
 
-  const complexFiles = Array.from(GlobSync('**/K*/index.{vue,js}', { cwd: componentFolder }));
+  const complexFiles = Array.from(glob.sync('**/K*/index.{vue,js}', { cwd: componentFolder }));
 
   for (const filename of complexFiles.filter(notTest)) {
     const filepath = path.resolve(componentFolder, filename);


### PR DESCRIPTION
## Description

In #823, we removed the `globby` package in favor of `node-glob`, but it seems that due to a version mismatch we were using `const { GlobSync } = require('glob');` as the api, but it wasnt working well and when querying the files, it wasnt finding any, and the jsdocs result was an empty object that made our component docs to miss the API info:

![image](https://github.com/user-attachments/assets/238ce472-c1e6-4368-9fc9-de299f4ff275)
 
This PR fixes this using `glob.sync` instead as suggested in [their docs](https://github.com/isaacs/node-glob?tab=readme-ov-file#globsyncpattern-string--string-options-globoptions--string--path) (and suggested by copilot :sweat_smile:).

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Fixes glob query in extrac api script.
  - **Products impact:** bugfix.
  - **Addresses:** -.
  - **Components:** Docs.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. run `yarn dev` and check that the API sections (props, events, slots) are present in component docs 
