### PR TITLE
[Proposal] Add useGridMetrics to calculate common selectionControlWidth for KCard

### DIFF
--- a/lib/cards/KCard.vue
+++ b/lib/cards/KCard.vue
@@ -5,7 +5,7 @@
     to allow for @click.stop on buttons and similar
     rendered within a card via its slots -->
   <li
-    :class="['k-card', $slots.select ? 'k-with-selection-controls' : undefined]"
+    :class="['k-card', selectionControlWidth > 0 ? 'k-with-selection-controls' : undefined]"
     :style="[gridItemStyle, focusStyle]"
     @focus="onFocus"
     @mouseenter="onHover"
@@ -45,7 +45,7 @@
               This is to
                 - (1) prevent double navigation (the wrapping
                       <li> is supposed to take care of navigation)
-                - (2) together with the `draggable` disabled, 
+                - (2) together with the `draggable` disabled,
                       ensures that text selection works on
                       the title text (see the feature for allowing
                       selecting card's content in `onClick`)
@@ -61,7 +61,7 @@
               @blur.native="onTitleBlur"
             >
               <span aria-hidden="true">
-                <!-- @slot A scoped slot via which the `title` can be customized. 
+                <!-- @slot A scoped slot via which the `title` can be customized.
                  Provides the `titleText` attribute.-->
                 <slot
                   v-if="$scopedSlots.title"
@@ -92,7 +92,7 @@
               @blur="onTitleBlur"
             >
               <span aria-hidden="true">
-                <!-- @slot A scoped slot via which the `title` can be customized. 
+                <!-- @slot A scoped slot via which the `title` can be customized.
                  Provides the `titleText` attribute. -->
                 <slot
                   v-if="$scopedSlots.title"
@@ -132,7 +132,7 @@
           v-if="thumbnailDisplay !== ThumbnailDisplays.NONE"
           class="k-thumbnail"
         >
-          <!-- 
+          <!--
             Render KImg even if thumbnailSrc is not provided since in that case
             KImg takes care of showing the gray placeholder area.
           -->
@@ -170,8 +170,9 @@
       a selection control is pressed or clicked
     -->
     <div
-      v-if="$slots.select"
+      ref="selectionControl"
       class="k-selection-control"
+      :style="{ minWidth: `${selectionControlWidth}px` }"
       @keyup.enter.stop
       @click.stop
     >
@@ -185,7 +186,8 @@
 
 <script>
 
-  import { inject } from 'vue';
+  import { getCurrentInstance, inject } from 'vue';
+  import { useCardMetrics } from './useGridMetrics';
 
   const Orientations = {
     HORIZONTAL: 'horizontal',
@@ -223,8 +225,20 @@
       // controls the width and layout of `KCard` items in the grid
       const gridItemStyle = inject('gridItemStyle');
 
+      const instance = getCurrentInstance();
+      const { selectionControlWidth } = useCardMetrics({
+        getMetrics: () => {
+          const selectionControlRef = instance.proxy.$refs.selectionControl;
+          const selectionControlWidth = selectionControlRef?.getBoundingClientRect().width || 0;
+          return {
+            selectionControlWidth,
+          };
+        },
+      });
+
       return {
         gridItemStyle,
+        selectionControlWidth,
       };
     },
     props: {
@@ -557,6 +571,9 @@
   /************* Common styles **************/
 
   .k-card {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
     width: 100%;
     padding: 0;
     margin: 0;
@@ -567,10 +584,6 @@
     cursor: pointer;
 
     &.k-with-selection-controls {
-      display: flex;
-      flex-direction: row-reverse;
-      align-items: center;
-
       .k-selection-control {
         margin-right: 20px;
       }

--- a/lib/cards/KCard.vue
+++ b/lib/cards/KCard.vue
@@ -5,7 +5,7 @@
     to allow for @click.stop on buttons and similar
     rendered within a card via its slots -->
   <li
-    :class="['k-card', selectionControlWidth > 0 ? 'k-with-selection-controls' : undefined]"
+    :class="['k-card', haveSelectionControl ? 'k-with-selection-controls' : undefined]"
     :style="[gridItemStyle, focusStyle]"
     @focus="onFocus"
     @mouseenter="onHover"
@@ -172,7 +172,7 @@
     <div
       ref="selectionControl"
       class="k-selection-control"
-      :style="{ minWidth: `${selectionControlWidth}px` }"
+      :style="{ minWidth: `${selectionControlWidth || 0}px` }"
       @keyup.enter.stop
       @click.stop
     >
@@ -186,7 +186,7 @@
 
 <script>
 
-  import { getCurrentInstance, inject } from 'vue';
+  import { computed, getCurrentInstance, inject } from 'vue';
   import { useCardMetrics } from './useGridMetrics';
 
   const Orientations = {
@@ -236,8 +236,18 @@
         },
       });
 
+      const haveSelectionControl = computed(() => {
+        // If selectionControlWidth is null, it means that the styles sync is not enabled
+        // so lets just rely on the presence of the select slot
+        if (selectionControlWidth.value === null) {
+          return Boolean(instance.proxy.$slots.select);
+        }
+        return selectionControlWidth.value > 0;
+      });
+
       return {
         gridItemStyle,
+        haveSelectionControl,
         selectionControlWidth,
       };
     },

--- a/lib/cards/KCardGrid.vue
+++ b/lib/cards/KCardGrid.vue
@@ -1,44 +1,46 @@
 <template>
 
-  <div
-    v-if="showGrid"
-    class="k-card-grid"
-  >
-    <transition
-      name="fade"
-      mode="out-in"
-      appear
-    >
-      <ul
-        v-if="isLoading"
-        key="loading"
-        :style="gridStyle"
-      >
-        <SkeletonCard
-          v-for="i in skeletonCount"
-          :key="i"
-          :height="skeletonHeight"
-          :orientation="skeletonOrientation"
-          :thumbnailDisplay="skeletonThumbnailDisplay"
-          :thumbnailAlign="skeletonThumbnailAlign"
-        />
-      </ul>
-      <ul
-        v-else
-        key="loaded"
-        :style="gridStyle"
-      >
-        <!-- @slot Slot for `KCard`s -->
-        <slot></slot>
-      </ul>
-    </transition>
-
+  <div>
     <div
-      v-if="debug"
-      class="k-debug"
+      v-if="showGrid"
+      class="k-card-grid"
     >
-      <div>DEBUG</div>
-      <div>breakpoint: {{ windowBreakpoint }}</div>
+      <transition
+        name="fade"
+        mode="out-in"
+        appear
+      >
+        <ul
+          v-if="isLoading"
+          key="loading"
+          :style="gridStyle"
+        >
+          <SkeletonCard
+            v-for="i in skeletonCount"
+            :key="i"
+            :height="skeletonHeight"
+            :orientation="skeletonOrientation"
+            :thumbnailDisplay="skeletonThumbnailDisplay"
+            :thumbnailAlign="skeletonThumbnailAlign"
+          />
+        </ul>
+        <ul
+          v-else
+          key="loaded"
+          :style="gridStyle"
+        >
+          <!-- @slot Slot for `KCard`s -->
+          <slot></slot>
+        </ul>
+      </transition>
+
+      <div
+        v-if="debug"
+        class="k-debug"
+      >
+        <div>DEBUG</div>
+        <div>breakpoint: {{ windowBreakpoint }}</div>
+      </div>
     </div>
   </div>
 
@@ -52,6 +54,7 @@
   import { LAYOUT_1_1_1, LAYOUT_1_2_2, LAYOUT_1_2_3 } from './gridBaseLayouts';
   import useGridLayout from './useGridLayout';
   import useGridLoading from './useGridLoading';
+  import useGridMetrics from './useGridMetrics';
   import SkeletonCard from './SkeletonCard';
 
   /**
@@ -63,6 +66,7 @@
       SkeletonCard,
     },
     setup(props) {
+      useGridMetrics();
       const { currentBreakpointConfig, windowBreakpoint } = useGridLayout(props);
       const {
         showGrid,

--- a/lib/cards/KCardGrid.vue
+++ b/lib/cards/KCardGrid.vue
@@ -66,7 +66,9 @@
       SkeletonCard,
     },
     setup(props) {
-      useGridMetrics();
+      if (props.syncCardsMetrics) {
+        useGridMetrics();
+      }
       const { currentBreakpointConfig, windowBreakpoint } = useGridLayout(props);
       const {
         showGrid,
@@ -173,6 +175,17 @@
       debug: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * Enables the `syncCardsMetrics` feature.
+       * This feature is used to synchronize the metrics of
+       * cards in the grid, e.g. when you have some cards with
+       * a select control and some without it, this will make that
+       * all cards have the same space for the select control.
+       */
+      syncCardsMetrics: {
+        type: Boolean,
+        default: true,
       },
     },
   };

