### PR TITLE
Migrate KCard documentation to use DocsExample component

### DIFF
--- a/docs/examples/KCard/ContentSlots.vue
+++ b/docs/examples/KCard/ContentSlots.vue
@@ -1,0 +1,86 @@
+<template>
+
+  <KCardGrid
+    layout="1-1-1"
+    :skeletonsConfig="skeletonsConfig"
+    :loading="loading"
+  >
+    <KCard
+      :to="{ path: '#guidelines' }"
+      :headingLevel="4"
+      :thumbnailSrc="require('../../assets/hummingbird-large-cc-by-sa-4.jpg')"
+      thumbnailDisplay="large"
+      title="Learn everything about hummingbirds: their habitats, feeding patterns, and stunning flight abilities"
+    >
+      <template #aboveTitle>
+        <KLabeledIcon
+          icon="readSolid"
+          label="Read"
+        />
+      </template>
+      <template #belowTitle>
+        <KTextTruncator
+          text="Discover how hummingbirds play a big role in nature despite their small size. Find out more about their beauty, how they help plants grow, and where they live."
+          :maxLines="5"
+        />
+      </template>
+      <template #footer>
+        <div
+          class="pills"
+          :style="{ color: $themeTokens.annotation }"
+        >
+          <span :style="{ backgroundColor: $themePalette.grey.v_100 }"> Short Activity </span>
+          <span :style="{ backgroundColor: $themePalette.grey.v_100 }"> Biology </span>
+        </div>
+      </template>
+    </KCard>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'horizontal',
+            thumbnailDisplay: 'large',
+            thumbnailAlign: 'left',
+            height: '300px',
+          },
+          {
+            breakpoints: [3, 4, 5, 6, 7],
+            height: '190px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>
+
+
+<style scoped>
+
+  .pills {
+    margin-left: -4px;
+  }
+
+  .pills span {
+    display: inline-block;
+    padding: 4px 8px;
+    margin: 4px;
+    border-radius: 4px;
+  }
+
+</style>

--- a/docs/examples/KCard/InteractiveElements.vue
+++ b/docs/examples/KCard/InteractiveElements.vue
@@ -1,0 +1,67 @@
+<template>
+
+  <KCardGrid
+    layout="1-1-1"
+    :skeletonsConfig="skeletonsConfig"
+    :loading="loading"
+  >
+    <DocsKCard
+      :headingLevel="4"
+      :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
+      thumbnailDisplay="large"
+      thumbnailAlign="right"
+    >
+      <template #footer>
+        <KIconButton
+          ariaLabel="Bookmark resource"
+          :icon="isBookmarked ? 'bookmark' : 'bookmarkEmpty'"
+          @click.stop="isBookmarked = !isBookmarked"
+        />
+      </template>
+    </DocsKCard>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  import useKResponsiveWindow from '../../../lib/composables/useKResponsiveWindow';
+
+  export default {
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return { windowBreakpoint };
+    },
+    data() {
+      return {
+        isBookmarked: false,
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'vertical',
+            thumbnailDisplay: 'large',
+            height: '460px',
+          },
+          {
+            breakpoints: [2],
+            height: '390px',
+          },
+          {
+            breakpoints: [3, 4, 5, 6, 7],
+            orientation: 'horizontal',
+            thumbnailAlign: 'right',
+            height: '170px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>

--- a/docs/examples/KCard/InteractiveElements.vue
+++ b/docs/examples/KCard/InteractiveElements.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :headingLevel="4"
       :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
       thumbnailDisplay="large"
@@ -18,7 +18,7 @@
           @click.stop="isBookmarked = !isBookmarked"
         />
       </template>
-    </DocsKCard>
+    </Card>
   </KCardGrid>
 
 </template>

--- a/docs/examples/KCard/Layout1.vue
+++ b/docs/examples/KCard/Layout1.vue
@@ -1,0 +1,124 @@
+<template>
+
+  <div class="card-container">
+    <KCardGrid
+      layout="1-2-3"
+      :skeletonsConfig="skeletonsConfig"
+      :loading="loading"
+    >
+      <DocsKCard
+        :headingLevel="4"
+        orientation="vertical"
+        thumbnailDisplay="large"
+        prependTitle="(1)"
+      >
+        <template #aboveTitle>
+          <KLabeledIcon
+            icon="readSolid"
+            label="Read"
+          />
+        </template>
+        <template #footer>
+          <div
+            class="pills"
+            :style="{ color: $themeTokens.annotation }"
+          >
+            <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Short Activity </span>
+            <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Biology </span>
+          </div>
+        </template>
+      </DocsKCard>
+      <DocsKCard
+        :headingLevel="4"
+        orientation="vertical"
+        thumbnailDisplay="large"
+        :thumbnailSrc="null"
+        prependTitle="(2)"
+      >
+        <template #aboveTitle>
+          <KLabeledIcon
+            icon="readSolid"
+            label="Read"
+          />
+        </template>
+        <template #footer>
+          <div
+            class="pills"
+            :style="{ color: $themeTokens.annotation }"
+          >
+            <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Short Activity </span>
+          </div>
+        </template>
+      </DocsKCard>
+      <DocsKCard
+        :headingLevel="4"
+        orientation="vertical"
+        thumbnailDisplay="small"
+        prependTitle="(3)"
+        hideFooter
+      >
+        <template #aboveTitle>
+          <KLabeledIcon
+            icon="readSolid"
+            label="Read"
+          />
+        </template>
+      </DocsKCard>
+    </KCardGrid>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'vertical',
+            thumbnailDisplay: 'large',
+            height: '490px',
+          },
+          {
+            breakpoints: [3, 4, 5, 6, 7],
+            height: '420px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>
+
+
+<style scoped>
+
+  .card-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 20px;
+    margin: 20px;
+  }
+
+  .pills {
+    margin-left: -4px;
+  }
+
+  .pills span {
+    display: inline-block;
+    padding: 4px 8px;
+    margin: 4px;
+    border-radius: 4px;
+  }
+
+</style>

--- a/docs/examples/KCard/Layout1.vue
+++ b/docs/examples/KCard/Layout1.vue
@@ -1,71 +1,69 @@
 <template>
 
-  <div class="card-container">
-    <KCardGrid
-      layout="1-2-3"
-      :skeletonsConfig="skeletonsConfig"
-      :loading="loading"
+  <KCardGrid
+    layout="1-2-3"
+    :skeletonsConfig="skeletonsConfig"
+    :loading="loading"
+  >
+    <DocsKCard
+      :headingLevel="4"
+      orientation="vertical"
+      thumbnailDisplay="large"
+      prependTitle="(1)"
     >
-      <DocsKCard
-        :headingLevel="4"
-        orientation="vertical"
-        thumbnailDisplay="large"
-        prependTitle="(1)"
-      >
-        <template #aboveTitle>
-          <KLabeledIcon
-            icon="readSolid"
-            label="Read"
-          />
-        </template>
-        <template #footer>
-          <div
-            class="pills"
-            :style="{ color: $themeTokens.annotation }"
-          >
-            <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Short Activity </span>
-            <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Biology </span>
-          </div>
-        </template>
-      </DocsKCard>
-      <DocsKCard
-        :headingLevel="4"
-        orientation="vertical"
-        thumbnailDisplay="large"
-        :thumbnailSrc="null"
-        prependTitle="(2)"
-      >
-        <template #aboveTitle>
-          <KLabeledIcon
-            icon="readSolid"
-            label="Read"
-          />
-        </template>
-        <template #footer>
-          <div
-            class="pills"
-            :style="{ color: $themeTokens.annotation }"
-          >
-            <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Short Activity </span>
-          </div>
-        </template>
-      </DocsKCard>
-      <DocsKCard
-        :headingLevel="4"
-        orientation="vertical"
-        thumbnailDisplay="small"
-        prependTitle="(3)"
-        hideFooter
-      >
-        <template #aboveTitle>
-          <KLabeledIcon
-            icon="readSolid"
-            label="Read"
-          />
-        </template>
-      </DocsKCard>
-    </KCardGrid>
-  </div>
+      <template #aboveTitle>
+        <KLabeledIcon
+          icon="readSolid"
+          label="Read"
+        />
+      </template>
+      <template #footer>
+        <div
+          class="pills"
+          :style="{ color: $themeTokens.annotation }"
+        >
+          <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Short Activity </span>
+          <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Biology </span>
+        </div>
+      </template>
+    </DocsKCard>
+    <DocsKCard
+      :headingLevel="4"
+      orientation="vertical"
+      thumbnailDisplay="large"
+      :thumbnailSrc="null"
+      prependTitle="(2)"
+    >
+      <template #aboveTitle>
+        <KLabeledIcon
+          icon="readSolid"
+          label="Read"
+        />
+      </template>
+      <template #footer>
+        <div
+          class="pills"
+          :style="{ color: $themeTokens.annotation }"
+        >
+          <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Short Activity </span>
+        </div>
+      </template>
+    </DocsKCard>
+    <DocsKCard
+      :headingLevel="4"
+      orientation="vertical"
+      thumbnailDisplay="small"
+      prependTitle="(3)"
+      hideFooter
+    >
+      <template #aboveTitle>
+        <KLabeledIcon
+          icon="readSolid"
+          label="Read"
+        />
+      </template>
+    </DocsKCard>
+  </KCardGrid>
 
 </template>
 
@@ -101,14 +99,6 @@
 
 
 <style scoped>
-
-  .card-container {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    padding: 20px;
-    margin: 20px;
-  }
 
   .pills {
     margin-left: -4px;

--- a/docs/examples/KCard/Layout1.vue
+++ b/docs/examples/KCard/Layout1.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :headingLevel="4"
       orientation="vertical"
       thumbnailDisplay="large"
@@ -26,8 +26,8 @@
           <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Biology </span>
         </div>
       </template>
-    </DocsKCard>
-    <DocsKCard
+    </Card>
+    <Card
       :headingLevel="4"
       orientation="vertical"
       thumbnailDisplay="large"
@@ -48,8 +48,8 @@
           <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Short Activity </span>
         </div>
       </template>
-    </DocsKCard>
-    <DocsKCard
+    </Card>
+    <Card
       :headingLevel="4"
       orientation="vertical"
       thumbnailDisplay="small"
@@ -62,7 +62,7 @@
           label="Read"
         />
       </template>
-    </DocsKCard>
+    </Card>
   </KCardGrid>
 
 </template>

--- a/docs/examples/KCard/Layout2.vue
+++ b/docs/examples/KCard/Layout2.vue
@@ -2,10 +2,10 @@
 
   <KCardGrid
     layout="1-2-2"
-    :skeletonsConfig="skeletonsConfig3"
+    :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :headingLevel="4"
       orientation="horizontal"
       thumbnailDisplay="large"
@@ -13,7 +13,7 @@
       thumbnailAlign="left"
       prependTitle="(1)"
     />
-    <DocsKCard
+    <Card
       :headingLevel="4"
       orientation="horizontal"
       thumbnailDisplay="small"

--- a/docs/examples/KCard/Layout2.vue
+++ b/docs/examples/KCard/Layout2.vue
@@ -1,29 +1,27 @@
 <template>
 
-  <div class="card-container">
-    <KCardGrid
-      layout="1-2-2"
-      :skeletonsConfig="skeletonsConfig3"
-      :loading="loading"
-    >
-      <DocsKCard
-        :headingLevel="4"
-        orientation="horizontal"
-        thumbnailDisplay="large"
-        :thumbnailSrc="null"
-        thumbnailAlign="left"
-        prependTitle="(1)"
-      />
-      <DocsKCard
-        :headingLevel="4"
-        orientation="horizontal"
-        thumbnailDisplay="small"
-        thumbnailAlign="right"
-        prependTitle="(2)"
-        showProgressInFooter
-      />
-    </KCardGrid>
-  </div>
+  <KCardGrid
+    layout="1-2-2"
+    :skeletonsConfig="skeletonsConfig3"
+    :loading="loading"
+  >
+    <DocsKCard
+      :headingLevel="4"
+      orientation="horizontal"
+      thumbnailDisplay="large"
+      :thumbnailSrc="null"
+      thumbnailAlign="left"
+      prependTitle="(1)"
+    />
+    <DocsKCard
+      :headingLevel="4"
+      orientation="horizontal"
+      thumbnailDisplay="small"
+      thumbnailAlign="right"
+      prependTitle="(2)"
+      showProgressInFooter
+    />
+  </KCardGrid>
 
 </template>
 
@@ -59,14 +57,6 @@
 
 
 <style scoped>
-
-  .card-container {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    padding: 20px;
-    margin: 20px;
-  }
 
   .pills {
     margin-left: -4px;

--- a/docs/examples/KCard/Layout2.vue
+++ b/docs/examples/KCard/Layout2.vue
@@ -1,0 +1,82 @@
+<template>
+
+  <div class="card-container">
+    <KCardGrid
+      layout="1-2-2"
+      :skeletonsConfig="skeletonsConfig3"
+      :loading="loading"
+    >
+      <DocsKCard
+        :headingLevel="4"
+        orientation="horizontal"
+        thumbnailDisplay="large"
+        :thumbnailSrc="null"
+        thumbnailAlign="left"
+        prependTitle="(1)"
+      />
+      <DocsKCard
+        :headingLevel="4"
+        orientation="horizontal"
+        thumbnailDisplay="small"
+        thumbnailAlign="right"
+        prependTitle="(2)"
+        showProgressInFooter
+      />
+    </KCardGrid>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'vertical',
+            thumbnailDisplay: 'large',
+            height: '490px',
+          },
+          {
+            breakpoints: [3, 4, 5, 6, 7],
+            height: '420px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>
+
+
+<style scoped>
+
+  .card-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 20px;
+    margin: 20px;
+  }
+
+  .pills {
+    margin-left: -4px;
+  }
+
+  .pills span {
+    display: inline-block;
+    padding: 4px 8px;
+    margin: 4px;
+    border-radius: 4px;
+  }
+
+</style>

--- a/docs/examples/KCard/Layout3.vue
+++ b/docs/examples/KCard/Layout3.vue
@@ -1,37 +1,35 @@
 <template>
 
-  <div class="card-container">
-    <KCardGrid
-      layout="1-2-3"
-      :skeletonsConfig="skeletonsConfig4"
-      :loading="loading"
+  <KCardGrid
+    layout="1-2-3"
+    :skeletonsConfig="skeletonsConfig4"
+    :loading="loading"
+  >
+    <DocsKCard
+      :headingLevel="4"
+      orientation="vertical"
+      thumbnailDisplay="none"
+      prependTitle="(1)"
+    />
+    <DocsKCard
+      :headingLevel="4"
+      orientation="vertical"
+      thumbnailDisplay="none"
+      prependTitle="(2)"
+      showProgressInFooter
     >
-      <DocsKCard
-        :headingLevel="4"
-        orientation="vertical"
-        thumbnailDisplay="none"
-        prependTitle="(1)"
-      />
-      <DocsKCard
-        :headingLevel="4"
-        orientation="vertical"
-        thumbnailDisplay="none"
-        prependTitle="(2)"
-        showProgressInFooter
-      >
-        <template #footer>
-          <span></span>
-        </template>
-      </DocsKCard>
-      <DocsKCard
-        :headingLevel="4"
-        orientation="vertical"
-        thumbnailDisplay="none"
-        prependTitle="(3)"
-        showMenuInFooter
-      />
-    </KCardGrid>
-  </div>
+      <template #footer>
+        <span></span>
+      </template>
+    </DocsKCard>
+    <DocsKCard
+      :headingLevel="4"
+      orientation="vertical"
+      thumbnailDisplay="none"
+      prependTitle="(3)"
+      showMenuInFooter
+    />
+  </KCardGrid>
 
 </template>
 
@@ -67,14 +65,6 @@
 
 
 <style scoped>
-
-  .card-container {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    padding: 20px;
-    margin: 20px;
-  }
 
   .pills {
     margin-left: -4px;

--- a/docs/examples/KCard/Layout3.vue
+++ b/docs/examples/KCard/Layout3.vue
@@ -2,16 +2,16 @@
 
   <KCardGrid
     layout="1-2-3"
-    :skeletonsConfig="skeletonsConfig4"
+    :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :headingLevel="4"
       orientation="vertical"
       thumbnailDisplay="none"
       prependTitle="(1)"
     />
-    <DocsKCard
+    <Card
       :headingLevel="4"
       orientation="vertical"
       thumbnailDisplay="none"
@@ -21,8 +21,8 @@
       <template #footer>
         <span></span>
       </template>
-    </DocsKCard>
-    <DocsKCard
+    </Card>
+    <Card
       :headingLevel="4"
       orientation="vertical"
       thumbnailDisplay="none"

--- a/docs/examples/KCard/Layout3.vue
+++ b/docs/examples/KCard/Layout3.vue
@@ -1,0 +1,90 @@
+<template>
+
+  <div class="card-container">
+    <KCardGrid
+      layout="1-2-3"
+      :skeletonsConfig="skeletonsConfig4"
+      :loading="loading"
+    >
+      <DocsKCard
+        :headingLevel="4"
+        orientation="vertical"
+        thumbnailDisplay="none"
+        prependTitle="(1)"
+      />
+      <DocsKCard
+        :headingLevel="4"
+        orientation="vertical"
+        thumbnailDisplay="none"
+        prependTitle="(2)"
+        showProgressInFooter
+      >
+        <template #footer>
+          <span></span>
+        </template>
+      </DocsKCard>
+      <DocsKCard
+        :headingLevel="4"
+        orientation="vertical"
+        thumbnailDisplay="none"
+        prependTitle="(3)"
+        showMenuInFooter
+      />
+    </KCardGrid>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'vertical',
+            thumbnailDisplay: 'large',
+            height: '490px',
+          },
+          {
+            breakpoints: [3, 4, 5, 6, 7],
+            height: '420px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>
+
+
+<style scoped>
+
+  .card-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    padding: 20px;
+    margin: 20px;
+  }
+
+  .pills {
+    margin-left: -4px;
+  }
+
+  .pills span {
+    display: inline-block;
+    padding: 4px 8px;
+    margin: 4px;
+    border-radius: 4px;
+  }
+
+</style>

--- a/docs/examples/KCard/Placeholder.vue
+++ b/docs/examples/KCard/Placeholder.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :headingLevel="4"
       :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
       thumbnailDisplay="large"

--- a/docs/examples/KCard/Placeholder.vue
+++ b/docs/examples/KCard/Placeholder.vue
@@ -1,0 +1,59 @@
+<template>
+
+  <KCardGrid
+    layout="1-1-1"
+    :skeletonsConfig="skeletonsConfig"
+    :loading="loading"
+  >
+    <DocsKCard
+      :headingLevel="4"
+      :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
+      thumbnailDisplay="large"
+      thumbnailAlign="right"
+      :thumbnailSrc="null"
+    />
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  import useKResponsiveWindow from '../../../lib/composables/useKResponsiveWindow';
+
+  export default {
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return { windowBreakpoint };
+    },
+    data() {
+      return {
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'vertical',
+            thumbnailDisplay: 'large',
+            height: '460px',
+          },
+          {
+            breakpoints: [2],
+            height: '390px',
+          },
+          {
+            breakpoints: [3, 4, 5, 6, 7],
+            orientation: 'horizontal',
+            thumbnailAlign: 'right',
+            height: '170px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>

--- a/docs/examples/KCard/SelectionControls.vue
+++ b/docs/examples/KCard/SelectionControls.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :to="{ path: '#guidelines' }"
       :headingLevel="4"
       :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
@@ -28,9 +28,9 @@
           @click.stop="isBookmarked1 = !isBookmarked1"
         />
       </template>
-    </DocsKCard>
+    </Card>
 
-    <DocsKCard
+    <Card
       :to="{ path: '#guidelines' }"
       :headingLevel="4"
       :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
@@ -53,7 +53,7 @@
           @click.stop="isBookmarked2 = !isBookmarked2"
         />
       </template>
-    </DocsKCard>
+    </Card>
   </KCardGrid>
 
 </template>

--- a/docs/examples/KCard/SelectionControls.vue
+++ b/docs/examples/KCard/SelectionControls.vue
@@ -1,0 +1,105 @@
+<template>
+
+  <KCardGrid
+    layout="1-1-1"
+    :skeletonsConfig="skeletonsConfig"
+    :loading="loading"
+  >
+    <DocsKCard
+      :to="{ path: '#guidelines' }"
+      :headingLevel="4"
+      :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
+      thumbnailDisplay="large"
+      thumbnailAlign="right"
+      title="First card"
+    >
+      <template #select>
+        <KCheckbox
+          :checked="isFirstCardChecked"
+          @change="isFirstCardChecked = !isFirstCardChecked"
+        >
+          <span class="visuallyhidden">Select 'First card'</span>
+        </KCheckbox>
+      </template>
+      <template #footer>
+        <KIconButton
+          ariaLabel="Bookmark resource"
+          :icon="isBookmarked1 ? 'bookmark' : 'bookmarkEmpty'"
+          @click.stop="isBookmarked1 = !isBookmarked1"
+        />
+      </template>
+    </DocsKCard>
+
+    <DocsKCard
+      :to="{ path: '#guidelines' }"
+      :headingLevel="4"
+      :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
+      thumbnailDisplay="large"
+      thumbnailAlign="right"
+      title="Second card"
+    >
+      <template #select>
+        <KCheckbox
+          :checked="isSecondCardChecked"
+          @change="isSecondCardChecked = !isSecondCardChecked"
+        >
+          <span class="visuallyhidden">Select 'Second card'</span>
+        </KCheckbox>
+      </template>
+      <template #footer>
+        <KIconButton
+          ariaLabel="Bookmark resource"
+          :icon="isBookmarked2 ? 'bookmark' : 'bookmarkEmpty'"
+          @click.stop="isBookmarked2 = !isBookmarked2"
+        />
+      </template>
+    </DocsKCard>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  import useKResponsiveWindow from '../../../lib/composables/useKResponsiveWindow';
+
+  export default {
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return { windowBreakpoint };
+    },
+    data() {
+      return {
+        isBookmarked1: false,
+        isBookmarked2: false,
+        isFirstCardChecked: false,
+        isSecondCardChecked: false,
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'vertical',
+            thumbnailDisplay: 'large',
+            height: '400px',
+          },
+          {
+            breakpoints: [2],
+            height: '380px',
+          },
+          {
+            breakpoints: [3, 4, 5, 6, 7],
+            orientation: 'horizontal',
+            thumbnailAlign: 'right',
+            height: '180px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>

--- a/docs/examples/KCard/Title.vue
+++ b/docs/examples/KCard/Title.vue
@@ -1,0 +1,54 @@
+<template>
+
+  <KCardGrid
+    layout="1-1-1"
+    :skeletonsConfig="skeletonsConfig"
+    :loading="loading"
+  >
+    <DocsKCard
+      :headingLevel="3"
+      orientation="horizontal"
+      thumbnailDisplay="small"
+      thumbnailAlign="right"
+      prependTitle="(1)"
+      hideFooter
+    >
+      <template #title="{ titleText }">
+        <KLabeledIcon icon="readSolid">
+          <KTextTruncator
+            :text="titleText"
+            :maxLines="1"
+          />
+        </KLabeledIcon>
+      </template>
+    </DocsKCard>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        loading: true,
+        skeletonsConfig: [
+          {
+            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
+            orientation: 'horizontal',
+            thumbnailDisplay: 'small',
+            thumbnailAlign: 'right',
+            height: '130px',
+          },
+        ],
+      };
+    },
+    mounted() {
+      setTimeout(() => {
+        this.loading = false;
+      }, 3000);
+    },
+  };
+
+</script>

--- a/docs/examples/KCard/Title.vue
+++ b/docs/examples/KCard/Title.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :headingLevel="3"
       orientation="horizontal"
       thumbnailDisplay="small"
@@ -21,7 +21,7 @@
           />
         </KLabeledIcon>
       </template>
-    </DocsKCard>
+    </Card>
   </KCardGrid>
 
 </template>

--- a/docs/examples/KCardGrid/BasicGrids/1-1-1.vue
+++ b/docs/examples/KCardGrid/BasicGrids/1-1-1.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       v-for="i in 2"
       :key="i"
       :headingLevel="5"

--- a/docs/examples/KCardGrid/BasicGrids/1-2-2.vue
+++ b/docs/examples/KCardGrid/BasicGrids/1-2-2.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       v-for="i in 3"
       :key="i"
       :headingLevel="5"

--- a/docs/examples/KCardGrid/BasicGrids/1-2-3.vue
+++ b/docs/examples/KCardGrid/BasicGrids/1-2-3.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       v-for="i in 5"
       :key="i"
       :headingLevel="5"

--- a/docs/examples/KCardGrid/CardHeightAlignment.vue
+++ b/docs/examples/KCardGrid/CardHeightAlignment.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig5"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       :headingLevel="4"
       preserveAboveTitle
     >
@@ -45,9 +45,9 @@
           </span>
         </div>
       </template>
-    </DocsKCard>
+    </Card>
 
-    <DocsKCard
+    <Card
       :headingLevel="4"
       preserveAboveTitle
     >
@@ -76,9 +76,9 @@
       <template #footer>
         <div></div>
       </template>
-    </DocsKCard>
+    </Card>
 
-    <DocsKCard
+    <Card
       :headingLevel="4"
       preserveAboveTitle
     >
@@ -113,7 +113,7 @@
           </span>
         </div>
       </template>
-    </DocsKCard>
+    </Card>
   </KCardGrid>
 
 </template>

--- a/docs/examples/KCardGrid/LayoutOverride.vue
+++ b/docs/examples/KCardGrid/LayoutOverride.vue
@@ -6,7 +6,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       v-for="i in 6"
       :key="i"
       :headingLevel="6"

--- a/docs/examples/KCardGrid/LoadingState.vue
+++ b/docs/examples/KCardGrid/LoadingState.vue
@@ -30,7 +30,7 @@
       :loading="loading"
       :debug="debug"
     >
-      <DocsKCard
+      <Card
         v-for="i in 3"
         :key="i"
         :headingLevel="4"

--- a/docs/examples/KCardGrid/ResponsiveFooter.vue
+++ b/docs/examples/KCardGrid/ResponsiveFooter.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       v-for="i in 2"
       :key="i"
       :headingLevel="4"
@@ -73,7 +73,7 @@
           </template>
         </div>
       </template>
-    </DocsKCard>
+    </Card>
   </KCardGrid>
 
 </template>

--- a/docs/examples/KCardGrid/ResponsiveOrientation.vue
+++ b/docs/examples/KCardGrid/ResponsiveOrientation.vue
@@ -5,7 +5,7 @@
     :skeletonsConfig="skeletonsConfig"
     :loading="loading"
   >
-    <DocsKCard
+    <Card
       v-for="i in 2"
       :key="i"
       :headingLevel="4"

--- a/docs/examples/common/Card.vue
+++ b/docs/examples/common/Card.vue
@@ -7,7 +7,7 @@
     :thumbnailDisplay="thumbnailDisplay"
     :thumbnailAlign="thumbnailAlign"
     :thumbnailSrc="
-      thumbnailSrc === null ? null : require('../assets/hummingbird-large-cc-by-sa-4.jpg')
+      thumbnailSrc === null ? null : require('~/assets/hummingbird-large-cc-by-sa-4.jpg')
     "
     :title="cardTitle"
   >

--- a/docs/pages-components/README.md
+++ b/docs/pages-components/README.md
@@ -1,1 +1,0 @@
-This is a directory for sub-components used in `pages` (if we placed them to `pages`, they'd be accessible as pages in the generated documentation which is not desired)

--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -25,7 +25,7 @@
           :skeletonsConfig="skeletonsConfig"
           :loading="loading"
         >
-          <DocsKCard
+          <Card
             :headingLevel="3"
             :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
             thumbnailDisplay="large"
@@ -416,94 +416,89 @@
         diverse kinds of content:
       </p>
 
-      <DocsShow
-        block
-        :style="{ width: '100%', maxWidth: 'none' }"
+      <h4>Layout 1: Vertical with Large and Small Thumbnails</h4>
+      <DocsExample
+        loadExample="KCard/Layout1.vue"
+        exampleId="kcard-layout"
       >
-        <h4>Layout 1: Vertical with Large and Small Thumbnails</h4>
-        <DocsExample
-          loadExample="KCard/Layout1.vue"
-          exampleId="kcard-layout"
-        >
-          <template #html>
-            <!-- eslint-disable -->
+        <template #html>
+          <!-- eslint-disable -->
 
-            <DocsShowCode language="html">
-              <KCardGrid ...>
-                <KCard
-                  ...
-                  orientation="vertical"
-                  thumbnailDisplay="large"
-                />
-                <KCard
-                  ...
-                  orientation="vertical"
-                  thumbnailDisplay="large"
-                />
-                <KCard
-                  ...
-                  orientation="vertical"
-                  thumbnailDisplay="small"
-                />
-              </KCardGrid>
-            </DocsShowCode>
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard
+                ...
+                orientation="vertical"
+                thumbnailDisplay="large"
+              />
+              <KCard
+                ...
+                orientation="vertical"
+                thumbnailDisplay="large"
+              />
+              <KCard
+                ...
+                orientation="vertical"
+                thumbnailDisplay="small"
+              />
+            </KCardGrid>
+          </DocsShowCode>
 
-            <!-- eslint-enable -->
-          </template>
-        </DocsExample>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
 
-        <h4>Layout 2: Horizontal with Large and Small Thumbnails</h4>
-        <DocsExample
-          loadExample="KCard/Layout2.vue"
-          exampleId="kcard-layout"
-        >
-          <template #html>
-            <!-- eslint-disable -->
+      <h4>Layout 2: Horizontal with Large and Small Thumbnails</h4>
+      <DocsExample
+        loadExample="KCard/Layout2.vue"
+        exampleId="kcard-layout"
+      >
+        <template #html>
+          <!-- eslint-disable -->
 
-            <DocsShowCode language="html">
-              <KCardGrid ...>
-                <KCard
-                  ...
-                  orientation="horizontal"
-                  thumbnailDisplay="large"
-                  thumbnailAlign="left"
-                />
-                <KCard
-                  ...
-                  orientation="horizontal"
-                  thumbnailDisplay="small"
-                  thumbnailAlign="right"
-                />
-              </KCardGrid>
-            </DocsShowCode>
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard
+                ...
+                orientation="horizontal"
+                thumbnailDisplay="large"
+                thumbnailAlign="left"
+              />
+              <KCard
+                ...
+                orientation="horizontal"
+                thumbnailDisplay="small"
+                thumbnailAlign="right"
+              />
+            </KCardGrid>
+          </DocsShowCode>
 
-            <!-- eslint-enable -->
-          </template>
-        </DocsExample>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
 
-        <h4>Layout 3: Vertical without Thumbnails</h4>
-        <DocsExample
-          loadExample="KCard/Layout3.vue"
-          exampleId="kcard-layout"
-        >
-          <template #html>
-            <!-- eslint-disable -->
+      <h4>Layout 3: Vertical without Thumbnails</h4>
+      <DocsExample
+        loadExample="KCard/Layout3.vue"
+        exampleId="kcard-layout"
+      >
+        <template #html>
+          <!-- eslint-disable -->
 
-            <DocsShowCode language="html">
-              <KCardGrid ...>
-                <KCard
-                  ...
-                  v-for="i in 3"
-                  orientation="vertical"
-                  thumbnailDisplay="none"
-                />
-              </KCardGrid>
-            </DocsShowCode>
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard
+                ...
+                v-for="i in 3"
+                orientation="vertical"
+                thumbnailDisplay="none"
+              />
+            </KCardGrid>
+          </DocsShowCode>
 
-            <!-- eslint-enable -->
-          </template>
-        </DocsExample>
-      </DocsShow>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
 
       <h3>
         Responsiveness

--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -22,7 +22,7 @@
       >
         <KCardGrid
           layout="1-1-1"
-          :skeletonsConfig="skeletonsConfig1"
+          :skeletonsConfig="skeletonsConfig"
           :loading="loading"
         >
           <DocsKCard
@@ -242,57 +242,34 @@
         customize the title.
       </p>
 
-      <DocsShow
+      <DocsExample
+        loadExample="KCard/Title.vue"
+        exampleId="kcard-title"
         block
-        :style="{ maxWidth: '600px' }"
       >
-        <KCardGrid
-          layout="1-1-1"
-          :skeletonsConfig="skeletonsConfig9"
-          :loading="loading"
-        >
-          <DocsKCard
-            :headingLevel="3"
-            orientation="horizontal"
-            thumbnailDisplay="small"
-            thumbnailAlign="right"
-            prependTitle="(1)"
-            hideFooter
-          >
-            <template #title="{ titleText }">
-              <KLabeledIcon icon="readSolid">
-                <KTextTruncator
-                  :text="titleText"
-                  :maxLines="1"
-                />
-              </KLabeledIcon>
+        <template #html>
+          <DocsShowCode language="html">
+            <template>
+              <KCardGrid>
+                <KCard
+                  :headingLevel="3"
+                  title="(1) Learn everything about hummingbirds: their habitats, feeding patterns, and stunning flight abilities"
+                  ...
+                >
+                  <template #title="{ titleText }">
+                    <KLabeledIcon icon="readSolid">
+                      <KTextTruncator
+                        :text="titleText"
+                        :maxLines="1"
+                      />
+                    </KLabeledIcon>
+                  </template>
+                </KCard>
+              </KCardGrid>
             </template>
-          </DocsKCard>
-        </KCardGrid>
-      </DocsShow>
-
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <template>
-          <KCardGrid>
-            <KCard
-              :headingLevel="3"
-              title="(1) Learn everything about hummingbirds: their habitats, feeding patterns, and stunning flight abilities"
-              ...
-            >
-              <template #title="{ titleText }">
-                <KLabeledIcon icon="readSolid">
-                  <KTextTruncator
-                    :text="titleText"
-                    :maxLines="1"
-                  />
-                </KLabeledIcon>
-              </template>
-            </KCard>
-          </KCardGrid>
+          </DocsShowCode>
         </template>
-      </DocsShowCode>
-      <!-- eslint-enable -->
+      </DocsExample>
 
       <p>
         <em>Do not use a heading element within the <code>title</code> slot to avoid duplicate
@@ -439,180 +416,94 @@
         diverse kinds of content:
       </p>
 
-      <DocsShow block>
-        <KCardGrid
-          layout="1-2-3"
-          :skeletonsConfig="skeletonsConfig2"
-          :loading="loading"
+      <DocsShow
+        block
+        :style="{ width: '100%', maxWidth: 'none' }"
+      >
+        <h4>Layout 1: Vertical with Large and Small Thumbnails</h4>
+        <DocsExample
+          loadExample="KCard/Layout1.vue"
+          exampleId="kcard-layout"
         >
-          <DocsKCard
-            :headingLevel="4"
-            orientation="vertical"
-            thumbnailDisplay="large"
-            prependTitle="(1)"
-          >
-            <template #aboveTitle>
-              <KLabeledIcon
-                icon="readSolid"
-                label="Read"
-              />
-            </template>
-            <template #footer>
-              <div
-                class="pills"
-                :style="{ color: $themeTokens.annotation }"
-              >
-                <span :style="{ 'background-color': $themePalette.grey.v_100 }">
-                  Short Activity
-                </span>
-                <span :style="{ 'background-color': $themePalette.grey.v_100 }"> Biology </span>
-              </div>
-            </template>
-          </DocsKCard>
-          <DocsKCard
-            :headingLevel="4"
-            orientation="vertical"
-            thumbnailDisplay="large"
-            :thumbnailSrc="null"
-            prependTitle="(2)"
-          >
-            <template #aboveTitle>
-              <KLabeledIcon
-                icon="readSolid"
-                label="Read"
-              />
-            </template>
-            <template #footer>
-              <div
-                class="pills"
-                :style="{ color: $themeTokens.annotation }"
-              >
-                <span :style="{ 'background-color': $themePalette.grey.v_100 }">
-                  Short Activity
-                </span>
-              </div>
-            </template>
-          </DocsKCard>
-          <DocsKCard
-            :headingLevel="4"
-            orientation="vertical"
-            thumbnailDisplay="small"
-            prependTitle="(3)"
-            hideFooter
-          >
-            <template #aboveTitle>
-              <KLabeledIcon
-                icon="readSolid"
-                label="Read"
-              />
-            </template>
-          </DocsKCard>
-        </KCardGrid>
-      </DocsShow>
+          <template #html>
+            <!-- eslint-disable -->
 
-      <DocsShow block>
-        <KCardGrid
-          layout="1-2-2"
-          :skeletonsConfig="skeletonsConfig3"
-          :loading="loading"
+            <DocsShowCode language="html">
+              <KCardGrid ...>
+                <KCard
+                  ...
+                  orientation="vertical"
+                  thumbnailDisplay="large"
+                />
+                <KCard
+                  ...
+                  orientation="vertical"
+                  thumbnailDisplay="large"
+                />
+                <KCard
+                  ...
+                  orientation="vertical"
+                  thumbnailDisplay="small"
+                />
+              </KCardGrid>
+            </DocsShowCode>
+
+            <!-- eslint-enable -->
+          </template>
+        </DocsExample>
+
+        <h4>Layout 2: Horizontal with Large and Small Thumbnails</h4>
+        <DocsExample
+          loadExample="KCard/Layout2.vue"
+          exampleId="kcard-layout"
         >
-          <DocsKCard
-            :headingLevel="4"
-            orientation="horizontal"
-            thumbnailDisplay="large"
-            :thumbnailSrc="null"
-            thumbnailAlign="left"
-            prependTitle="(1)"
-          />
-          <DocsKCard
-            :headingLevel="4"
-            orientation="horizontal"
-            thumbnailDisplay="small"
-            thumbnailAlign="right"
-            prependTitle="(2)"
-            showProgressInFooter
-          />
-        </KCardGrid>
-      </DocsShow>
+          <template #html>
+            <!-- eslint-disable -->
 
-      <DocsShow block>
-        <KCardGrid
-          layout="1-2-3"
-          :skeletonsConfig="skeletonsConfig4"
-          :loading="loading"
+            <DocsShowCode language="html">
+              <KCardGrid ...>
+                <KCard
+                  ...
+                  orientation="horizontal"
+                  thumbnailDisplay="large"
+                  thumbnailAlign="left"
+                />
+                <KCard
+                  ...
+                  orientation="horizontal"
+                  thumbnailDisplay="small"
+                  thumbnailAlign="right"
+                />
+              </KCardGrid>
+            </DocsShowCode>
+
+            <!-- eslint-enable -->
+          </template>
+        </DocsExample>
+
+        <h4>Layout 3: Vertical without Thumbnails</h4>
+        <DocsExample
+          loadExample="KCard/Layout3.vue"
+          exampleId="kcard-layout"
         >
-          <DocsKCard
-            :headingLevel="4"
-            orientation="vertical"
-            thumbnailDisplay="none"
-            prependTitle="(1)"
-          />
-          <DocsKCard
-            :headingLevel="4"
-            orientation="vertical"
-            thumbnailDisplay="none"
-            prependTitle="(2)"
-            showProgressInFooter
-          >
-            <template #footer>
-              <span></span>
-            </template>
-          </DocsKCard>
-          <DocsKCard
-            :headingLevel="4"
-            orientation="vertical"
-            thumbnailDisplay="none"
-            prependTitle="(3)"
-            showMenuInFooter
-          />
-        </KCardGrid>
+          <template #html>
+            <!-- eslint-disable -->
+
+            <DocsShowCode language="html">
+              <KCardGrid ...>
+                <KCard
+                  ...
+                  v-for="i in 3"
+                  orientation="vertical"
+                  thumbnailDisplay="none"
+                />
+              </KCardGrid>
+            </DocsShowCode>
+
+            <!-- eslint-enable -->
+          </template>
+        </DocsExample>
       </DocsShow>
-
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <KCardGrid ...>
-          <KCard
-            ...
-            orientation="vertical"
-            thumbnailDisplay="large"
-          />
-          <KCard
-            ...
-            orientation="vertical"
-            thumbnailDisplay="large"
-          />
-          <KCard
-            ...
-            orientation="vertical"
-            thumbnailDisplay="small"
-          />
-        </KCardGrid>
-
-        <KCardGrid ...>
-          <KCard
-            ...
-            orientation="horizontal"
-            thumbnailDisplay="large"
-            thumbnailAlign="left"
-          />
-          <KCard
-            ...
-            orientation="horizontal"
-            thumbnailDisplay="small"
-            thumbnailAlign="right"
-          />
-        </KCardGrid>
-
-        <KCardGrid ...>
-          <KCard
-            ...
-            v-for="i in 3"
-            orientation="vertical"
-            thumbnailDisplay="none"
-          />
-        </KCardGrid>
-      </DocsShowCode>
-      <!-- eslint-enable -->
 
       <h3>
         Responsiveness
@@ -643,68 +534,37 @@
         />. Apply custom styling to the inner content of slots to achieve desired effects.
       </p>
 
-      <DocsShow block>
-        <KCardGrid
-          layout="1-1-1"
-          :skeletonsConfig="skeletonsConfig5"
-          :loading="loading"
-        >
-          <KCard
-            :to="{ path: '#guidelines' }"
-            :headingLevel="4"
-            :thumbnailSrc="require('../assets/hummingbird-large-cc-by-sa-4.jpg')"
-            thumbnailDisplay="large"
-            title="Learn everything about hummingbirds: their habitats, feeding patterns, and stunning flight abilities"
-          >
-            <template #aboveTitle>
-              <KLabeledIcon
-                icon="readSolid"
-                label="Read"
-              />
-            </template>
-            <template #belowTitle>
-              <KTextTruncator
-                text="Discover how hummingbirds play a big role in nature despite their small size. Find out more about their beauty, how they help plants grow, and where they live."
-                :maxLines="5"
-              />
-            </template>
-            <template #footer>
-              <div
-                class="pills"
-                :style="{ color: $themeTokens.annotation }"
-              >
-                <span :style="{ backgroundColor: $themePalette.grey.v_100 }"> Short Activity </span>
-                <span :style="{ backgroundColor: $themePalette.grey.v_100 }"> Biology </span>
-              </div>
-            </template>
-          </KCard>
-        </KCardGrid>
-      </DocsShow>
-
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <KCardGrid ...>
-          <KCard ...>
-            <template #aboveTitle>
-              <KLabeledIcon
-                icon="readSolid"
-                label="Read"
-              />
-            </template>
-            <template #belowTitle>
-              <KTextTruncator
-                text="Discover how hummingbirds play a big role in nature despite their small size. Find out more about their beauty, how they help plants grow, and where they live."
-                :maxLines="5"
-              />
-            </template>
-            <template #footer>
-              <span :style="{ ... }">Short Activity</span>
-              <span :style="{ ... }">Biology</span>
-            </template>
-          </KCard>
-        </KCardGrid>
-      </DocsShowCode>
-      <!-- eslint-enable -->
+      <DocsExample
+        loadExample="KCard/ContentSlots.vue"
+        exampleId="kcard-content-slots"
+        block
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard ...>
+                <template #aboveTitle>
+                  <KLabeledIcon
+                    icon="readSolid"
+                    label="Read"
+                  />
+                </template>
+                <template #belowTitle>
+                  <KTextTruncator
+                    text="Discover how hummingbirds play a big role in nature despite their small size. Find out more about their beauty, how they help plants grow, and where they live."
+                    :maxLines="5"
+                  />
+                </template>
+                <template #footer>
+                  <span :style="{ ... }">Short Activity</span>
+                  <span :style="{ ... }">Biology</span>
+                </template>
+              </KCard>
+            </KCardGrid>
+          </DocsShowCode>
+        </template>
+      </DocsExample>
 
       <p>
         The <code>title</code> slot is available as an alternative to the <code>title</code> prop.
@@ -762,37 +622,28 @@
         <em>Provide a placeholder element even if a thumbnail image is available.</em> It serves as
         fallback content if the image fails to load unexpectedly.
       </p>
-
-      <DocsShow block>
-        <KCardGrid
-          layout="1-1-1"
-          :skeletonsConfig="skeletonsConfig6"
-          :loading="loading"
-        >
-          <DocsKCard
-            :headingLevel="4"
-            :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
-            thumbnailDisplay="large"
-            thumbnailAlign="right"
-            :thumbnailSrc="null"
-          />
-        </KCardGrid>
-      </DocsShow>
-
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <KCardGrid ...>
-          <KCard ...>
-            <template #thumbnailPlaceholder>
-              <KIcon
-                :style="{ fontSize: '48px' }"
-                icon="readSolid"
-              />
-            </template>
-          </KCard>
-        </KCardGrid>
-      </DocsShowCode>
-      <!-- eslint-enable -->
+      <DocsExample
+        loadExample="KCard/Placeholder.vue"
+        exampleId="kcard-placeholder"
+        block
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard ...>
+                <template #thumbnailPlaceholder>
+                  <KIcon
+                    :style="{ fontSize: '48px' }"
+                    icon="readSolid"
+                  />
+                </template>
+              </KCard>
+            </KCardGrid>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
 
       <h4>
         Image scaling
@@ -841,44 +692,29 @@
         needed to indicate the bookmark's toggled state. Always assess on a case-by-case basis.
       </p>
 
-      <DocsShow block>
-        <KCardGrid
-          layout="1-1-1"
-          :skeletonsConfig="skeletonsConfig7"
-          :loading="loading"
-        >
-          <DocsKCard
-            :headingLevel="4"
-            :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
-            thumbnailDisplay="large"
-            thumbnailAlign="right"
-          >
-            <template #footer>
-              <KIconButton
-                ariaLabel="Bookmark resource"
-                :icon="isBookmarked1 ? 'bookmark' : 'bookmarkEmpty'"
-                @click.stop="isBookmarked1 = !isBookmarked1"
-              />
-            </template>
-          </DocsKCard>
-        </KCardGrid>
-      </DocsShow>
-
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <KCardGrid ...>
-          <KCard ...>
-            <template #footer>
-              <KIconButton
-                ariaLabel="Bookmark resource"
-                :icon="isBookmarked ? 'bookmark' : 'bookmarkEmpty'"
-                @click.stop="isBookmarked = !isBookmarked"
-              />
-            </template>
-          </KCard>
-        </KCardGrid>
-      </DocsShowCode>
-      <!-- eslint-enable -->
+      <DocsExample
+        loadExample="KCard/InteractiveElements.vue"
+        exampleId="kcard-interactive-elements"
+        block
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard ...>
+                <template #footer>
+                  <KIconButton
+                    ariaLabel="Bookmark resource"
+                    :icon="isBookmarked ? 'bookmark' : 'bookmarkEmpty'"
+                    @click.stop="isBookmarked = !isBookmarked"
+                  />
+                </template>
+              </KCard>
+            </KCardGrid>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
 
       <h3>
         Selection controls
@@ -904,94 +740,41 @@
 
       <p>Managing the selection state is not <code>KCard</code>'s responsibility.</p>
 
-      <DocsShow
+      <DocsExample
+        loadExample="KCard/SelectionControls.vue"
+        exampleId="kcard-selection-controls"
         block
-        :style="{ maxWidth: '800px' }"
       >
-        <KCardGrid
-          layout="1-1-1"
-          :skeletonsConfig="skeletonsConfig8"
-          :loading="loading"
-        >
-          <DocsKCard
-            :to="{ path: '#guidelines' }"
-            :headingLevel="4"
-            :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
-            thumbnailDisplay="large"
-            thumbnailAlign="right"
-            title="First card"
-          >
-            <template #select>
-              <KCheckbox
-                :checked="isFirstCardChecked"
-                @change="isFirstCardChecked = !isFirstCardChecked"
-              >
-                <span class="visuallyhidden">Select 'First card'</span>
-              </KCheckbox>
-            </template>
-            <template #footer>
-              <KIconButton
-                ariaLabel="Bookmark resource"
-                :icon="isBookmarked2 ? 'bookmark' : 'bookmarkEmpty'"
-                @click.stop="isBookmarked2 = !isBookmarked2"
-              />
-            </template>
-          </DocsKCard>
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard ...>
+                <template #select>
+                  <KCheckbox
+                    :checked="..."
+                    @change="..."
+                  >
+                    <span class="visuallyhidden">Select 'First card'</span>
+                  </KCheckbox>
+                </template>
+              </KCard>
 
-          <DocsKCard
-            :to="{ path: '#guidelines' }"
-            :headingLevel="4"
-            :orientation="windowBreakpoint > 2 ? 'horizontal' : 'vertical'"
-            thumbnailDisplay="large"
-            thumbnailAlign="right"
-            title="Second card"
-          >
-            <template #select>
-              <KCheckbox
-                :checked="isSecondCardChecked"
-                @change="isSecondCardChecked = !isSecondCardChecked"
-              >
-                <span class="visuallyhidden">Select 'Second card'</span>
-              </KCheckbox>
-            </template>
-            <template #footer>
-              <KIconButton
-                ariaLabel="Bookmark resource"
-                :icon="isBookmarked3 ? 'bookmark' : 'bookmarkEmpty'"
-                @click.stop="isBookmarked3 = !isBookmarked3"
-              />
-            </template>
-          </DocsKCard>
-        </KCardGrid>
-      </DocsShow>
-
-      <!-- eslint-disable -->
-      <DocsShowCode language="html">
-        <KCardGrid ...>
-          <KCard ...>
-            <template #select>
-              <KCheckbox
-                :checked="..."
-                @change="..."
-              >
-                <span class="visuallyhidden">Select 'First card'</span>
-              </KCheckbox>
-            </template>
-          </KCard>
-
-          <KCard ...>
-            <template #select>
-              <KCheckbox
-                :checked="..."
-                @change="..."
-              >
-                <span class="visuallyhidden">Select 'Second card'</span>
-              </KCheckbox>
-            </template>
-          </KCard>
-        </KCardGrid>
-      </DocsShowCode>
-      <!-- eslint-enable -->
+              <KCard ...>
+                <template #select>
+                  <KCheckbox
+                    :checked="..."
+                    @change="..."
+                  >
+                    <span class="visuallyhidden">Select 'Second card'</span>
+                  </KCheckbox>
+                </template>
+              </KCard>
+            </KCardGrid>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
     </DocsPageSection>
 
     <DocsPageSection
@@ -1012,26 +795,16 @@
 <script>
 
   import useKResponsiveWindow from '../../lib/composables/useKResponsiveWindow';
-  import DocsKCard from '../pages-components/DocsKCard';
 
   export default {
-    components: {
-      DocsKCard,
-    },
-
     setup() {
       const { windowBreakpoint } = useKResponsiveWindow();
       return { windowBreakpoint };
     },
     data() {
       return {
-        isBookmarked1: false,
-        isBookmarked2: false,
-        isBookmarked3: false,
-        isFirstCardChecked: false,
-        isSecondCardChecked: false,
         loading: true,
-        skeletonsConfig1: [
+        skeletonsConfig: [
           {
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
@@ -1049,117 +822,6 @@
             height: '220px',
           },
         ],
-        skeletonsConfig2: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            orientation: 'vertical',
-            thumbnailDisplay: 'large',
-            height: '490px',
-          },
-          {
-            breakpoints: [3, 4, 5, 6, 7],
-            height: '420px',
-          },
-        ],
-        skeletonsConfig3: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            orientation: 'horizontal',
-            thumbnailDisplay: 'large',
-            thumbnailAlign: 'left',
-            height: '310px',
-          },
-          {
-            breakpoints: [4, 5, 6, 7],
-            height: '240px',
-          },
-        ],
-        skeletonsConfig4: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            height: '290px',
-          },
-          {
-            breakpoints: [4, 5, 6, 7],
-            height: '225px',
-          },
-        ],
-        skeletonsConfig5: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            orientation: 'horizontal',
-            thumbnailDisplay: 'large',
-            thumbnailAlign: 'left',
-            height: '300px',
-          },
-          {
-            breakpoints: [3, 4, 5, 6, 7],
-            height: '190px',
-          },
-        ],
-        skeletonsConfig6: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            orientation: 'vertical',
-            thumbnailDisplay: 'large',
-            height: '460px',
-          },
-          {
-            breakpoints: [2],
-            height: '390px',
-          },
-          {
-            breakpoints: [3, 4, 5, 6, 7],
-            orientation: 'horizontal',
-            thumbnailAlign: 'right',
-            height: '170px',
-          },
-        ],
-        skeletonsConfig7: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            orientation: 'vertical',
-            thumbnailDisplay: 'large',
-            height: '460px',
-          },
-          {
-            breakpoints: [2],
-            height: '390px',
-          },
-          {
-            breakpoints: [3, 4, 5, 6, 7],
-            orientation: 'horizontal',
-            thumbnailAlign: 'right',
-            height: '170px',
-          },
-        ],
-        skeletonsConfig8: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            orientation: 'vertical',
-            thumbnailDisplay: 'large',
-            height: '400px',
-          },
-          {
-            breakpoints: [2],
-            height: '380px',
-          },
-          {
-            breakpoints: [3, 4, 5, 6, 7],
-            orientation: 'horizontal',
-            thumbnailAlign: 'right',
-            height: '180px',
-          },
-        ],
-        skeletonsConfig9: [
-          {
-            breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            orientation: 'horizontal',
-            thumbnailDisplay: 'small',
-            thumbnailAlign: 'right',
-            height: '130px',
-          },
-        ],
       };
     },
     mounted() {
@@ -1170,19 +832,3 @@
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  .pills {
-    margin-left: -4px;
-
-    span {
-      display: inline-block;
-      padding: 4px 8px;
-      margin: 4px;
-      border-radius: 4px;
-    }
-  }
-
-</style>

--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -419,6 +419,7 @@
       <DocsExample
         loadExample="KCard/Layout1.vue"
         exampleId="kcard-layout"
+        block
       >
         <template #html>
           <!-- eslint-disable -->
@@ -450,6 +451,7 @@
       <DocsExample
         loadExample="KCard/Layout2.vue"
         exampleId="kcard-layout"
+        block
       >
         <template #html>
           <!-- eslint-disable -->
@@ -478,6 +480,7 @@
       <DocsExample
         loadExample="KCard/Layout3.vue"
         exampleId="kcard-layout"
+        block
       >
         <template #html>
           <!-- eslint-disable -->

--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -416,7 +416,6 @@
         diverse kinds of content:
       </p>
 
-      <h4>Layout 1: Vertical with Large and Small Thumbnails</h4>
       <DocsExample
         loadExample="KCard/Layout1.vue"
         exampleId="kcard-layout"
@@ -448,7 +447,6 @@
         </template>
       </DocsExample>
 
-      <h4>Layout 2: Horizontal with Large and Small Thumbnails</h4>
       <DocsExample
         loadExample="KCard/Layout2.vue"
         exampleId="kcard-layout"
@@ -477,7 +475,6 @@
         </template>
       </DocsExample>
 
-      <h4>Layout 3: Vertical without Thumbnails</h4>
       <DocsExample
         loadExample="KCard/Layout3.vue"
         exampleId="kcard-layout"

--- a/docs/plugins/load-common-components.js
+++ b/docs/plugins/load-common-components.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 
 import VueSimpleMarkdown from 'vue-simple-markdown';
+import DocsKCard from '../pages-components/DocsKCard';
 import DocsExample from '~/common/DocsExample';
 import DocsExternalLink from '~/common/DocsExternalLink';
 import DocsGithubLink from '~/common/DocsGithubLink';

--- a/docs/plugins/load-common-components.js
+++ b/docs/plugins/load-common-components.js
@@ -35,6 +35,6 @@ Vue.component('DocsToggleContent', DocsToggleContent);
 Vue.component('DocsToggleButton', DocsToggleButton);
 Vue.component('DocsTable', DocsTable);
 Vue.component('DocsSubNav', DocsSubNav);
-Vue.component('DocsKCard', Card);
+Vue.component('Card', Card);
 
 Vue.use(VueSimpleMarkdown);

--- a/docs/plugins/load-common-components.js
+++ b/docs/plugins/load-common-components.js
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 
 import VueSimpleMarkdown from 'vue-simple-markdown';
-import DocsKCard from '../pages-components/DocsKCard';
+import Card from '../examples/common/Card.vue';
 import DocsExample from '~/common/DocsExample';
 import DocsExternalLink from '~/common/DocsExternalLink';
 import DocsGithubLink from '~/common/DocsGithubLink';
@@ -18,7 +18,6 @@ import DocsToggleButton from '~/common/DocsToggleButton';
 import DocsFilter from '~/common/DocsFilter';
 import DocsTable from '~/common/DocsTable';
 import DocsSubNav from '~/common/DocsSubNav';
-import DocsKCard from '~/pages-components/DocsKCard.vue';
 
 Vue.component('DocsExample', DocsExample);
 Vue.component('DocsPageTemplate', DocsPageTemplate);
@@ -36,6 +35,6 @@ Vue.component('DocsToggleContent', DocsToggleContent);
 Vue.component('DocsToggleButton', DocsToggleButton);
 Vue.component('DocsTable', DocsTable);
 Vue.component('DocsSubNav', DocsSubNav);
-Vue.component('DocsKCard', DocsKCard);
+Vue.component('DocsKCard', Card);
 
 Vue.use(VueSimpleMarkdown);


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This pull request migrates the KCard documentation to use the new DocsExample component, as part of the ongoing effort to improve the developer documentation quality. This change is in line with the task outlined in issue #950 and the parent issue #949.

#### Issue addressed
<!-- Only necessary if applicable -->
Addresses #950

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

- **Description:** Updated KCard documentation to use the DocsExample component and migrated example code into separate Vue files in the KCard directory. Cleaned up unnecessary script in KCard.vue.
- **Products impact:** none
- **Addresses:** [#950](https://github.com/learningequality/kolibri-design-system/issues/950)
- **Components:** KCard
- **Breaking:** no
- **Impacts a11y:** no
- **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_