### PR TITLE
Adds configurable sticky columns to KTable

### DIFF
--- a/docs/pages/ktable.vue
+++ b/docs/pages/ktable.vue
@@ -98,6 +98,28 @@
         block
       />
 
+      <!-- Table with sticky columns -->
+      <h3>Table with sticky columns</h3>
+      <p>
+        This is an example to show how <code>KTable</code> can be used with sticky columns. The
+        <code>stickyColumns</code> prop is used to define which columns should be sticky. The value
+        can be a string or an array of strings. The string can be one of the following:
+      </p>
+      <ul>
+        <li><code>first</code> - makes the first column sticky</li>
+        <li><code>last</code> - makes the last column sticky</li>
+        <li>
+          <code>firstTwo</code> - makes the first Two columns sticky; overrides "first" if both are
+          present
+        </li>
+      </ul>
+      <DocsExample
+        loadExample="KTable/StickyColumns.vue"
+        exampleId="sticky-columns"
+        block
+      />
+
+      <!-- Disable built-in sorting -->
       <h3>Disable built-in sorting</h3>
       <p>
         For <code>sortable</code> tables, you can use the <code>disableBuiltinSorting</code> prop to

--- a/examples/KTable/StickyColumns.vue
+++ b/examples/KTable/StickyColumns.vue
@@ -1,0 +1,75 @@
+<template>
+
+  <KTable
+    :headers="headersWithCustomWidths"
+    :rows="customRows"
+    :stickyColumns="stickyColumns"
+    caption="Table showing sticky columns"
+    sortable
+  />
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        headersWithCustomWidths: [
+          { label: 'Name', dataType: 'string', minWidth: '120px', columnId: 'name' },
+          { label: 'Age', dataType: 'number', minWidth: '100px', columnId: 'age' },
+          { label: 'City', dataType: 'string', minWidth: '200px', columnId: 'city' },
+          {
+            label: 'Joined',
+            dataType: 'date',
+            minWidth: '150px',
+            columnId: 'joined',
+          },
+          {
+            label: 'Favorite Color',
+            dataType: 'string',
+            minWidth: '150px',
+            columnId: 'favoriteColor',
+          },
+          {
+            label: 'Favorite Food',
+            dataType: 'string',
+            minWidth: '150px',
+            columnId: 'favoriteFood',
+          },
+          {
+            label: 'Options',
+            dataType: 'string',
+            minWidth: '200px',
+            columnId: 'options',
+          },
+        ],
+        customRows: [
+          ['John Doe', 28, 'New York', '2022-01-15T00:00:00Z', 'Blue', 'Pizza', 'Edit/Delete'],
+          [
+            'Jane Smith',
+            34,
+            'Los Angeles',
+            '2021-12-22T00:00:00Z',
+            'Green',
+            'Sushi',
+            'Edit/Delete',
+          ],
+          ['Samuel Green', 22, 'Chicago', '2023-03-10T00:00:00Z', 'Red', 'Tacos', 'Edit/Delete'],
+          [
+            'Alice Johnson',
+            30,
+            'Houston',
+            '2020-07-18T00:00:00Z',
+            'Purple',
+            'Burgers',
+            'Edit/Delete',
+          ],
+        ],
+        stickyColumns: ['firstTwo', 'last'],
+      };
+    },
+  };
+
+</script>

--- a/lib/KTable/KTableGridItem.vue
+++ b/lib/KTable/KTableGridItem.vue
@@ -63,6 +63,8 @@
           minWidth: this.minWidth,
           width: this.width,
           borderBottom: `1px solid ${this.$themeTokens.fineLine}`,
+          minHeight: '40px',
+          height: 'auto',
         };
       },
     },
@@ -89,6 +91,9 @@
 <style scoped>
 
   .cell-content {
+    display: flex;
+    align-items: center;
+    min-height: 40px;
     word-break: break-word;
     white-space: normal;
   }