--- a/lib/cards/useGridMetrics.js
+++ b/lib/cards/useGridMetrics.js
@@ -1,0 +1,87 @@
+import { throttle } from 'lodash';
+import { getCurrentInstance, inject, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue';
+import useKResponsiveElement from '../composables/useKResponsiveElement';
+
+/**
+ * Composable to provide the context for calculating card metrics inside a grid.
+ * It allows cards to register and unregister their get metrics functions, and with
+ * this, we calculate the greatest metrics among all registered cards, so cards can then
+ * use this information to calculate their own metrics and have a consistent layout.
+ */
+export default function useGridMetrics() {
+  const registeredCards = ref({});
+
+  const registerCard = (uid, { getMetrics }) => {
+    registeredCards.value = {
+      ...registeredCards.value,
+      [uid]: {
+        getMetrics,
+      },
+    };
+  };
+  const unregisterCard = uid => {
+    const newRegisteredCards = { ...registeredCards.value };
+    delete newRegisteredCards[uid];
+    registeredCards.value = newRegisteredCards;
+  };
+
+  const selectionControlWidth = ref(0);
+
+  const calculateGridMetrics = () => {
+    let newSelectionControlWidth = 0;
+    const cards = Object.values(registeredCards.value);
+    for (const card of cards) {
+      const metrics = card.getMetrics();
+      if (metrics.selectionControlWidth > newSelectionControlWidth) {
+        newSelectionControlWidth = metrics.selectionControlWidth;
+      }
+    }
+    selectionControlWidth.value = newSelectionControlWidth;
+  };
+  const throttledCalculateGridMetrics = throttle(calculateGridMetrics, 50);
+
+  const { elementWidth, elementHeight } = useKResponsiveElement();
+
+  watch([elementWidth, elementHeight, registeredCards], throttledCalculateGridMetrics);
+
+  provide('registerCard', registerCard);
+  provide('unregisterCard', unregisterCard);
+  provide('selectionControlWidth', selectionControlWidth);
+}
+
+/**
+ * Composable to inject the card metrics inside a card.
+ * It allows cards to register their get metrics function,
+ * so the grid can calculate the greatest metrics
+ * among all registered cards.
+ *
+ * @param {Object} options - Options for the composable.
+ * @param {Function} options.getMetrics - Function to get the card metrics. It should return
+ *  an object with the following properties:
+ *   - selectionControlWidth: The width of the selection control of the card.
+ *
+ * @returns {Object} - The card metrics.
+ * @property {Ref<number>} selectionControlWidth - Width of selection control the card should use.
+ */
+export function useCardMetrics({ getMetrics } = {}) {
+  if (!getMetrics) {
+    throw new Error('getMetrics function is required');
+  }
+  const registerCard = inject('registerCard');
+  const unregisterCard = inject('unregisterCard');
+  const selectionControlWidth = inject('selectionControlWidth');
+
+  const instance = getCurrentInstance();
+  const uid = instance.proxy._uid;
+
+  onMounted(() => {
+    registerCard?.(uid, { getMetrics });
+  });
+  onBeforeUnmount(() => {
+    unregisterCard?.(uid);
+  });
+
+  return {
+    selectionControlWidth,
+  };
+}

--- a/lib/cards/useGridMetrics.js
+++ b/lib/cards/useGridMetrics.js
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash';
+import { throttle } from 'frame-throttle';
 import { getCurrentInstance, inject, onBeforeUnmount, onMounted, provide, ref, watch } from 'vue';
 import useKResponsiveElement from '../composables/useKResponsiveElement';
 
@@ -38,7 +38,7 @@ export default function useGridMetrics() {
     }
     selectionControlWidth.value = newSelectionControlWidth;
   };
