### PR TITLE
[KTable] : Added horizontal separator lines

### DIFF
--- a/lib/KTable/KTableGridItem.vue
+++ b/lib/KTable/KTableGridItem.vue
@@ -2,7 +2,7 @@
 
   <td
     :class="$computedClass(coreOutlineFocus)"
-    :style="{ textAlign: textAlign, minWidth: minWidth, width: width }"
+    :style="tdStyle"
     tabindex="0"
     data-focus="true"
     role="gridcell"
@@ -57,6 +57,14 @@
           },
         };
       },
+      tdStyle() {
+        return {
+          textAlign: this.textAlign,
+          minWidth: this.minWidth,
+          width: this.width,
+          borderBottom: `1px solid ${this.$themeTokens.fineLine}`,
+        };
+      },
     },
     methods: {
       onKeydown(event) {
@@ -83,6 +91,10 @@
   .cell-content {
     word-break: break-word;
     white-space: normal;
+  }
+
+  td {
+    border-bottom: 1px solid;
   }
 
 </style>

--- a/lib/KTable/KTableGridItem.vue
+++ b/lib/KTable/KTableGridItem.vue
@@ -93,8 +93,4 @@
     white-space: normal;
   }
 
-  td {
-    border-bottom: 1px solid;
-  }
-
 </style>

--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -43,6 +43,7 @@
                 { backgroundColor: $themePalette.white },
                 isColumnFocused(index) ? { backgroundColor: $themePalette.grey.v_100 } : {},
                 { textAlign: getTextAlign(header.dataType) },
+                { borderBottom: `1px solid ${$themeTokens.fineLine}` },
               ]"
               role="columnheader"
               data-focus="true"
@@ -202,6 +203,7 @@
         const style = {};
         if (header.minWidth) style.minWidth = header.minWidth;
         if (header.width) style.width = header.width;
+
         return style;
       };
 

--- a/lib/__tests__/KTable.spec.js
+++ b/lib/__tests__/KTable.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import KTable from '../KTable';
 import { renderComponentForVisualTest, takeSnapshot } from '../../jest.conf/visual.testUtils';
 
-describe.visual('KTable Border Visual Test', () => {
+describe.visual('Sortable Table', () => {
   const snapshotOptions = { widths: [600], minHeight: 200 };
 
   it('renders header with correct borderBottom style', async () => {

--- a/lib/__tests__/KTable.spec.js
+++ b/lib/__tests__/KTable.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import KTable from '../KTable';
 import { renderComponentForVisualTest, takeSnapshot } from '../../jest.conf/visual.testUtils';
 
-describe.visual('Sortable Table', () => {
+describe.visual('Sortable Table Visual Test', () => {
   const snapshotOptions = { widths: [600], minHeight: 200 };
 
   it('renders header with correct borderBottom style', async () => {

--- a/lib/__tests__/KTable.spec.js
+++ b/lib/__tests__/KTable.spec.js
@@ -1,5 +1,35 @@
 import { mount } from '@vue/test-utils';
 import KTable from '../KTable';
+import { renderComponentForVisualTest, takeSnapshot } from '../../jest.conf/visual.testUtils';
+
+describe.visual('KTable Border Visual Test', () => {
+  const snapshotOptions = { widths: [600], minHeight: 200 };
+
+  it('renders header with correct borderBottom style', async () => {
+    await renderComponentForVisualTest('KTable', {
+      headers: [
+        { label: 'Name', dataType: 'string', columnId: 'name' },
+        { label: 'Age', dataType: 'number', columnId: 'age' },
+      ],
+      rows: [
+        ['Alice', 25],
+        ['Bob', 30],
+      ],
+      caption: 'Test Table',
+      sortable: true,
+    });
+    await takeSnapshot('KTable - Header borderBottom style', snapshotOptions, async page => {
+      const th = await page.$('thead th');
+      const borderBottom = await page.evaluate(el => getComputedStyle(el).borderBottom, th);
+      const borderColor = await page.evaluate(el => getComputedStyle(el).borderBottomColor, th);
+
+      const themeFineLine = '#e0e0e0'; //Using dummy color here.
+
+      expect(borderBottom).toContain('1px solid');
+      expect(borderColor.toLowerCase()).toBe(themeFineLine.toLowerCase());
+    });
+  });
+});
 
 const assertTableContent = (wrapper, rows) => {
   const tableRows = wrapper.findAll('tbody tr');


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Added horizontal separator lines below each row, based on the Figma design provided.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1036

### Before/after screenshots
<!-- Insert images here if applicable -->
Before
![before](https://github.com/user-attachments/assets/ca51f107-828d-42d6-95d6-29884779cf85)
After 
![after](https://github.com/user-attachments/assets/be06576d-52be-4f7d-a65a-1494625455d4)


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Added horizontal separator lines
  - **Products impact:** None
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1036
  - **Components:** KTable
  - **Breaking:** No
  - **Impacts a11y:** No
  - **Guidance:**  - 

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