--- a/lib/KTable/KTableGridItem.vue
+++ b/lib/KTable/KTableGridItem.vue
@@ -91,9 +91,7 @@
 <style scoped>
 
   .cell-content {
-    display: flex;
-    align-items: center;
-    min-height: 40px;
+    justify-content: inherit;
     word-break: break-word;
     white-space: normal;
   }

--- a/lib/KTable/__tests__/KTable.spec.js
+++ b/lib/KTable/__tests__/KTable.spec.js
@@ -1,0 +1,91 @@
+import { shallowMount } from '@vue/test-utils';
+import KTable from '../';
+
+import {
+  renderComponentForVisualTest,
+  takeSnapshot,
+  scrollToPos,
+  delay,
+} from '../../../jest.conf/visual.testUtils';
+
+function makeWrapper(opts) {
+  return shallowMount(KTable, opts);
+}
+
+describe('KTable', () => {
+  const basicHeaders = [
+    { label: 'Name', dataType: 'string', columnId: 'name' },
+    { label: 'Age', dataType: 'number', columnId: 'age' },
+    { label: 'City', dataType: 'string', columnId: 'city' },
+  ];
+
+  const basicRows = [
+    ['John Doe', 28, 'New York'],
+    ['Jane Smith', 34, 'Los Angeles'],
+  ];
+
+  it('renders without errors with basic props', () => {
+    const wrapper = makeWrapper({
+      propsData: {
+        headers: basicHeaders,
+        rows: basicRows,
+        caption: 'Basic table test',
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('table').exists()).toBe(true);
+  });
+
+  it('renders with sticky columns', () => {
+    const wrapper = makeWrapper({
+      propsData: {
+        headers: basicHeaders,
+        rows: basicRows,
+        caption: 'Sticky columns test',
+        stickyColumns: ['first'],
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('.sticky-column').exists()).toBe(true);
+  });
+});
+
+// intial implementation written with Claude
+describe.visual('KTable', () => {
+  const wideSnapshotOptions = { widths: [1200], minHeight: 400 };
+  const scrolledSnapshotOptions = { widths: [800], minHeight: 400 };
+
+  it('Render KTable with sticky columns - default state', async () => {
+    await renderComponentForVisualTest('KTableStickyColumnsTest');
+    await takeSnapshot('KTable - sticky columns - default', wideSnapshotOptions);
+  });
+
+  it('Render KTable with sticky columns - scrolled horizontally', async () => {
+    await renderComponentForVisualTest('KTableStickyColumnsScrollTest');
+    await delay(500); // Allow table to render
+
+    // Scroll the table horizontally to test sticky column behavior
+    await scrollToPos('.k-table-wrapper', { left: 300 });
+    await delay(300); // Allow scroll to complete
+
+    await takeSnapshot('KTable - sticky columns - scrolled', scrolledSnapshotOptions);
+  });
+
+  it('Render KTable cell height consistency', async () => {
+    await renderComponentForVisualTest('KTableCellHeightTest');
+    await takeSnapshot('KTable - cell height consistency', wideSnapshotOptions);
+  });
+
+  it('Render KTable dropshadow indicators', async () => {
+    await renderComponentForVisualTest('KTableDropshadowTest');
+    await delay(500); // Allow table to render and calculate scrollability
+
+    // Scroll slightly to activate dropshadow
+    await scrollToPos('.k-table-wrapper', { left: 50 });
+    await delay(300);
+
+    await takeSnapshot('KTable - dropshadow indicators', scrolledSnapshotOptions);
+  });
+});

--- a/lib/KTable/__tests__/components/KTableCellHeight.vue
+++ b/lib/KTable/__tests__/components/KTableCellHeight.vue
@@ -1,0 +1,54 @@
+<template>
+
+  <div>
+    <h3>Regular Table (no sticky columns)</h3>
+    <div style="width: 600px; height: 200px; margin-bottom: 20px; border: 1px solid #cccccc">
+      <KTable
+        :headers="headers"
+        :rows="mixedContentRows"
+        caption="Regular table - cell height test"
+      />
+    </div>
+
+    <h3>Sticky Columns Table</h3>
+    <div style="width: 600px; height: 200px; border: 1px solid #cccccc">
+      <KTable
+        :headers="headers"
+        :rows="mixedContentRows"
+        :stickyColumns="['first']"
+        caption="Sticky columns table - cell height test"
+      />
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KTableCellHeight',
+    data() {
+      return {
+        headers: [
+          { label: 'Name', dataType: 'string', minWidth: '120px', columnId: 'name' },
+          { label: 'Short', dataType: 'string', minWidth: '80px', columnId: 'short' },
+          { label: 'Long Content', dataType: 'string', minWidth: '200px', columnId: 'long' },
+          { label: 'Number', dataType: 'number', minWidth: '100px', columnId: 'number' },
+        ],
+        mixedContentRows: [
+          ['John', 'A', 'This is a longer piece of content that should wrap', 42],
+          ['Jane Smith', 'B', 'Short', 156],
+          ['Very Long Name Here', 'C', 'Medium length content here', 789],
+          [
+            'Bob',
+            'D',
+            'Another long piece of content that demonstrates text wrapping in table cells',
+            23,
+          ],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/lib/KTable/__tests__/components/KTableDropshadow.vue
+++ b/lib/KTable/__tests__/components/KTableDropshadow.vue
@@ -1,0 +1,98 @@
+<template>
+
+  <div>
+    <h3>Dropshadow Test - Sticky Columns with Wide Content</h3>
+    <div style="width: 700px; height: 300px; border: 1px solid #cccccc">
+      <KTable
+        :headers="wideHeaders"
+        :rows="sampleRows"
+        :stickyColumns="['firstTwo', 'last']"
+        caption="Table with dropshadow indicators on sticky columns"
+        sortable
+      />
+    </div>
+    <p><small>Scroll horizontally to see dropshadows appear on sticky columns</small></p>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KTableDropshadow',
+    data() {
+      return {
+        wideHeaders: [
+          { label: 'ID', dataType: 'number', minWidth: '80px', columnId: 'id' },
+          { label: 'Name', dataType: 'string', minWidth: '140px', columnId: 'name' },
+          { label: 'Department', dataType: 'string', minWidth: '180px', columnId: 'department' },
+          { label: 'Position', dataType: 'string', minWidth: '160px', columnId: 'position' },
+          { label: 'Location', dataType: 'string', minWidth: '160px', columnId: 'location' },
+          { label: 'Start Date', dataType: 'date', minWidth: '140px', columnId: 'startDate' },
+          { label: 'Salary', dataType: 'number', minWidth: '120px', columnId: 'salary' },
+          { label: 'Manager', dataType: 'string', minWidth: '140px', columnId: 'manager' },
+          { label: 'Actions', dataType: 'undefined', minWidth: '100px', columnId: 'actions' },
+        ],
+        sampleRows: [
+          [
+            1,
+            'John Doe',
+            'Engineering',
+            'Senior Engineer',
+            'New York',
+            '2022-01-15',
+            95000,
+            'Sarah Connor',
+            'Edit',
+          ],
+          [
+            2,
+            'Jane Smith',
+            'Design',
+            'UX Designer',
+            'Los Angeles',
+            '2021-12-22',
+            85000,
+            'Mike Johnson',
+            'Edit',
+          ],
+          [
+            3,
+            'Samuel Green',
+            'Engineering',
+            'Junior Developer',
+            'Chicago',
+            '2023-03-10',
+            65000,
+            'Sarah Connor',
+            'Edit',
+          ],
+          [
+            4,
+            'Alice Johnson',
+            'Marketing',
+            'Product Manager',
+            'Houston',
+            '2020-07-18',
+            105000,
+            'David Wilson',
+            'Edit',
+          ],
+          [
+            5,
+            'Bob Wilson',
+            'Sales',
+            'Account Executive',
+            'Miami',
+            '2022-05-20',
+            75000,
+            'Lisa Brown',
+            'Edit',
+          ],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/lib/KTable/__tests__/components/KTableStickyColumns.vue
+++ b/lib/KTable/__tests__/components/KTableStickyColumns.vue
@@ -1,0 +1,65 @@
+<template>
+
+  <div style="width: 600px; height: 300px; border: 1px solid #cccccc">
+    <KTable
+      :headers="wideHeaders"
+      :rows="sampleRows"
+      :stickyColumns="['first']"
+      caption="Table with sticky first column"
+      sortable
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KTableStickyColumns',
+    data() {
+      return {
+        wideHeaders: [
+          { label: 'Name', dataType: 'string', minWidth: '120px', columnId: 'name' },
+          { label: 'Age', dataType: 'number', minWidth: '100px', columnId: 'age' },
+          { label: 'City', dataType: 'string', minWidth: '200px', columnId: 'city' },
+          { label: 'Country', dataType: 'string', minWidth: '150px', columnId: 'country' },
+          { label: 'Profession', dataType: 'string', minWidth: '180px', columnId: 'profession' },
+          { label: 'Email', dataType: 'string', minWidth: '250px', columnId: 'email' },
+          { label: 'Phone', dataType: 'string', minWidth: '150px', columnId: 'phone' },
+        ],
+        sampleRows: [
+          ['John Doe', 28, 'New York', 'USA', 'Engineer', 'john.doe@example.com', '+1-555-0123'],
+          [
+            'Jane Smith',
+            34,
+            'Los Angeles',
+            'USA',
+            'Designer',
+            'jane.smith@example.com',
+            '+1-555-0124',
+          ],
+          [
+            'Samuel Green',
+            22,
+            'Chicago',
+            'USA',
+            'Developer',
+            'sam.green@example.com',
+            '+1-555-0125',
+          ],
+          [
+            'Alice Johnson',
+            30,
+            'Houston',
+            'USA',
+            'Manager',
+            'alice.johnson@example.com',
+            '+1-555-0126',
+          ],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/lib/KTable/__tests__/components/KTableStickyColumnsScroll.vue
+++ b/lib/KTable/__tests__/components/KTableStickyColumnsScroll.vue
@@ -1,0 +1,94 @@
+<template>
+
+  <div style="width: 800px; height: 400px; border: 1px solid #cccccc">
+    <KTable
+      :headers="wideHeaders"
+      :rows="sampleRows"
+      :stickyColumns="['firstTwo', 'last']"
+      caption="Table with first two and last columns sticky - scrollable"
+      sortable
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KTableStickyColumnsScroll',
+    data() {
+      return {
+        wideHeaders: [
+          { label: 'Name', dataType: 'string', minWidth: '140px', columnId: 'name' },
+          { label: 'Age', dataType: 'number', minWidth: '80px', columnId: 'age' },
+          { label: 'City', dataType: 'string', minWidth: '200px', columnId: 'city' },
+          { label: 'Country', dataType: 'string', minWidth: '150px', columnId: 'country' },
+          { label: 'Profession', dataType: 'string', minWidth: '180px', columnId: 'profession' },
+          { label: 'Company', dataType: 'string', minWidth: '200px', columnId: 'company' },
+          { label: 'Email', dataType: 'string', minWidth: '250px', columnId: 'email' },
+          { label: 'Phone', dataType: 'string', minWidth: '150px', columnId: 'phone' },
+          { label: 'Actions', dataType: 'undefined', minWidth: '120px', columnId: 'actions' },
+        ],
+        sampleRows: [
+          [
+            'John Doe',
+            28,
+            'New York',
+            'USA',
+            'Engineer',
+            'TechCorp',
+            'john.doe@example.com',
+            '+1-555-0123',
+            'Edit/Delete',
+          ],
+          [
+            'Jane Smith',
+            34,
+            'Los Angeles',
+            'USA',
+            'Designer',
+            'DesignCo',
+            'jane.smith@example.com',
+            '+1-555-0124',
+            'Edit/Delete',
+          ],
+          [
+            'Samuel Green',
+            22,
+            'Chicago',
+            'USA',
+            'Developer',
+            'CodeWorks',
+            'sam.green@example.com',
+            '+1-555-0125',
+            'Edit/Delete',
+          ],
+          [
+            'Alice Johnson',
+            30,
+            'Houston',
+            'USA',
+            'Manager',
+            'ManageCorp',
+            'alice.johnson@example.com',
+            '+1-555-0126',
+            'Edit/Delete',
+          ],
+          [
+            'Bob Wilson',
+            45,
+            'Miami',
+            'USA',
+            'Analyst',
+            'DataFlow',
+            'bob.wilson@example.com',
+            '+1-555-0127',
+            'Edit/Delete',
+          ],
+        ],
+      };
+    },
+  };
+
+</script>

--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -749,14 +749,10 @@
         if (cellRect.left < availableLeft) {
           const scrollAmount = availableLeft - cellRect.left;
           tableWrapper.scrollLeft -= scrollAmount;
-        }
-
-        else if (cellRect.right > availableRight) {
+        } else if (cellRect.right > availableRight) {
           const scrollAmount = cellRect.right - availableRight;
           tableWrapper.scrollLeft += scrollAmount;
-        }
-
-        else if (cellRect.width > availableWidth && cellRect.left > availableLeft) {
+        } else if (cellRect.width > availableWidth && cellRect.left > availableLeft) {
           const scrollAmount = cellRect.left - availableLeft;
           tableWrapper.scrollLeft += scrollAmount;
         }


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
This PR allows for configurable stickiness for the first, first two, and last columns on a table

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses [#1005](https://github.com/learningequality/kolibri-design-system/issues/1005)

### Before/after screenshots

default table with no content that overflows width; default table (i.e. no changes made by me to the documentation page for this example) when the content overflows the width; specific sticky column implementation

https://github.com/user-attachments/assets/6d9dbf95-6554-4efd-8be5-d849d92d135e



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** This PR adds optional sticky columns for the first, firstTwo, and last columns. The default is 'first' only if nothing else is specified, and the stickiness is only apparent is the contents of the table is wider than the container
  - **Products impact:** Choose from - none (for internal updates) / bugfix / new API / updated API / removed API. If it's 'none', use "-" for all items below to indicate they are not relevant.
  - **Addresses:** [Link(s) to GH issue(s) addressed. Include KDS links as well as links to related issues in a consumer product repository too.](https://github.com/learningequality/kolibri-design-system/issues/1005). Part of 0.19 Kolibri work
  - **Components:** KTable
  - **Breaking:** No
  - **Impacts a11y:** No
  - **Guidance:** The "default" behavior of the first column being sticky will be introduced when KDS is updated after this is merged. Use of the additional options depends on the content of the table, and may need to be customized for mobile responsiveness

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Preview the additions to the KTable docs page built in the PR, specifically the sticky table example

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
No 

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
Is the first column being sticky a reasonable default? 

I considered a more expansive API for additional column stickiness, but practically speaking, this is the only scenario we need. Since we are also having a broader conversation about some KTable refactors for a more dev friendly experience and reducing the use of column indices, etc. I decided to start with the most narrowly scoped approach to solve the problem at hand. I also can quite think of how a middle-of-the-table column stickiness would help anything. I also considered the value of using the indices vs. using a string prop with validation. I find the user experience of the 'first', 'firstTwo', 'last' to be easiest to follow, but would be interested in any other perspectives here. 
