### PR TITLE
Wrap ResizeObserver callback with requestAnimationFrame

### DIFF
--- a/lib/composables/useKResponsiveElement.js
+++ b/lib/composables/useKResponsiveElement.js
@@ -1,15 +1,16 @@
-import { throttle } from 'frame-throttle';
 import { onMounted, onBeforeUnmount, ref, getCurrentInstance } from 'vue';
 
 let _resizeObserver;
 
 if (typeof window !== 'undefined' && window.ResizeObserver) {
   _resizeObserver = new ResizeObserver(entries => {
-    for (const entry of entries) {
-      if (entry.target._resizeListener) {
-        entry.target._resizeListener();
+    requestAnimationFrame(() => {
+      for (const entry of entries) {
+        if (entry.target?._resizeListener) {
+          entry.target._resizeListener();
+        }
       }
-    }
+    });
   });
 }
 
@@ -28,8 +29,7 @@ export default function useKResponsiveElement() {
   onMounted(() => {
     updateEl();
     if (_resizeObserver) {
-      const throttledUpdateEl = throttle(updateEl);
-      instance.proxy.$el._resizeListener = throttledUpdateEl;
+      instance.proxy.$el._resizeListener = updateEl;
 
       _resizeObserver.observe(instance.proxy.$el);
     }


### PR DESCRIPTION
## Description

Wraps ResizeObserver callback in `useKResponsiveElement` with requestAnimationFrame to avoid possible resize observer issues, see https://github.com/learningequality/kolibri-design-system/issues/960.

#### Issue addressed

Closes #960.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Wraps ResizeObserver callback in `useKResponsiveElement` with requestAnimationFrame to avoid possible resize observer issues.
  - **Products impact:** none.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/960.
  - **Components:** -.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
