### PR TITLE
Improve KTabsList documentation example styling

### DIFF
--- a/docs/examples/KTabsList/CustomStyling.vue
+++ b/docs/examples/KTabsList/CustomStyling.vue
@@ -5,10 +5,10 @@
     tabsId="tabsProps"
     ariaLabel="Coach reports"
     :tabs="tabs"
-    :color="$themeTokens.textInverted"
-    :colorActive="$themeTokens.textInverted"
-    :backgroundColor="$themeTokens.primary"
-    :hoverBackgroundColor="$themeTokens.primaryDark"
+    :color="$themeTokens.primary"
+    :colorActive="$themeTokens.primary"
+    :backgroundColor="$themeTokens.secondary"
+    :hoverBackgroundColor="$themeTokens.secondaryDark"
   />
 
 </template>


### PR DESCRIPTION
## Description

Improve `KTabsList` documentation example styling so that the active tab underline is visible.

| Before | After |
| --------- | -------- |
| ![Screenshot from 2025-06-30 20-41-38](https://github.com/user-attachments/assets/2d2aeced-5923-4086-9310-f2e3922a3937) | ![Screenshot from 2025-06-30 20-55-41](https://github.com/user-attachments/assets/66b1e817-d9d3-49d0-a388-d7afc5f405f1) |

#### Issue addressed

Closes https://github.com/learningequality/kolibri-design-system/issues/993. Note that this issue was supposed to resolve a regression from https://github.com/learningequality/kolibri-design-system/pull/956 where we lost this dark background

![420808562-d5def27e-759f-410d-bfea-91b635e93122](https://github.com/user-attachments/assets/a3973687-c58d-48a6-9809-90b15398a10c)

by renewing it. But after rethinking, I think it's better to just tweak the example itself. It's simpler, and I would say that it makes clearer that background behind tabs is not `KTabsList`s responsibility (I originally used dark background only so that the white underline on active tab would be visible).

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Improves KTabsList documentation example styling
  - **Products impact:** none
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/993
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Reviewer guidance

Preview documentation build.
