### PR TITLE
[Visual Testing] Allow object component rendering and unmount previoius component on render

### DIFF
--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -1,6 +1,12 @@
 name: Percy Visual Tests
 
-on: [pull_request_target]
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
 
 jobs:
   pre_job:
@@ -15,20 +21,40 @@ jobs:
         with:
           github_token: ${{ github.token }}
           paths: '["lib/**", "jest.conf/visual*" ]'
+          # Avoid duplicate skipping so it can be run again on the target branch
+          skip_after_successful_duplicate: false
 
   visual_tests:
     name: Frontend Visual Tests
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
-    environment: percy_tests
+    strategy:
+      # Using matrix just to dynamically set the environment variable
+      matrix:
+        env:
+          # Protect deployments from non-merged PRs but allow merged PRs to run
+          # on the target branch
+          - ${{ github.event.pull_request.merged == false && 'percy_tests' || '' }}
+    environment: ${{ matrix.env }}
     outputs:
       percy_url: ${{ steps.extract-url.outputs.percy_url }}
     steps:
       - name: Checkout code from PR
+        if: github.event.pull_request.merged == false
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Checkout code from target branch
+        if: github.event.pull_request.merged == true
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Set PERCY_BRANCH to target branch
+        if: github.event.pull_request.merged == true
+        # set the PERCY_BRANCH environment variable to the target branch for the Percy build
+        # to be associated with the target branch
+        run: echo "PERCY_BRANCH=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -61,7 +87,7 @@ jobs:
   comment:
     name: Comment Percy results
     needs: visual_tests
