### PR TITLE
Use correct name for KToolbar

### DIFF
--- a/lib/KToolbar.vue
+++ b/lib/KToolbar.vue
@@ -65,7 +65,7 @@
   import UiProgressLinear from './keen/UiProgressLinear.vue';
 
   export default {
-    name: 'UiToolbar',
+    name: 'KToolbar',
 
     components: {
       UiIconButton,


### PR DESCRIPTION
## Description

At some point, we've exposed `UiToolbar` as `KToolbar` but the component's name stayed `UiToolbar`. This renames it to `KToolbar`.

I found no imports referencing `UiToolbar` in Kolibri and neither Studio, so this should have no impact.

#### Issue addressed

I tried to search for `KToolbar`s in Kolibri in Vue Devtools, and seeing `UiToolbar` in component's tree was confusing.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Rename `UiToolbar` component name to `KToolbar`
  - **Products impact:** none
  - **Addresses:**-
  - **Components:** KToolbar
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->