### PR TITLE
fix(KExternalLink):Replace spanStyle logic in KExternalLink.vue with flex gap for consistent icon-text alignment

### DIFF
--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -12,39 +12,40 @@
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >
-    <!-- @slot Slot alternative to the `icon` prop -->
-    <slot name="icon">
+    <span class="kexlink-inner">
+      <!-- @slot Icon before text. Slot alternative to the `icon` prop. -->
+      <slot name="icon">
+        <KIcon
+          v-if="icon"
+          :icon="icon"
+          :color="iconColor"
+        />
+      </slot>
+
+      <!-- @slot Link text -->
+      <slot v-if="$slots.default"></slot>
+
+      <template v-else>
+        <span
+          class="link-text"
+          :style="spanStyle"
+        >{{ text }}</span>
+      </template>
+
+      <!-- @slot Icon after text. Slot alternative to the `iconAfter` prop. -->
+      <slot name="iconAfter">
+        <KIcon
+          v-if="iconAfter"
+          :icon="iconAfter"
+          :color="iconColor"
+        />
+      </slot>
       <KIcon
-        v-if="icon"
-        :icon="icon"
-        style="top: 4px"
+        v-if="openInNewTab"
+        icon="openNewTab"
         :color="iconColor"
       />
-    </slot>
-
-    <slot v-if="$slots.default"></slot>
-
-    <template v-else>
-      <span
-        class="link-text"
-        :style="spanStyle"
-      >{{ text }}</span>
-    </template>
-
-    <slot name="iconAfter">
-      <KIcon
-        v-if="iconAfter"
-        :icon="iconAfter"
-        style="top: 4px"
-        :color="iconColor"
-      />
-    </slot>
-    <KIcon
-      v-if="openInNewTab"
-      icon="openNewTab"
-      style="top: 4px"
-      :color="iconColor"
-    />
+    </span>
   </a>
 
 </template>
@@ -102,37 +103,6 @@
         hovering: false,
       };
     },
-    computed: {
-      /**
-       * If link opens in new tab or if icon is provided,
-       * add 8px margin between the icon and the text
-       */
-      spanStyle() {
-        const styles = {};
-        if (this.openInNewTab || this.icon) {
-          if (this.isRtl) {
-            // If RTL-language, but English link, displays correct margins
-            styles['marginRight'] = '8px';
-            // Checks to see if link for new tab is in same dir as page lang
-            if (this.text !== this.href) {
-              styles['marginRight'] = '0px';
-              styles['marginLeft'] = '8px';
-            }
-          } else {
-            if (this.text === this.href) {
-              styles['marginRight'] = '8px';
-            } else {
-              styles['marginLeft'] = '8px';
-            }
-          }
-        }
-
-        if (this.iconAfter) {
-          styles['marginRight'] = '8px';
-        }
-        return { ...styles };
-      },
-    },
   };
 
 </script>
@@ -141,5 +111,11 @@
 <style lang="scss" scoped>
 
   @import './buttons';
+
+  .kexlink-inner {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+  }
 
 </style>


### PR DESCRIPTION

## Description
This PR removes the conditional **spanStyle() logic from KExternalLink.vue** and replaces it with a clean, CSS-based layout using display: **inline-flex and gap: 8px.** This ensures consistent spacing between the link text and icons across all scenarios, including RTL/LTR, user-provided content, and both slot-based and prop-based icons.

This fix eliminates the need for **Studio-side layout overrides such as .kexternal-redirect,** which were temporarily used to compensate for margin bugs in KDS.

#### Issue addressed
Fixes unexpected 8px margins caused by hardcoded spanStyle logic in KExternalLink.vue.

Addresses
	•	Fixes: KDS issue #1055
	•	Unblocks: Studio issue [#5127](https://github.com/learningequality/studio/issues/5127)

### Before/after screenshots
Before:
<img width="1512" alt="Screenshot 2025-07-09 at 11 24 58 PM" src="https://github.com/user-attachments/assets/8ce535af-edd1-41fc-8c28-9bbe474a73d5" />

After:
<img width="1512" alt="Screenshot 2025-07-08 at 9 53 42 AM" src="https://github.com/user-attachments/assets/d59e11f9-9934-4009-a280-e20dffd6fea2" />



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Replaced conditional inline margin logic with inline-flex and gap styling in KExternalLink.vue.
  - **Products impact:** bugfix
  - **Addresses:**	
 	•	Fixes: KDS issue #1055
	•	Unblocks: Studio issue [#5127](https://github.com/learningequality/studio/issues/5127)
  - **Components:** KExternalLink
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** After updating Kolibri or Studio to include this version of KDS, the .kexternal-redirect class (and similar overrides) can be safely removed, as spacing is now consistently handled within KDS.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

Step 1: Open the KExternalLink component in the KDS environment.
Step 2: Preview combinations including:
	•	text === href
	•	text !== href
	•	icon via prop
	•	icon via slot
	•	openInNewTab
	•	RTL and LTR layouts
Step 3: Confirm spacing between icon and text is consistent and visually clean in all cases.
Step 4: Test in consumer (Studio) if possible — e.g., Settings > About Studio.


## (optional) Implementation notes
	•	Used .kexlink-inner class with display: inline-flex, align-items: center, and gap: 8px.
	•	Fully removed spanStyle() logic.
	•	No dependency on this.isRtl, since flex gap handles both directions automatically.
	•	No new tech debt introduced.

### At a high level, how did you implement this?
Replaced the computed spanStyle() logic (which conditionally applied margin based on RTL/LTR and icon positioning) with a simple, robust layout using display: inline-flex and gap: 8px on a wrapper .kexlink-inner class inside KExternalLink.vue. This ensures consistent icon-text spacing without requiring inline logic or RTL checks.

### Does this introduce any tech-debt items?
No new tech debt introduced. This change actually reduces complexity by:
	•	Removing hardcoded style logic and RTL conditionals
	•	Centralizing layout concerns into clean, reusable CSS
	•	Eliminating the need for downstream overrides (e.g., in Studio)

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [x] Are all UI components LTR and RTL compliant (if applicable)?
- [x] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
This update brings KExternalLink fully in line with modern CSS practices and eliminates the need for Studio-specific hacks (like .kexternal-redirect). Verified visually across LTR, RTL, slot-based and prop-based icons, and various link content combinations.

As discussed with @MisRob, I will now **open two Studio PRs**:
• One to remove the **::v-deep(.kexternal-redirect) override in the license modal**, which will close Studio issue #5127.
• Another follow-up to clean up redundant usage of **`.kexternal-redirect` in places like UsingStudio/index.vue.**

Both are now unblocked by this KDS fix.
