### PR TITLE
KCheckbox: Use flex rather than table for display

### DIFF
--- a/lib/KCheckbox.vue
+++ b/lib/KCheckbox.vue
@@ -5,7 +5,6 @@
     :class="{ 'k-checkbox-disabled': disabled }"
     @click="toggleCheck"
   >
-    <div class="tr">
       <div class="k-checkbox">
         <input
           :id="id"
@@ -64,7 +63,6 @@
           {{ description }}
         </div>
       </label>
-    </div>
   </div>
 
 </template>
@@ -194,18 +192,13 @@
   $checkbox-height: 24px;
 
   .k-checkbox-container {
-    display: table;
+    display: flex;
     margin-top: 8px;
     margin-bottom: 8px;
   }
 
-  .tr {
-    display: table-row;
-  }
-
   .k-checkbox {
     position: relative;
-    display: table-cell;
     width: $checkbox-height;
     height: $checkbox-height;
     vertical-align: top;
@@ -222,7 +215,6 @@
   }
 
   .k-checkbox-label {
-    display: table-cell;
     padding-left: 8px;
     line-height: 24px;
     cursor: pointer;


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

#### Before:

See how when the box is highlighted, there is space under it.

[Screencast_20250318_161152.webm](https://github.com/user-attachments/assets/3d2a1d67-41ee-4441-87c0-1cea754e3a39)

#### After

See how now the checkbox and its label are equal height & centered together

[Screencast_20250318_161241.webm](https://github.com/user-attachments/assets/276859e3-4142-42cd-8d17-f9835413ebc8)

#### Issue addressed
<!-- Only necessary if applicable -->

Using the table display value resulted in the checkbox icon having some unnecessary space beneath it which can make centering it bothersome when not using the label prop.

For example - [here in Kolibri](https://github.com/learningequality/kolibri/blob/280cb81aa1ebae0000cc88d70b39d0959eacc9a3/kolibri/plugins/coach/assets/src/views/quizzes/CreateExamPage/CreateQuizSection.vue#L633-L635) we have some /deep/ styling to mitigate this by moving the box itself down a bit like so:

![slumpy-checkboxes](https://github.com/user-attachments/assets/8f0c707e-a376-4c4b-971b-05de1db26004)


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Summary of change(s)
  - **Products impact:** Choose from - none (for internal updates) / bugfix / new API / updated API / removed API. If it's 'none', use "-" for all items below to indicate they are not relevant.
  - **Addresses:** Link(s) to GH issue(s) addressed. Include KDS links as well as links to related issues in a consumer product repository too.
  - **Components:** Affected public KDS component. Do not include internal sub-components or documentation components.
  - **Breaking:** Will this change break something in a consumer? Choose from: yes / no
  - **Impacts a11y:** Does this change improve a11y or adds new features that can be used to improve it? Choose from: yes / no
  - **Guidance:** Why and how to introduce this update to a consumer? Required for breaking changes, appreciated for changes with a11y impact, and welcomed for non-breaking changes when relevant.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
