### PR TITLE
Add min-width: 0 for k-card-area

### DIFF
--- a/lib/cards/KCard.vue
+++ b/lib/cards/KCard.vue
@@ -45,7 +45,7 @@
               This is to
                 - (1) prevent double navigation (the wrapping
                       <li> is supposed to take care of navigation)
-                - (2) together with the `draggable` disabled, 
+                - (2) together with the `draggable` disabled,
                       ensures that text selection works on
                       the title text (see the feature for allowing
                       selecting card's content in `onClick`)
@@ -61,7 +61,7 @@
               @blur.native="onTitleBlur"
             >
               <span aria-hidden="true">
-                <!-- @slot A scoped slot via which the `title` can be customized. 
+                <!-- @slot A scoped slot via which the `title` can be customized.
                  Provides the `titleText` attribute.-->
                 <slot
                   v-if="$scopedSlots.title"
@@ -92,7 +92,7 @@
               @blur="onTitleBlur"
             >
               <span aria-hidden="true">
-                <!-- @slot A scoped slot via which the `title` can be customized. 
+                <!-- @slot A scoped slot via which the `title` can be customized.
                  Provides the `titleText` attribute. -->
                 <slot
                   v-if="$scopedSlots.title"
@@ -132,7 +132,7 @@
           v-if="thumbnailDisplay !== ThumbnailDisplays.NONE"
           class="k-thumbnail"
         >
-          <!-- 
+          <!--
             Render KImg even if thumbnailSrc is not provided since in that case
             KImg takes care of showing the gray placeholder area.
           -->
@@ -584,6 +584,7 @@
     flex-direction: column;
     justify-content: space-between; // push footer to the bottom of the card
     width: 100%;
+    min-width: 0;
     height: 100%;
     border-radius: 0.5em;
     outline-offset: -1px;


### PR DESCRIPTION
## Description

This PR fixes the need for KTextTruncator to have an `overflow-wrap: anywhere` to solve an overflowed text issue in KCard. The main reason why we cannot use `overflow-wrap: anywhere` is that this is not supported by our browserlist (here the caniuse [link](https://caniuse.com/?search=overflow-wrap%3A%20anywhere)) while `overflow-wrap: break-word` is.

The main reason why `overflow-wrap: anywhere` was needed in the first place was because with `overflow-wrap: break-word` the cards with a long word/link (with no spaces within it) looked like this:

![image](https://github.com/user-attachments/assets/62d7079d-2f49-4079-8e2c-86077f585a2b)

This happens because of a wonky interaction between `overflow-wrap` and horizontal flex containers. When we have an `overflow-wrap: break-word` with a long word inside a flex item, the `overflow-wrap: break-word` property makes the flex item grow as much as possible, causing all other flex items to overflow. This is solved by introducing a `min-width: 0` to the flex item containing the long words to force flex to shrink a child below its minimum content size as needed, see [Understanding the automatic minimum size of flex items](https://www.bigbinary.com/blog/understanding-the-automatic-minimum-size-of-flex-items) for a broader explanation.

After:

![image](https://github.com/user-attachments/assets/e9b6f28f-3fb1-44c7-b8af-c6ed1bfac788)


#### Issue addressed
Closes #958.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Adds a `min-width: 0` to k card area to prevent text overflow issues within KCards with checkboxes.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/958.
  - **Components:**  KCard.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

