### PR TITLE
Cleanup KModal documentation

### DIFF
--- a/docs/examples/KModal/ModalWithCustomActions.vue
+++ b/docs/examples/KModal/ModalWithCustomActions.vue
@@ -5,10 +5,13 @@
     <KModal
       v-if="showModal"
       title="Title"
-      cancelText="Close"
-      @cancel="closeModal"
     >
-      Description
+      <template #actions>
+        <KIconButton
+          icon="close"
+          @click="closeModal"
+        />
+      </template>
     </KModal>
   </div>
 

--- a/docs/examples/KModal/ModalWithDifferentSizes.vue
+++ b/docs/examples/KModal/ModalWithDifferentSizes.vue
@@ -6,16 +6,12 @@
     <KButton @click="openModal('large')">Large Modal</KButton>
     <KModal
       v-if="showModal"
-      :appendToOverlay="true"
       :size="modalSize"
-      :title="`Modal with ${modalSize} size`"
+      title="Title"
+      cancelText="Close"
+      @cancel="closeModal"
     >
-      <template>
-        {{ `Modal with ${modalSize} size` }}
-      </template>
-      <template #actions>
-        <KButton @click="closeModal"> Close </KButton>
-      </template>
+      {{ `Modal with ${modalSize} size` }}
     </KModal>
   </div>
 

--- a/docs/examples/KModal/ModalWithDynamicWidth.vue
+++ b/docs/examples/KModal/ModalWithDynamicWidth.vue
@@ -4,16 +4,12 @@
     <KButton @click="openModal">Open modal</KButton>
     <KModal
       v-if="showModal"
-      :appendToOverlay="true"
+      title="Title"
       size="600"
-      :title="`Modal with precise size`"
+      cancelText="Close"
+      @cancel="closeModal"
     >
-      <template>
-        {{ `Modal with 600px size` }}
-      </template>
-      <template #actions>
-        <KButton @click="closeModal"> Close </KButton>
-      </template>
+      Modal with 600px size
     </KModal>
   </div>
 

--- a/docs/examples/KModal/ModalWithSubmitCancel.vue
+++ b/docs/examples/KModal/ModalWithSubmitCancel.vue
@@ -7,21 +7,19 @@
       v-if="showModal"
       :appendToOverlay="true"
       size="medium"
-      title="Submit form"
+      title="Title"
       submitText="Submit"
       :submitDisabled="!enableSubmit"
       cancelText="Cancel"
       @submit="modalEmits('submit')"
       @cancel="modalEmits('cancel')"
     >
-      <template>
-        <p>Check the below check box to enable the submit button</p>
-        <KCheckbox
-          :checked="enableSubmit"
-          label="Enable submit"
-          @change="triggerCheckBox"
-        />
-      </template>
+      <p>Check the below check box to enable the submit button</p>
+      <KCheckbox
+        :checked="enableSubmit"
+        label="Enable submit"
+        @change="triggerCheckBox"
+      />
     </KModal>
   </div>
 

--- a/docs/pages/kmodal.vue
+++ b/docs/pages/kmodal.vue
@@ -17,53 +17,64 @@
     >
       <DocsSubNav
         :items="[
-          { text: 'Dialog box with description', href: '#dialog-box' },
-          { text: 'Modal with enabled / disabled submit', href: '#submit-form' },
-          { text: 'Modal with predefined sizes', href: '#modal-sizes' },
-          { text: 'Modal with precise size', href: '#modal-dynamic-size' },
+          { text: 'With description', href: '#description' },
+          { text: 'With enabled / disabled submit', href: '#enabled-disabled-submit' },
+          { text: 'With predefined sizes', href: '#predefined-sizes' },
+          { text: 'With precise size', href: '#precise-size' },
+          { text: 'With custom actions', href: '#custom-actions' },
         ]"
       />
 
       <h3>
-        Dialog box with description
-        <DocsAnchorTarget anchor="#dialog-box" />
+        With description
+        <DocsAnchorTarget anchor="#description" />
       </h3>
       <p>To show information, warnings, or notifications.</p>
       <DocsExample
         loadExample="KModal/ModalWithDescription.vue"
-        exampleId="dialog-box"
+        exampleId="description"
       />
 
       <h3>
-        Modal with enabled / disabled submit
-        <DocsAnchorTarget anchor="#submit-form" />
+        With enabled / disabled submit
+        <DocsAnchorTarget anchor="#enabled-disabled-submit" />
       </h3>
-      <p>Modal with checkbox, submit, and cancel buttons</p>
+      <p>Modal with checkbox, submit, and cancel buttons.</p>
       <DocsExample
         loadExample="KModal/ModalWithSubmitCancel.vue"
-        exampleId="submit-form"
+        exampleId="enabled-disabled-submit"
       />
 
       <h3>
-        Modal with predefined sizes
-        <DocsAnchorTarget anchor="#modal-sizes" />
+        With predefined sizes
+        <DocsAnchorTarget anchor="#predefined-sizes" />
       </h3>
       <p>There are three predefined modal sizes.</p>
       <DocsExample
         loadExample="KModal/ModalWithDifferentSizes.vue"
-        exampleId="modal-sizes"
+        exampleId="predefined-sizes"
         :hideStyle="true"
         block
       />
 
       <h3>
-        Modal with precise size
-        <DocsAnchorTarget anchor="#modal-dynamic-size" />
+        With precise size
+        <DocsAnchorTarget anchor="#precise-size" />
       </h3>
-      <p>Modal with 600px width</p>
+      <p>Modal with 600px width.</p>
       <DocsExample
         loadExample="KModal/ModalWithDynamicWidth.vue"
-        exampleId="modal-dynamic-size"
+        exampleId="precise-size"
+      />
+
+      <h3>
+        With custom actions
+        <DocsAnchorTarget anchor="#custom-actions" />
+      </h3>
+      <p>Use <code>actions</code> slot to override the default buttons.</p>
+      <DocsExample
+        loadExample="KModal/ModalWithCustomActions.vue"
+        exampleId="custom-actions"
       />
     </DocsPageSection>
   </DocsPageTemplate>


### PR DESCRIPTION
## Description

- Do not demonstrate #actions slot when it's not needed
- Add a new example for #actions slot
- Few details to simplify language and make docs and examples consistent
- Make internal variables consistent

#### Issue addressed

I saw community contributors often use `#actions` slot (makes implementation a bit more complex than necessary) in cases when it'd be better to use `submitText` and `cancelText` props. Then I noticed that's what we actually demonstrated in our docs.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Clean up KModal documentation
  - **Products impact:** None
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -

## Reviewer guidance

See the [preview build](https://deploy-preview-1101--kolibri-design-system.netlify.app/kmodal).