-    if: ${{ needs.visual_tests.result == 'success' }}
+    if: ${{ needs.visual_tests.result == 'success' && github.event.pull_request.merged == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code from PR

--- a/dev_docs/07_visual_testing_guide.md
+++ b/dev_docs/07_visual_testing_guide.md
@@ -88,14 +88,23 @@ KDS has a visual testing system that allows you to take snapshots of how KDS Com
 
           **Note:** Use `'default'` key for passing default slots, with the HTML content specified using `innerHTML` prop. Checkout [`KButton.spec.js`](../lib/buttons-and-links/__tests__/KButton.spec.js) for reference.
 
-      - **Example involving more complex component structures:** When dealing with more complex component structures, it's recommended to create a dedicated Vue component for visual testing purposes. This custom component can be placed in the same directory as the test file, inside a `components` folder. You can then import this component and render it using the `renderComponent` method.
+      - **Example involving more complex component structures:** When dealing with more complex component structures, it's recommended to create a dedicated test component for visual testing purposes.
 
-          ```javascript
-            import CustomVueComponent from './components/CustomVueComponent.vue';
+        * This custom component should be placed in the same directory as the test file, inside a `components` folder with a name following the pattern `K[TestCase]Test.vue`
+          * e.g.: `/lib/KImg/__tests__/components/KImgTest.vue`.
+        * Then you will need to declare this component in the the [visual.load-test-components.js](../jest.conf/visual.load-test-components.js) file so that its available for rendering in the visual testing playground.
+          * e.g.:
+            ```javascript
+            import KImgTest from '~~/lib/KImg/__tests__/components/KImgTest.vue';
 
             ...
 
-            await renderComponent(CustomVueComponent, { someProp: 'someValue' });
+            Vue.component('KImgTest', KImgTest);
+            ```
+        * Finally, you can then use the test component name in the `renderComponent` method.
+
+          ```javascript
+            await renderComponent('KImgTest', { someProp: 'someValue' });
           ```
 
           This approach ensures that all necessary child components and slots are correctly set up and rendered.

--- a/dev_docs/07_visual_testing_guide.md
+++ b/dev_docs/07_visual_testing_guide.md
@@ -83,21 +83,25 @@ KDS has a visual testing system that allows you to take snapshots of how KDS Com
                   items: ['Option 1', 'Option 2'],
                 },
               },
-            }); 
+            });
           ```
 
           **Note:** Use `'default'` key for passing default slots, with the HTML content specified using `innerHTML` prop. Checkout [`KButton.spec.js`](../lib/buttons-and-links/__tests__/KButton.spec.js) for reference.
 
-      - **Example involving more complex component structures:** When dealing with more complex component structures, it's recommended to create a dedicated Vue component for visual testing purposes. Add all the use cases in a Vue file and then render the custom component using the `renderComponent` function. 
+      - **Example involving more complex component structures:** When dealing with more complex component structures, it's recommended to create a dedicated Vue component for visual testing purposes. This custom component can be placed in the same directory as the test file, inside a `components` folder. You can then import this component and render it using the `renderComponent` method.
 
           ```javascript
-            await renderComponent('CustomVueComponent');
+            import CustomVueComponent from './components/CustomVueComponent.vue';
+
+            ...
+
+            await renderComponent(CustomVueComponent, { someProp: 'someValue' });
           ```
 
           This approach ensures that all necessary child components and slots are correctly set up and rendered.
 
-   - Make sure to use `describe.visual` or `it.visual` instead of the default notations for writing test blocks containing visual tests so as to prevent any unexpected behavior. These custom blocks add a `[Visual]` tag to the test name whose presence or absence are then checked using a regex pattern based on the type of tests executed. 
-      - Anything inside these blocks will not be executed when running unit tests. The default `describe` and `it` blocks can be used inside a parent `describe.visual` block, which itelf can be placed within a `describe` block as its parent (as `describe` blocks just group the tests placed within them). 
+   - Make sure to use `describe.visual` or `it.visual` instead of the default notations for writing test blocks containing visual tests so as to prevent any unexpected behavior. These custom blocks add a `[Visual]` tag to the test name whose presence or absence are then checked using a regex pattern based on the type of tests executed.
+      - Anything inside these blocks will not be executed when running unit tests. The default `describe` and `it` blocks can be used inside a parent `describe.visual` block, which itelf can be placed within a `describe` block as its parent (as `describe` blocks just group the tests placed within them).
       - In simple terms, any test block with a `[Visual]` tag will be executed when running visual tests, regardless of the type of test blocks used within it, and will be ignored when running unit tests. Using `describe.visual` or `it.visual` automatically appends this tag to the test name.
       - This implementation helps determine which test blocks should be executed by Jest and which ones should be skipped.
 
@@ -117,7 +121,7 @@ KDS has a visual testing system that allows you to take snapshots of how KDS Com
   - **Puppeteer:** for interacting with the testing environment and the rendered components.
   - **Jest-Puppeteer:** to provide all required configuration to run tests using Puppeteer.
   - **Percy:** to take snapshots for comparing visual diffs.
-  
+
   The key parts of the mechanism include:
 
 1. **Configuration Files**: Since we are using Jest for both unit and visual tests, there are two separate configuration files for visual tests apart from the ones being used for unit tests so as to ensure separation of logic needed for running both types of tests.

--- a/docs/pages/testing-playground.vue
+++ b/docs/pages/testing-playground.vue
@@ -37,8 +37,6 @@
 
 <script>
 
-  import { deserializeComponent } from '../../jest.conf/visual.testUtils';
-
   /**
    * Renders the components for visual testing
    * to ensure expected visual behavior under
@@ -86,11 +84,6 @@
       handleMessage(event) {
         if (event.data.type === 'RENDER_COMPONENT') {
           this.component = event.data.component;
-          if (typeof this.component === 'object') {
-            // If its a custom component, deserialize it and add it to the components object
-            this.component = deserializeComponent(this.component);
-            this.$options.components[this.component.name] = this.component;
-          }
           this.componentProps = event.data.props;
           this.slots = event.data.slots || {};
         }

--- a/docs/pages/testing-playground.vue
+++ b/docs/pages/testing-playground.vue
@@ -37,6 +37,8 @@
 
 <script>
 
+  import { deserializeComponent } from '../../jest.conf/visual.testUtils';
+
   /**
    * Renders the components for visual testing
    * to ensure expected visual behavior under
@@ -84,6 +86,11 @@
       handleMessage(event) {
         if (event.data.type === 'RENDER_COMPONENT') {
           this.component = event.data.component;
+          if (typeof this.component === 'object') {
+            // If its a custom component, deserialize it and add it to the components object
+            this.component = deserializeComponent(this.component);
+            this.$options.components[this.component.name] = this.component;
+          }
           this.componentProps = event.data.props;
           this.slots = event.data.slots || {};
         }

--- a/jest.conf/visual.load-test-components.js
+++ b/jest.conf/visual.load-test-components.js
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+
+import KButtonWithDropdownTest from '../lib/buttons-and-links/__tests__/components/KButtonWithDropdownTest.vue';
+
+Vue.component('KButtonWithDropdownTest', KButtonWithDropdownTest);

--- a/jest.conf/visual.load-test-components.js
+++ b/jest.conf/visual.load-test-components.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
 
-import KButtonWithDropdownTest from '../lib/buttons-and-links/__tests__/components/KButtonWithDropdownTest.vue';
+import KButtonWithDropdownTest from '~~/lib/buttons-and-links/__tests__/components/KButtonWithDropdownTest.vue';
 
 Vue.component('KButtonWithDropdownTest', KButtonWithDropdownTest);

--- a/jest.conf/visual.testUtils.js
+++ b/jest.conf/visual.testUtils.js
@@ -30,6 +30,11 @@ export async function renderComponent(component, props, slots = {}) {
     return testing_playground ? testing_playground.innerHTML : '';
   });
 
+  // Clean up the previous rendered component
+  await page.evaluate(() => {
+    window.postMessage({ type: 'RENDER_COMPONENT', component: 'div', }, '*');
+  });
+
   await page.evaluate(
     ({ component, props, slots }) => {
       window.postMessage(

--- a/jest.conf/visual.testUtils.js
+++ b/jest.conf/visual.testUtils.js
@@ -1,41 +1,6 @@
 import percySnapshot from '@percy/puppeteer';
 
 /**
- * Serializes Vue component methods to strings. This is necessary because Puppeteer cannot serialize
- * component methods like the "render" method when passing them to `page.evaluate`.
- * @param {*} component Vue component
- * @returns Component serialized with methods as strings
- */
-function serializeComponent(component) {
-  const serializedComponent = {};
-  Object.keys(component).forEach(key => {
-    if (typeof component[key] === 'function') {
-      serializedComponent[key] = component[key].toString();
-    } else {
-      serializedComponent[key] = component[key];
-    }
-  });
-  return serializedComponent;
-}
-
-/**
- * Deserializes a serialized Vue component by converting string methods back to functions.
- * @param {*} obj serialized component
- * @returns deserialized component
- */
-export function deserializeComponent(obj) {
-  const component = {};
-  Object.keys(obj).forEach(key => {
-    if (typeof obj[key] === 'string' && obj[key].startsWith('function')) {
-      component[key] = new Function(`return ${obj[key]}`)();
-    } else {
-      component[key] = obj[key];
-    }
-  });
-  return component;
-}
-
-/**
  * Renders a Vue component within the VisualTestingPlayground.
  *
  * @param {string} component - The name of the Vue component to render.
@@ -82,11 +47,7 @@ export async function renderComponent(component, props, slots = {}) {
         '*',
       );
     },
-    {
-      component: typeof component === 'object' ? serializeComponent(component) : component,
-      props,
-      slots,
-    },
+    { component, props, slots },
   );
   await page.waitForSelector('#testing-playground');
 

--- a/lib/buttons-and-links/__tests__/KButton.spec.js
+++ b/lib/buttons-and-links/__tests__/KButton.spec.js
@@ -153,6 +153,12 @@ describe('KButton', () => {
       await takeSnapshot('KButton - Dropdown Opened', snapshotOptions);
     });
 
+    it('renders correctly KDropdownMenu with header slot on click', async () => {
+      await renderComponent('KButtonWithDropdownTest');
+      await click('button');
+      await takeSnapshot('KButton - Dropdown with header opened', snapshotOptions);
+    });
+
     it('should render the default slot when provided', async () => {
       await renderComponent(
         'KButton',

--- a/lib/buttons-and-links/__tests__/components/KButtonWithDropdownTest.vue
+++ b/lib/buttons-and-links/__tests__/components/KButtonWithDropdownTest.vue
@@ -1,0 +1,27 @@
+<template>
+
+  <KButton
+    primary
+    text="KButton test"
+  >
+    <template #menu>
+      <KDropdownMenu
+        :options="[{ label: 'Option 1' }, { label: 'Option 2' }, { label: 'Option 3' }]"
+      >
+        <template #header>
+          <span style="margin: 1rem">Menu header</span>
+        </template>
+      </KDropdownMenu>
+    </template>
+  </KButton>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KButtonWithDropdownTest',
+  };
+
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,9 @@
+const plugins = ['~/plugins/load-common-components.js', '~/plugins/load-lib-components.js'];
+
+if (process.env.VISUAL_TESTING === 'true') {
+  plugins.push('~~/jest.conf/visual.load-test-components.js');
+}
+
 export default {
   mode: 'universal',
   head: {
@@ -15,7 +21,7 @@ export default {
     ],
   },
   srcDir: './docs/',
-  plugins: ['~/plugins/load-common-components.js', '~/plugins/load-lib-components.js'],
+  plugins: plugins,
   css: ['normalize.css/normalize.css', '~/assets/main'],
   modulesDir: ['node_modules', 'docs'], // allow custom DocsShowCode loader to be found
   build: {


### PR DESCRIPTION
## Description

This PR:
* Allow object components in the `renderComponent` method. This way we can render a custom test component withouth needing to register it in Vue.
* Clears the previous component that was rendered to clear context of previous test runs.
* Run visual tests on target branch after PR merge.
  * This is needed since we need the changes to run on the target branch, to have our baseline updated in Percy.
## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Allow object component rendering and unmount previoius component on render
  - **Products impact:** internal
  - **Addresses:** .
  - **Components:** .
  - **Breaking:** 
  - **Impacts a11y:** 
  - **Guidance:** 

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
