### PR TITLE
added visual test for KBreadcrumbs

### DIFF
--- a/jest.conf/visual.load-test-components.js
+++ b/jest.conf/visual.load-test-components.js
@@ -2,6 +2,8 @@ import Vue from 'vue';
 
 import KButtonWithDropdownTest from '~~/lib/buttons-and-links/__tests__/components/KButtonWithDropdownTest.vue';
 import KDropdownMenuTest from '~~/lib/KDropdownMenu/__tests__/components/KDropdownMenuTest.vue';
+import KBreadcrumbsTest from '~~/lib/KBreadcrumbs/__tests__/components/KBreadcrumbsTest.vue';
 
 Vue.component('KButtonWithDropdownTest', KButtonWithDropdownTest);
 Vue.component('KDropdownMenuTest', KDropdownMenuTest);
+Vue.component('KBreadcrumbsTest', KBreadcrumbsTest);

--- a/lib/KBreadcrumbs/__tests__/KBreadcrumbs.spec.js
+++ b/lib/KBreadcrumbs/__tests__/KBreadcrumbs.spec.js
@@ -1,0 +1,110 @@
+import {
+  renderComponentForVisualTest,
+  takeSnapshot,
+  click,
+} from '../../../jest.conf/visual.testUtils';
+
+describe.visual('KBreadcrumbs Visual Tests', () => {
+  const snapshotOptions = { widths: [375, 768], minHeight: 200 };
+
+  it.visual('Breadcrumbs - Single Item (showSingleItem)', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsTest', {
+      items: [{ text: 'Single Item', link: null }],
+      showSingleItem: true,
+    });
+    await takeSnapshot('KBreadcrumbs - Single Item', snapshotOptions);
+  });
+
+  it.visual('Breadcrumbs - Single Item (hidden)', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsTest', {
+      items: [{ text: 'Single Item', link: null }],
+      showSingleItem: false,
+    });
+    await takeSnapshot('KBreadcrumbs - Single Item Hidden', snapshotOptions);
+  });
+
+  it.visual('Breadcrumbs - Multiple Items (no overflow)', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsTest', {
+      items: [
+        { text: 'Home', link: { path: '/' } },
+        { text: 'Library', link: { path: '/lib' } },
+        { text: 'Data', link: null },
+      ],
+      containerWidth: '600px',
+    });
+    await takeSnapshot('KBreadcrumbs - No Overflow', snapshotOptions);
+  });
+
+  it.visual('Breadcrumbs - Overflow with Dropdown Open', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsTest', {
+      items: [
+        { text: 'Home', link: { path: '/' } },
+        { text: 'Library', link: { path: '/lib' } },
+        { text: 'Category', link: { path: '/category' } },
+        { text: 'Subcategory', link: { path: '/subcategory' } },
+        { text: 'Files', link: null },
+      ],
+      containerWidth: '300px',
+    });
+
+    await page.waitForSelector('.breadcrumbs-dropdown-wrapper button', {
+      visible: true,
+      timeout: 5000,
+    });
+    await click('.breadcrumbs-dropdown-wrapper button');
+
+    await page.waitFor(300);
+
+    await takeSnapshot('KBreadcrumbs - Overflow with Dropdown Open', snapshotOptions);
+  });
+
+  it.visual('Breadcrumbs - Long Text Truncation', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsTest', {
+      items: [
+        { text: 'Home', link: { path: '/' } },
+        {
+          text: 'A very long breadcrumb text that should truncate properly when displayed in the component',
+          link: { path: '/long' },
+        },
+        { text: 'Data', link: null },
+      ],
+      containerWidth: '400px',
+    });
+    await takeSnapshot('KBreadcrumbs - Long Text', snapshotOptions);
+  });
+
+  it.visual('Breadcrumbs - With Links', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsTest', {
+      items: [
+        { text: 'Home', link: { path: '/' } },
+        { text: 'Library', link: { path: '/lib' } },
+        { text: 'Files', link: { path: '/files' } },
+      ],
+      containerWidth: '600px',
+    });
+    await takeSnapshot('KBreadcrumbs - With Links', snapshotOptions);
+  });
+
+  it.visual('Breadcrumbs - Mixed Links with Dropdown Open', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsTest', {
+      items: [
+        { text: 'Home', link: null },
+        { text: 'Library', link: { path: '/lib' } },
+        { text: 'Resources', link: { path: '/resources' } },
+        { text: 'Documents', link: { path: '/documents' } },
+        { text: 'Files', link: null },
+      ],
+      containerWidth: '300px',
+    });
+
+    await page.waitForSelector('.breadcrumbs-dropdown-wrapper button', {
+      visible: true,
+      timeout: 5000,
+    });
+    await click('.breadcrumbs-dropdown-wrapper button');
+
+    await page.waitFor(300);
+
+    await takeSnapshot('KBreadcrumbs - Mixed Links with Dropdown Open', snapshotOptions);
+  });
+});

