### PR TITLE
Always load KImg lazily

### DIFF
--- a/docs/pages/kimg.vue
+++ b/docs/pages/kimg.vue
@@ -39,6 +39,41 @@
         dimensions are 200×114 px.
       </p>
 
+      <h3>Alternative text</h3>
+
+      <p>
+        Unless an image is
+        <DocsExternalLink
+          text="decorative"
+          href="https://www.w3.org/WAI/tutorials/images/decorative/"
+        />, you need to provide alternative text via
+        <DocsInternalLink href="/kimg#prop:altText">
+          <code>altText</code>
+        </DocsInternalLink>.
+      </p>
+
+      <DocsShowCode language="html">
+        <KImg
+          src="hummingbird.jpg"
+          altText="A sitting hummingbird"
+        />
+      </DocsShowCode>
+
+      <p>
+        If it's meant to be decorative, indicate it by using
+        <DocsInternalLink href="/kimg#prop:isDecorative">
+          <code>isDecorative</code>
+        </DocsInternalLink>. Alternative text won't be required in this case and the image will be hidden from
+        assistive technologies.
+      </p>
+
+      <DocsShowCode language="html">
+        <KImg
+          src="hummingbird.jpg"
+          isDecorative
+        />
+      </DocsShowCode>
+
       <h3>Loading</h3>
 
       <p>
@@ -100,41 +135,6 @@
           </DocsShowCode>
         </template>
       </DocsExample>
-
-      <h3>Alternative text</h3>
-
-      <p>
-        Unless an image is
-        <DocsExternalLink
-          text="decorative"
-          href="https://www.w3.org/WAI/tutorials/images/decorative/"
-        />, you need to provide alternative text via
-        <DocsInternalLink href="/kimg#prop:altText">
-          <code>altText</code>
-        </DocsInternalLink>.
-      </p>
-
-      <DocsShowCode language="html">
-        <KImg
-          src="hummingbird.jpg"
-          altText="A sitting hummingbird"
-        />
-      </DocsShowCode>
-
-      <p>
-        If it's meant to be decorative, indicate it by using
-        <DocsInternalLink href="/kimg#prop:isDecorative">
-          <code>isDecorative</code>
-        </DocsInternalLink>. Alternative text won't be required in this case and the image will be hidden from
-        assistive technologies.
-      </p>
-
-      <DocsShowCode language="html">
-        <KImg
-          src="hummingbird.jpg"
-          isDecorative
-        />
-      </DocsShowCode>
 
       <h3 id="scaling">Scaling</h3>
 

--- a/docs/pages/kimg.vue
+++ b/docs/pages/kimg.vue
@@ -39,6 +39,18 @@
         dimensions are 200×114 px.
       </p>
 
+      <h3>Loading</h3>
+
+      <p>
+        <code>KImg</code> always loads
+        <DocsExternalLink
+          text="lazily"
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#lazy"
+        />. <em>Make sure to explicitly set the width and height as accurately as possible</em> to
+        prevent layout shifts and inaccurate browser calculations, which may cause the image to not
+        display when it enters the viewport.
+      </p>
+
       <h3>Rendering within inline and block elements</h3>
 
       <h4>Inline</h4>

--- a/lib/KImg/index.vue
+++ b/lib/KImg/index.vue
@@ -6,6 +6,7 @@
         :src="src"
         :alt="alternativeText"
         :style="imgStyles"
+        loading="lazy"
         @error="onError"
         @load="onLoad"
       >


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

Based on @rtibbles suggestion, this update makes `KImg` load lazily.

## Comments

Making this option configurable didn't seem necessary - as far as I can say from our use-cases and [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#lazy) this is what we'd want to do by default.

However, there's one possible issue with this approach:

![Screenshot from 2025-03-19 16-59-08](https://github.com/user-attachments/assets/814a02a8-46dc-4f46-ac94-e9aed63ad616)

I've considered adding documentation guidance in an attempt to address this:

![Screenshot from 2025-03-19 17-56-02](https://github.com/user-attachments/assets/4776eb19-d40c-4501-ae07-9eba7797257e)

However `KImg` API doesn't currently have the way to configure `height` and `width` attributes of `<img>`. This needs to be discussed and then all places in Kolibri, Studio, and KDS that use `KImg` updated to use them.

[Slack thread](https://learningequality.slack.com/archives/CTG8XDTCL/p1742403875546469)

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Summary of change(s)
  - **Products impact:** Choose from - none (for internal updates) / bugfix / new API / updated API / removed API. If it's 'none', use "-" for all items below to indicate they are not relevant.
  - **Addresses:** Link(s) to GH issue(s) addressed. Include KDS links as well as links to related issues in a consumer product repository too.
  - **Components:** Affected public KDS component. Do not include internal sub-components or documentation components.
  - **Breaking:** Will this change break something in a consumer? Choose from: yes / no
  - **Impacts a11y:** Does this change improve a11y or adds new features that can be used to improve it? Choose from: yes / no
  - **Guidance:** Why and how to introduce this update to a consumer? Required for breaking changes, appreciated for changes with a11y impact, and welcomed for non-breaking changes when relevant.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
