### PR TITLE
Bumps KDS version to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,39 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 [#918]: https://github.com/learningequality/kolibri-design-system/pull/918
 
+- [#918]
+  - **Description:** Adds new transition: `component-vertical-slide-out-in` in KTransition suitable when need to reduce vertical jarring effect during the entrance/exit of a
+component
+  - **Products impact:** new API
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/845
+  - **Components:** KTransition
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -
+
+[#918]: https://github.com/learningequality/kolibri-design-system/pull/918
+
+- [#918]
+  - **Description:** Adds new Icon: `github`
+  - **Products impact:** new icon
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/845
+  - **Components:** KIcon
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -
+
+[#918]: https://github.com/learningequality/kolibri-design-system/pull/918
+
+- [#918]
+  - **Description:** Adds new required prop for `DocsExample` component: `exampleId`
+  - **Products impact:** new API
+  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/845
+  - **Components:** -
+  - **Breaking:** no
+  - **Impacts a11y:** no
+  - **Guidance:** -
+
+[#918]: https://github.com/learningequality/kolibri-design-system/pull/918
 
 
 - [#935]
@@ -1507,7 +1540,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 [#741]: https://github.com/learningequality/kolibri-design-system/pull/751
 
 - [#650]
-  - **Description:** Add `KRadioButtonGroup` component to fix keyboard navigation in radio button groups in Firefox 
+  - **Description:** Add `KRadioButtonGroup` component to fix keyboard navigation in radio button groups in Firefox
   - **Products impact:** New API
   - **Addresses:** https://github.com/learningequality/kolibri/issues/10491
   - **Components:** `KRadioButtonGroup`
@@ -1565,9 +1598,9 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 - [705]
   - **Description:**  Update`KCard`  updates: Adds 'preserveAboveTitle`, `preserveBelowTitle`, `preserveFooter` prop for flexible  slot management.
-  - **Products impact:**  Card updates 
+  - **Products impact:**  Card updates
   - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/702
-  - **Components:** `KCard` 
+  - **Components:** `KCard`
   - **Breaking:** N0
   - **Impacts a11y:** No
   - **Guidance:**
@@ -1597,7 +1630,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 [#718]: https://github.com/learningequality/kolibri-design-system/pull/718
 
 - [#687]
-  - **Description:** Adds logic that inserts ARIA live assertive and polite regions to an application's document body during KDS initialization and documents this on the new "Installation" page. Relatedly adds `useKLiveRegion` composable with public methods for updating the live regions with assertive and polite messages. 
+  - **Description:** Adds logic that inserts ARIA live assertive and polite regions to an application's document body during KDS initialization and documents this on the new "Installation" page. Relatedly adds `useKLiveRegion` composable with public methods for updating the live regions with assertive and polite messages.
   - **Products impact:** new API
   - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/668
   - **Components:** `useKLiveRegion`
@@ -1608,10 +1641,10 @@ Changelog is rather internal in nature. See release notes for the public overvie
 [#687]: https://github.com/learningequality/kolibri-design-system/pull/687
 
 - [#688]
-  - **Description:**  Update`KCard` styling 
-  - **Products impact:**  Card updates 
-  - **Addresses:** 
-  - **Components:** `KCard` 
+  - **Description:**  Update`KCard` styling
+  - **Products impact:**  Card updates
+  - **Addresses:**
+  - **Components:** `KCard`
   - **Breaking:** N0
   - **Impacts a11y:** No
   - **Guidance:**
@@ -1620,7 +1653,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 - [#707]
   - **Description:** Card Validations
-  - **Products impact:**  
+  - **Products impact:**
   - **Addresses:** [#695](https://github.com/learningequality/kolibri-design-system/issues/695)
   - **Components:** `KCard`
   - **Breaking:** No
@@ -1630,10 +1663,10 @@ Changelog is rather internal in nature. See release notes for the public overvie
 [#707]: https://github.com/learningequality/kolibri-design-system/pull/707
 
 - [#706]
-  - **Description:** Add new alignment options to `KCard` 
-  - **Products impact:**  new alignment 
+  - **Description:** Add new alignment options to `KCard`
+  - **Products impact:**  new alignment
   - **Addresses:** [#701](https://github.com/learningequality/kolibri-design-system/issues/701)
-  - **Components:** `KCard` 
+  - **Components:** `KCard`
   - **Breaking:** N0
   - **Impacts a11y:** No
   - **Guidance:**
@@ -1642,10 +1675,10 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 
 - [#709]
-  - **Description:**  Update spaces to the latest design`KCard` 
-  - **Products impact:**  Card updates 
+  - **Description:**  Update spaces to the latest design`KCard`
+  - **Products impact:**  Card updates
   - **Addresses:** [#704](https://github.com/learningequality/kolibri-design-system/issues/704)
-  - **Components:** `KCard` 
+  - **Components:** `KCard`
   - **Breaking:** N0
   - **Impacts a11y:** No
   - **Guidance:**
@@ -1839,7 +1872,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Components:** KModal.
   - **Breaking:** no
   - **Impacts a11y:** no
-  - **Guidance:** 
+  - **Guidance:**
 
 - [#680]
   - **Description:** Fixes the calculation of overflowed items when changes in the size of the list item slots occur.
@@ -1848,7 +1881,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
   - **Components:** KListWithOverflow.
   - **Breaking:** no
   - **Impacts a11y:** no
-  - **Guidance:** 
+  - **Guidance:**
 
 [#680]: https://github.com/learningequality/kolibri-design-system/pull/680
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "repository": {


### PR DESCRIPTION
## Description
* Bumps KDS version to 5.0.1
* Adds missing changelog items of #918

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Bumps KDS version to 5.0.1
  - **Products impact:** -
  - **Addresses:** -.
  - **Components:** -.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