--- a/lib/KBreadcrumbs/__tests__/components/KBreadcrumbsTest.vue
+++ b/lib/KBreadcrumbs/__tests__/components/KBreadcrumbsTest.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <div :style="{ width: containerWidth, padding: '16px' }">
+    <KBreadcrumbs
+      :items="items"
+      :showSingleItem="showSingleItem"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KBreadcrumbsTest',
+    props: {
+      items: {
+        type: Array,
+        required: true,
+      },
+      showSingleItem: {
+        type: Boolean,
+        default: false,
+      },
+      containerWidth: {
+        type: String,
+        default: '100%',
+      },
+    },
+  };
+
+</script>

--- a/lib/KBreadcrumbs/index.vue
+++ b/lib/KBreadcrumbs/index.vue
@@ -152,7 +152,7 @@
   import throttle from 'lodash/throttle';
   import every from 'lodash/every';
   import keys from 'lodash/keys';
-  import useKResponsiveElement from './composables/useKResponsiveElement';
+  import useKResponsiveElement from '../composables/useKResponsiveElement';
 
   const DROPDOWN_BTN_WIDTH = 55;
   const DEFAULT_LAST_BREADCRUMB_MAX_WIDTH = 300;
@@ -313,7 +313,7 @@
 
 <style lang="scss" scoped>
 
-  @import './styles/definitions';
+  @import '../styles/definitions';
   $crumb-max-width: 300px;
 
   .breadcrumbs {

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -2,7 +2,7 @@ import { isNuxtServerSideRendering } from '../lib/utils';
 import computedClass from './styles/computedClass';
 import { darken1, darken2, darken3 } from './styles/darkenColors.js';
 
-import KBreadcrumbs from './KBreadcrumbs';
+import KBreadcrumbs from './KBreadcrumbs/index.vue';
 import KButton from './buttons-and-links/KButton';
 import KButtonGroup from './buttons-and-links/KButtonGroup';
 import KCard from './cards/KCard';


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This PR adds visual tests for the KBreadcrumbs component, covering the following scenarios:
- Breadcrumbs with just one item (with/without showSingleItem).
- Breadcrumbs with multiple items that do not overflow the available width.
- Breadcrumbs with multiple items that overflow the available width.
- Breadcrumbs with multiple items that have long text.
- Breadcrumbs with links.
- Dropdown open for overflowed breadcrumbs with links.
- Dropdown open for overflowed breadcrumbs without links.

Additionally, the KBreadCrumbs component file has been renamed from KBreadcrumbs.vue to KBreadcrumbs/index.vue to better organize the component structure.


#### Issue addressed
<!-- Only necessary if applicable -->
#924 


### Before/after screenshots
<!-- Insert images here if applicable -->
NA

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

- **Description:**  Added visual tests for  KBreadcrumbs  and renamed  KBreadcrumbs.vue to  KBreadcrumbs/index.vue.

- **Products impact**: None

- **Addresses**: #924 

- **Components**: KBreadcrumbs

- **Breaking**: No

- **Impacts a11y**: No

- **Guidance**: Visual tests are implemented in separate test files following the approach used for KButton visual tests. This ensures that different configurations of KBreadcrumbs render correctly and consistently.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Pull down the branch and build the project.
2. Run the visual tests using -- yarn test:visual
3. Verify that the visual tests for  KBreadcrumbs pass for all scenarios.
4. Check the Percy build to confirm that snapshots are captured correctly.

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
No, these changes follow the existing testing infrastructure and component guidelines.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [✅ ] Contributor has fully tested the PR manually
- [✅ ] If there are any front-end changes, before/after screenshots are included
- [✅] Critical and brittle code paths are covered by unit tests
- [✅] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->
 - Verify that the visual tests run as expected and that Percy snapshots accurately reflect the UI changes.
 - Confirm that renaming the component file to index.vue does not break any existing imports.
 - Ensure that the new tests follow the pattern used in the KButton visual tests.

- [✅] Is the code clean and well-commented?
- [✅] Are there tests for this change?

## Comments
<!-- Any additional notes you'd like to add -->
Please let me know if there are any questions or further adjustments needed.