### PR TITLE
Match the hover background color of flat-button KButton to that of KIconButton

### DIFF
--- a/lib/buttons-and-links/KIconButton.vue
+++ b/lib/buttons-and-links/KIconButton.vue
@@ -108,8 +108,6 @@
     },
     computed: {
       appearanceOverrides() {
-        const hover =
-          this.appearance === 'flat-button' ? { backgroundColor: 'rgba(0,0,0,.1)' } : {};
         return {
           ...this.sizeStyles,
           // Circle
@@ -119,7 +117,6 @@
           // Remove minHeight & padding
           minHeight: '0px',
           padding: '0',
-          ':hover': hover,
         };
       },
       sizeStyles() {

--- a/lib/buttons-and-links/buttonMixin.js
+++ b/lib/buttons-and-links/buttonMixin.js
@@ -93,7 +93,7 @@ export default {
       return {
         color: this.$themeTokens.primary,
         ':hover': {
-          backgroundColor: this.$themePalette.grey.v_200,
+          backgroundColor: 'rgba(0,0,0,.1)',
         },
         ':focus': { ...this.$coreOutline, outlineOffset: 0 },
         ':disabled': disabledStyle,
@@ -120,7 +120,7 @@ export default {
       return {
         color: this.$themeTokens.text,
         ':hover': {
-          backgroundColor: this.$themePalette.grey.v_300,
+          backgroundColor: 'rgba(0,0,0,.1)',
         },
         ':focus': { ...this.$coreOutline, outlineOffset: 0 },
         ':disabled': disabledStyle,


### PR DESCRIPTION
## Description

When we have a KButton on top of non-white backgrounds, we see a gray background color on hover:

![image](https://github.com/user-attachments/assets/8a6fd3e7-b464-4148-a587-9f773ca5a1f6)

This PR fixes this by using the same black, semi transparent background color on hover that uses KIconButton:

![image](https://github.com/user-attachments/assets/0c0168d3-91b5-49a5-8c8e-1f064a3166e6)

![image](https://github.com/user-attachments/assets/e25ef75f-a9a6-474c-acc5-875b574432a2)


Note:

This is changing a little bit the hover background color when the button is on top of white backgrounds. Is there any problem with this? Should we use a higher number for the background opacity?

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/fcfc6168-0808-4d99-8857-9a9dcfec828e) | ![image](https://github.com/user-attachments/assets/7ee5b5ca-e0b4-4a5d-8453-8518b3ae0998) |

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Match the hover background color of flat-button KButton to that of KIconButton
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** KButton.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** 
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