-  const throttledCalculateGridMetrics = throttle(calculateGridMetrics, 50);
+  const throttledCalculateGridMetrics = throttle(calculateGridMetrics);
 
   const { elementWidth, elementHeight } = useKResponsiveElement();
 
@@ -67,18 +67,24 @@ export function useCardMetrics({ getMetrics } = {}) {
   if (!getMetrics) {
     throw new Error('getMetrics function is required');
   }
-  const registerCard = inject('registerCard');
-  const unregisterCard = inject('unregisterCard');
-  const selectionControlWidth = inject('selectionControlWidth');
+  const registerCard = inject('registerCard', null);
+  const unregisterCard = inject('unregisterCard', null);
+  const selectionControlWidth = inject('selectionControlWidth', null);
+
+  if (!registerCard || !unregisterCard || !selectionControlWidth) {
+    return {
+      selectionControlWidth: ref(null),
+    };
+  }
 
   const instance = getCurrentInstance();
   const uid = instance.proxy._uid;
 
   onMounted(() => {
-    registerCard?.(uid, { getMetrics });
+    registerCard(uid, { getMetrics });
   });
   onBeforeUnmount(() => {
-    unregisterCard?.(uid);
+    unregisterCard(uid);
   });
 
   return {


### PR DESCRIPTION
## Description

This PR proposes a way to calculate common metrics in the KCards context. The idea is that on mount, each card provides a `getMetrics` function (name can be changed) that returns measurements of specific parts/sections of the card, e.g. the width of the selection control. With this, the KCardGrid component will calculate the greater selection control width among its children KCards, and will provide this value for the cards to use this measurement as min-width of its selection-control div, so they all can have the same measurement for that section of the card.

We can test how it goes a pattern liike this, and if it works well with the selection control, in the future we can expand the `getMetrics` method to share metrics like the height of the title/above title, and align these sections more proactevely.

For now, with this update, If I remove [this fallback](https://github.com/nucleogenesis/kolibri/blob/49fbdd8b2881bc0363c3b3aa7e277eef71b4a02a/kolibri/plugins/coach/assets/src/views/common/resourceSelection/ContentCardList.vue#L54-L59) element in the ContentCardList in Kolibri, this keeps working as expected:

https://github.com/user-attachments/assets/1b90c872-b9b5-440d-a996-2d4c71c16d4d

#### Issue addressed

Addresses #980

### Before/after screenshots
<!-- Insert images here if applicable -->

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Adds KCardGrid management for reserving space for selection control width in KCard to align cards that already selection controls and the ones who doesnt.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/980.
  - **Components:** KCard
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
