### PR TITLE
KBreadcrumbs: The Unboldening

### DIFF
--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -352,7 +352,6 @@
     z-index: 8;
     max-width: 100%;
     padding: 16px;
-    font-weight: bold;
   }
 
   .breadcrumbs-dropdown-items {

--- a/lib/KBreadcrumbs.vue
+++ b/lib/KBreadcrumbs.vue
@@ -321,7 +321,6 @@
     margin-top: 8px;
     margin-bottom: 8px;
     font-size: 16px;
-    font-weight: bold;
     line-height: 32px;
     white-space: nowrap;
   }


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

#### Issue addressed
<!-- Only necessary if applicable -->

This was discussed in KDS tactical today and I went to make an issue for it and... it's just a one line change so I made a PR instead of writing the issue :smile: 

### Before/after screenshots
<!-- Insert images here if applicable -->

#### Before
![fw-bold-2](https://github.com/user-attachments/assets/a22276e5-e3a6-4d0b-852e-969503875edd)


#### After

![fw-normal-2](https://github.com/user-attachments/assets/5ba2ec54-036c-4520-bd86-422071e9d36d)


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Removes `font-weight: bold` from KBreadcrumbs
  - **Products impact:** All
  - **Addresses:** Discussion in KDS tactical
  - **Components:** KBreadcrumbs
  - **Breaking:** No
  - **Impacts a11y:** No
  - **Guidance:** This is a minor style change.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
