### PR TITLE
[KSelect] Add truncateOptionsLabel prop

### DIFF
--- a/lib/KSelect/KSelectOption.vue
+++ b/lib/KSelect/KSelectOption.vue
@@ -108,12 +108,20 @@
           };
         },
       },
+      /**
+       * Whether to truncate the label text if it is too long, and keep it on one line.
+       */
+      truncateLabel: {
+        type: Boolean,
+        default: true,
+      },
     },
 
     computed: {
       classes() {
         return [
           `ui-select-option--type-${this.type}`,
+          { 'truncate-label': this.truncateLabel },
           { 'is-highlighted': this.highlighted },
           { 'is-selected': this.selected },
           { 'is-disabled': this.option.disabled },
@@ -172,9 +180,11 @@
     }
   }
 
-  .ui-select-option-basic,
-  .ui-select-option-image-text {
-    @include text-truncation;
+  .truncate-label {
+    .ui-select-option-basic,
+    .ui-select-option-image-text {
+      @include text-truncation;
+    }
   }
 
   .ui-select-option-image {

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -133,6 +133,7 @@
                 :multiple="multiple"
                 :option="option"
                 :selected="isOptionSelected(option)"
+                :truncateLabel="truncateOptionsLabel"
                 type="basic"
                 @click.native.stop="selectOption(option)"
                 @mouseover.native.stop="onMouseover(option)"
@@ -380,6 +381,15 @@
       inline: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * Whether or not to truncate the options label
+       * when the label is too long to fit in one line.
+       * If false, the label will break into multiple lines.
+       */
+      truncateOptionsLabel: {
+        type: Boolean,
+        default: true,
       },
     },
     data() {


### PR DESCRIPTION
## Description

* Adds truncateOptionsLabel prop to control wether to truncate or wrap KSelect options label when it overflows.

#### Issue addressed

Needed to fix https://github.com/learningequality/kolibri/issues/12166.

### Before/after screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/2938ebe6-f84b-41f8-a054-2765421b7826) | ![image](https://github.com/user-attachments/assets/7119239f-dad2-46d4-b929-f79e49d074b0) |


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Adds truncateOptionsLabel prop to control wether to truncate or wrap KSelect options label when it overflows.
  - **Products impact:** new API.
  - **Addresses:** https://github.com/learningequality/kolibri/issues/12166.
  - **Components:** KSelect.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Check out this [Kolibri PR](https://github.com/learningequality/kolibri/pull/13404).
2. Go to learn > library
3. Check KSelect options wrapped.

## Comments

Does the prop name makes sense? Should it be changed? Should it be set to `false` by default?
