### PR TITLE
Issue 995

### DIFF
--- a/docs/common/DocsExample.vue
+++ b/docs/common/DocsExample.vue
@@ -123,6 +123,11 @@
         default: false,
         required: false,
       },
+      /**
+       * Its purpose is to dynamically control the set of documentation tabs rendered
+       * @type {Array}
+       * @example ['template', 'script', 'style']
+       */
       docTabs: {
         type: Array,
         required: false,

--- a/docs/common/DocsExample.vue
+++ b/docs/common/DocsExample.vue
@@ -123,6 +123,13 @@
         default: false,
         required: false,
       },
+      docTabs: {
+        type: Array,
+        required: false,
+        default() {
+          return ['template', 'script', 'style'];
+        },
+      },
     },
     data() {
       return {
@@ -140,7 +147,7 @@
         const tabList = [];
 
         const templateContent = this.applyRegex(this.content, 'template');
-        if (this.$slots.html || templateContent) {
+        if ((this.$slots.html || templateContent) && this.docTabs.includes('template')) {
           tabList.push({
             id: 'html-codeblock',
             label: 'Template',
@@ -150,7 +157,7 @@
         }
 
         const scriptContent = this.applyRegex(this.content, 'script');
-        if (this.$slots.javascript || scriptContent) {
+        if ((this.$slots.javascript || scriptContent) && this.docTabs.includes('script')) {
           tabList.push({
             id: 'js-codeblock',
             label: 'Script',
@@ -160,7 +167,7 @@
         }
 
         const styleContent = this.applyRegex(this.content, 'style');
-        if (this.$slots.scss || styleContent) {
+        if ((this.$slots.scss || styleContent) && this.docTabs.includes('style')) {
           tabList.push({
             id: 'scss-codeblock',
             label: 'Style',

--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -419,6 +419,7 @@
       <DocsExample
         loadExample="KCard/Layout1.vue"
         exampleId="kcard-layout"
+        :docTabs="['script', 'template']"
         block
       >
         <template #html>


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
The docTabs prop is defined as an optional array (type: Array, required: false) that controls the displayed documentation tabs. If no value is provided, it defaults to showing 'template', 'script', and 'style' tabs.

### Before/after screenshots
<!-- Insert images here if applicable -->
Before
<img width="724" alt="image" src="https://github.com/user-attachments/assets/2d833da6-6686-4477-ad8e-86a5aae79ed2" />


After
<img width="765" alt="image" src="https://github.com/user-attachments/assets/45e71bc7-945c-409d-bb2c-97aaab6c5e86" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->
  - **Description:**
 The docTabs prop is defined as an optional array (type: Array, required: false) that controls the displayed documentation 
 tabs. If no value is provided, it defaults to showing 'template', 'script', and 'style' tabs.
  - **Addresses:** 
  https://github.com/learningequality/kolibri-design-system/issues/995
  - **Components:** 
  1. Add new prop to KCard component layout docsExample
  2. DocsExample component is updated with new prop
  - **Breaking:**  no
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->


- [✓] Contributor has fully tested the PR manually
- [✓] If there are any front-end changes, before/after screenshots are included
- [✓] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [✓] Is the code clean and well-commented?

## Comments
<!-- Any additional notes you'd like to add -->
Instead of using three different props as mentioned. Only one props to solve this issue. Let me know it we need it as three different props.
