### PR TITLE
Fix KSelect overflows

### DIFF
--- a/lib/KSelect/__tests__/KSelect.spec.js
+++ b/lib/KSelect/__tests__/KSelect.spec.js
@@ -13,6 +13,11 @@ describe.visual('KSelect Visual Tests', () => {
     { value: 'option3', label: 'Option 3' },
   ];
 
+  const longOptions = [
+    { value: 'option1', label: 'This is a very long option label that should be truncated' },
+    { value: 'option2', label: 'Another long option label that needs to be tested' },
+  ];
+
   it('renders KSelect in its base form with a label', async () => {
     await renderComponentForVisualTest('KSelect', {
       label: 'Select an option',
@@ -137,5 +142,27 @@ describe.visual('KSelect Visual Tests', () => {
     });
     await click('.ui-select-label');
     await takeSnapshot('KSelect - Multiple selection with dropdown open', snapshotOptions);
+  });
+
+  it('renders KSelect with long labels and clearable', async () => {
+    await renderComponentForVisualTest('KSelect', {
+      label: 'Select options',
+      options: longOptions,
+      value: [longOptions[0], longOptions[1]],
+    });
+    await takeSnapshot('KSelect - Multiple selection with long labels', snapshotOptions);
+  });
+
+  it('renders KSelect with long labels and clearable', async () => {
+    await renderComponentForVisualTest('KSelect', {
+      label: 'Select options',
+      options: longOptions,
+      value: [longOptions[0], longOptions[1]],
+      clearable: true,
+    });
+    await takeSnapshot(
+      'KSelect - Multiple selection with long labels and clearable',
+      snapshotOptions,
+    );
   });
 });

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -88,6 +88,7 @@
           </UiIcon>
           <KIconButton
             v-else
+            size="small"
             class="overlay-close-button"
             icon="close"
             :ariaLabel="clearText"
@@ -1032,6 +1033,7 @@
 
   .ui-select-content {
     flex-grow: 1;
+    width: 100%;
   }
 
   .ui-select-label-text {
@@ -1135,11 +1137,6 @@
   }
 
   /* stylelint-enable */
-
-  .overlay-close-button {
-    position: absolute;
-    right: 0;
-  }
 
   .ui-select-inline {
     display: inline-block;


### PR DESCRIPTION
## Description

Fixes KSelect overflow by setting a width: 100% value to the `ui-select-content` div. Also turned the clear button small to avoid vertical overflows on button hover.

#### Issue addressed
Closes #1066.

### Before/after screenshots

| Before | After |
| --- | --- |
| <img width="558" height="190" alt="image" src="https://github.com/user-attachments/assets/ddc5de28-91c3-490a-b125-ac0e101c16e5" /> | <img width="558" height="190" alt="image" src="https://github.com/user-attachments/assets/22b10588-5d84-4387-85de-1c0d9c84131e" /> |
| <img width="558" height="190" alt="image" src="https://github.com/user-attachments/assets/7fb0593d-9977-4445-aab7-422357b40e9e" /> | <img width="558" height="190" alt="image" src="https://github.com/user-attachments/assets/9b03b241-6f7e-4f36-b287-1fc148013ba3" /> |


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Fixes KSelect content being overflowed when there was a selected option with a long label.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1066.
  - **Components:** KSelect.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

  - **Description:** Turns clear button to be small to avoid vertical overflow on button hover.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1066.
  - **Components:** KSelect.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .
 
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
