### PR TITLE
Bugfix for `DocsExample`: Add check for `.vue` extension

### DIFF
--- a/docs/common/DocsExample.vue
+++ b/docs/common/DocsExample.vue
@@ -100,6 +100,9 @@
         type: String,
         required: false,
         default: null,
+        validator(value) {
+          return value === null || value.endsWith('.vue');
+        },
       },
       /**
        * Unique identifier for the example. Needs to be be unique in regards

--- a/docs/pages/kimg.vue
+++ b/docs/pages/kimg.vue
@@ -49,7 +49,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/Base"
+        loadExample="KImg/Base.vue"
         exampleId="base-inline"
       >
         <template #html>
@@ -73,7 +73,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/Base"
+        loadExample="KImg/Base.vue"
         exampleId="base-block"
         block
       >
@@ -141,7 +141,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/FitCenterInside"
+        loadExample="KImg/FitCenterInside.vue"
         exampleId="fit-center-inside"
         block
       >
@@ -169,7 +169,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/FitContain"
+        loadExample="KImg/FitContain.vue"
         exampleId="fit-contain"
         block
       >
@@ -197,7 +197,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/FitXY"
+        loadExample="KImg/FitXY.vue"
         exampleId="fit-xy"
         block
       >
@@ -233,7 +233,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/AspectRatio"
+        loadExample="KImg/AspectRatio.vue"
         exampleId="aspect-ratio"
         block
       >
@@ -267,7 +267,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/Placeholder"
+        loadExample="KImg/Placeholder.vue"
         exampleId="placeholder"
         block
       />
@@ -292,7 +292,7 @@
       </p>
 
       <DocsExample
-        loadExample="KImg/ContentOnTop"
+        loadExample="KImg/ContentOnTop.vue"
         exampleId="content-on-top"
       >
         <template #html>


### PR DESCRIPTION
## Description
- Added a validator that the `loadExample` prop is provided; it should end with a `.vue` extension
- Migrated the examples for `KImg` to correctly specify the extension

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Add validator for the extension for loadExample prop in DocsExample
  - **Products impact:** -
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** Will this change break something in a consumer? Choose from: no
  - **Impacts a11y:** no
  - **Guidance:** -
  
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
