### PR TITLE
Add presentational prop to KCheckbox

### DIFF
--- a/lib/KCheckbox/index.vue
+++ b/lib/KCheckbox/index.vue
@@ -3,11 +3,13 @@
   <div
     class="k-checkbox-container"
     :class="{ 'k-checkbox-disabled': disabled }"
+    :style="{ pointerEvents: presentational ? 'none' : 'auto' }"
     @click="toggleCheck"
   >
     <div class="tr">
       <div class="k-checkbox">
         <input
+          v-if="!presentational"
           :id="id"
           ref="kCheckboxInput"
           type="checkbox"
@@ -42,10 +44,11 @@
         />
       </div>
 
-      <label
+      <component
+        :is="labelTag"
         :dir="labelDir"
         class="k-checkbox-label"
-        :for="id"
+        :for="presentational ? null : id"
         :class="{ visuallyhidden: !showLabel }"
         :style="labelStyle"
         @click.prevent
@@ -63,7 +66,7 @@
         >
           {{ description }}
         </div>
-      </label>
+      </component>
     </div>
   </div>
 
@@ -129,6 +132,16 @@
         default: null,
         required: false,
       },
+      /**
+       * Whether or not the checkbox is presentational.
+       * Useful for cases where the checkbox is used
+       * as a visual element only, and keyboard focus
+       * should be managed by other elements.
+       */
+      presentational: {
+        type: Boolean,
+        default: false,
+      },
     },
     data: () => ({
       isActive: false,
@@ -157,6 +170,9 @@
         return {
           color: this.disabled ? this.$themeTokens.textDisabled : '',
         };
+      },
+      labelTag() {
+        return this.presentational ? 'div' : 'label';
       },
     },
     methods: {


### PR DESCRIPTION
## Description
* Adds `presentational` prop to KCheckbox, to make the checkbox unfocusable but not disabled.

#### Issue addressed

Needed for https://github.com/learningequality/kolibri/issues/13408.


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:**  Adds `presentational` prop to KCheckbox, to make the checkbox unfocusable but not disabled.
  - **Products impact:** new API.
  - **Addresses:** https://github.com/learningequality/kolibri/issues/13408.
  - **Components:** KCheckbox.
  - **Breaking:** no
  - **Impacts a11y:** yes.
  - **Guidance:**.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

* You can test the changes in https://github.com/learningequality/kolibri/pull/13460 where this new prop is used.

