### PR TITLE
Refactor visual tests suites

### DIFF
--- a/docs/plugins/load-common-components.js
+++ b/docs/plugins/load-common-components.js
@@ -18,6 +18,8 @@ import DocsToggleButton from '~/common/DocsToggleButton';
 import DocsFilter from '~/common/DocsFilter';
 import DocsTable from '~/common/DocsTable';
 import DocsSubNav from '~/common/DocsSubNav';
+import VisualTestExample from '~~/jest.conf/components/VisualTestExample.vue';
+import VisualTestLayout from '~~/jest.conf/components/VisualTestLayout.vue';
 
 Vue.component('DocsExample', DocsExample);
 Vue.component('DocsPageTemplate', DocsPageTemplate);
@@ -38,3 +40,7 @@ Vue.component('DocsSubNav', DocsSubNav);
 Vue.component('Card', Card);
 
 Vue.use(VueSimpleMarkdown);
+
+// Visual tests helper components
+Vue.component('VisualTestExample', VisualTestExample);
+Vue.component('VisualTestLayout', VisualTestLayout);

--- a/jest.conf/components/VisualTestExample.vue
+++ b/jest.conf/components/VisualTestExample.vue
@@ -1,0 +1,111 @@
+<template>
+
+  <div class="visual-test-example">
+    <div class="example-title">
+      <p>{{ title }}</p>
+    </div>
+    <div
+      :id="id"
+      class="example-content"
+      :style="{ width: width }"
+    >
+      <slot>
+        <component :is="loadedComponent" />
+      </slot>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+
+  /**
+   * Displays an example of a visual test within a card-like container,
+   * with the title displayed on top.
+   */
+  export default {
+    name: 'VisualTestExample',
+    setup(props) {
+      const loadedComponent = ref(null);
+
+      const loadComponent = async () => {
+        const component = await import(`~/examples/${props.loadExample}`);
+        loadedComponent.value = component.default;
+      };
+
+      if (props.loadExample) {
+        loadComponent();
+      }
+
+      return {
+        loadedComponent,
+      };
+    },
+    props: {
+      /**
+       * The title of the visual test example. This will be displayed on top of
+       * the example content area.
+       */
+      title: {
+        type: String,
+        required: true,
+      },
+      /**
+       * The width of the card container.
+       */
+      width: {
+        type: String,
+        default: null,
+      },
+      /**
+       * Path to the Vue component file to be displayed as example
+       * The path should be relative to the 'docs/examples/' directory.
+       * @type {String}
+       * @example 'KComponent/Variant.vue'
+       */
+      loadExample: {
+        type: String,
+        required: false,
+        default: null,
+        validator(value) {
+          return value === null || value.endsWith('.vue');
+        },
+      },
+      /**
+       * The ID of the DOM node of the visual test example container.
+       * Useful for querying the element in tests (e.g. to click it).
+       */
+      id: {
+        type: String,
+        default: null,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .visual-test-example {
+    .example-content {
+      width: fit-content;
+      padding: 16px;
+      background-color: #ffffff;
+      border: 1px solid #dddddd;
+      border-radius: 4px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    }
+
+    .example-title {
+      p {
+        margin-bottom: 2px;
+        color: #777777;
+      }
+    }
+  }
+
+</style>

--- a/jest.conf/components/VisualTestLayout.vue
+++ b/jest.conf/components/VisualTestLayout.vue
@@ -1,0 +1,50 @@
+<template>
+
+  <div class="visual-test-layout">
+    <slot></slot>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { onBeforeUnmount, ref } from 'vue';
+  import { isNuxtServerSideRendering } from '~~/lib/utils';
+
+  export default {
+    name: 'VisualTestLayout',
+    setup() {
+      const prevStyle = ref('');
+
+      if (!isNuxtServerSideRendering()) {
+        prevStyle.value = document.body.style.cssText;
+        document.body.style.backgroundColor = '#e5e5e5';
+        document.body.style.margin = '0';
+        document.body.style.padding = '0';
+        document.body.style.minWidth = '100vw';
+        document.body.style.minHeight = '100vh';
+      }
+
+      onBeforeUnmount(() => {
+        if (!isNuxtServerSideRendering()) {
+          // Restore previous styles on unmount
+          document.body.style.cssText = prevStyle.value;
+        }
+      });
+    },
+  };
+
+</script>
+
+
+<style>
+
+  .visual-test-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: flex-start;
+  }
+
+</style>

--- a/jest.conf/visual.load-test-components.js
+++ b/jest.conf/visual.load-test-components.js
@@ -1,5 +1,7 @@
 import Vue from 'vue';
 
+import VisualTestExample from './components/VisualTestExample.vue';
+import VisualTestLayout from './components/VisualTestLayout.vue';
 import KButtonWithDropdownTest from '~~/lib/buttons-and-links/__tests__/components/KButtonWithDropdownTest.vue';
 import KDropdownMenuTest from '~~/lib/KDropdownMenu/__tests__/components/KDropdownMenuTest.vue';
 import KCheckboxSlotTest from '~~/lib/KCheckbox/__tests__/components/KCheckboxSlotTest.vue';
@@ -16,6 +18,10 @@ import KImgWithBackgroundColorTest from '~~/lib/KImg/__tests__/components/KImgWi
 
 import KIconVisualTest from '~~/lib/KIcon/__tests__/components/KIconVisualTest.vue';
 import KTextboxVisualTest from '~~/lib/KTextbox/__tests__/components/KTextboxVisualTest.vue';
+
+// Visual tests helper components
+Vue.component('VisualTestExample', VisualTestExample);
+Vue.component('VisualTestLayout', VisualTestLayout);
 
 Vue.component('KCheckboxSlotTest', KCheckboxSlotTest);
 Vue.component('KButtonWithDropdownTest', KButtonWithDropdownTest);

--- a/lib/KIcon/__tests__/components/KIconVisualTest.vue
+++ b/lib/KIcon/__tests__/components/KIconVisualTest.vue
@@ -1,46 +1,45 @@
 <template>
 
-  <div>
-    <p>Basic:</p>
-    <Basic />
-
-    <p>Size:</p>
-    <Size />
-
-    <p>Color:</p>
-    <Color />
-
-    <p>Responsive:</p>
-    <Responsive />
-
-    <p>Ignores color prop:</p>
-    <KIcon
-      icon="allActivities"
-      color="green"
+  <VisualTestLayout>
+    <VisualTestExample
+      title="Basic"
+      loadExample="KIcon/Basic.vue"
     />
 
-    <p>Broken image for non-existent icon:</p>
-    <KIcon icon="Non icon" />
-  </div>
+    <VisualTestExample
+      title="Color"
+      loadExample="KIcon/Color.vue"
+    />
+
+    <VisualTestExample title="Ignores color prop">
+      <KIcon
+        icon="allActivities"
+        color="green"
+      />
+    </VisualTestExample>
+
+    <VisualTestExample title="Broken image for non-existent icon">
+      <KIcon icon="Non icon" />
+    </VisualTestExample>
+
+    <VisualTestExample
+      title="Size"
+      loadExample="KIcon/Size.vue"
+    />
+
+    <VisualTestExample
+      title="Responsive"
+      loadExample="KIcon/Responsive.vue"
+    />
+  </VisualTestLayout>
 
 </template>
 
 
 <script>
 
-  import Basic from '../../../../docs/examples/KIcon/Basic';
-  import Size from '../../../../docs/examples/KIcon/Size';
-  import Color from '../../../../docs/examples/KIcon/Color';
-  import Responsive from '../../../../docs/examples/KIcon/Responsive';
-
   export default {
     name: 'KIconVisualTest',
-    components: {
-      Basic,
-      Size,
-      Color,
-      Responsive,
-    },
   };
 
 </script>

--- a/lib/KTextbox/__tests__/KTextbox.spec.js
+++ b/lib/KTextbox/__tests__/KTextbox.spec.js
@@ -1,5 +1,9 @@
 import { shallowMount, mount } from '@vue/test-utils';
-import { renderComponentForVisualTest, takeSnapshot } from '../../../jest.conf/visual.testUtils';
+import {
+  click,
+  renderComponentForVisualTest,
+  takeSnapshot,
+} from '../../../jest.conf/visual.testUtils';
 import KTextbox from '../index';
 
 describe('KTextbox component', () => {
@@ -226,6 +230,10 @@ describe.visual('KTextbox visual tests', () => {
   const snapshotOptions = { widths: [800], minHeight: 512 };
   it('renders', async () => {
     await renderComponentForVisualTest('KTextboxVisualTest');
+
+    // Prepares active textbox test case
+    await click('#active-textbox input');
+
     await takeSnapshot('KTextbox visual tests', snapshotOptions);
   });
 });

--- a/lib/KTextbox/__tests__/components/KTextboxVisualTest.vue
+++ b/lib/KTextbox/__tests__/components/KTextboxVisualTest.vue
@@ -1,67 +1,82 @@
 <template>
 
-  <div>
-    <p>Label:</p>
-    <WithLabel />
+  <VisualTestLayout>
+    <VisualTestExample
+      title="Label"
+      width="400px"
+      loadExample="KTextbox/WithLabel.vue"
+    />
 
-    <p>Validation:</p>
-    <Validation />
+    <VisualTestExample
+      id="active-textbox"
+      title="Active textbox"
+      width="400px"
+    >
+      <KTextbox label="Active textbox" />
+    </VisualTestExample>
 
-    <p>Character Limit:</p>
-    <CharacterLimit />
+    <VisualTestExample
+      title="Validation"
+      width="400px"
+      loadExample="KTextbox/Validation.vue"
+    />
 
-    <p>Disabled:</p>
-    <Disabled />
+    <VisualTestExample
+      title="Character limit"
+      width="400px"
+      loadExample="KTextbox/CharacterLimit.vue"
+    />
 
-    <p>Readonly:</p>
-    <Readonly />
+    <VisualTestExample
+      title="Disabled"
+      width="400px"
+      loadExample="KTextbox/Disabled.vue"
+    />
 
-    <p>Number input:</p>
-    <Number />
+    <VisualTestExample
+      title="Readonly"
+      width="400px"
+      loadExample="KTextbox/Readonly.vue"
+    />
 
-    <p>Password input:</p>
-    <Password />
+    <VisualTestExample
+      title="Number input"
+      width="400px"
+      loadExample="KTextbox/Number.vue"
+    />
 
-    <p>Textarea:</p>
-    <AsTextarea />
+    <VisualTestExample
+      title="Password input"
+      width="400px"
+      loadExample="KTextbox/Password.vue"
+    />
 
-    <p>Clearable:</p>
-    <Clearable />
+    <VisualTestExample
+      title="Textarea"
+      width="400px"
+      loadExample="KTextbox/AsTextarea.vue"
+    />
 
-    <p>Invalid Text:</p>
-    <InvalidText />
-  </div>
+    <VisualTestExample
+      title="Clearable"
+      width="400px"
+      loadExample="KTextbox/Clearable.vue"
+    />
+
+    <VisualTestExample
+      title="Invalid text"
+      width="400px"
+      loadExample="KTextbox/InvalidText.vue"
+    />
+  </VisualTestLayout>
 
 </template>
 
 
 <script>
 
-  import WithLabel from '../../../../docs/examples/KTextbox/WithLabel';
-  import Validation from '../../../../docs/examples/KTextbox/Validation';
-  import CharacterLimit from '../../../../docs/examples/KTextbox/CharacterLimit';
-  import Disabled from '../../../../docs/examples/KTextbox/Disabled';
-  import Readonly from '../../../../docs/examples/KTextbox/Readonly';
-  import Number from '../../../../docs/examples/KTextbox/Number';
-  import Password from '../../../../docs/examples/KTextbox/Password';
-  import AsTextarea from '../../../../docs/examples/KTextbox/AsTextarea';
-  import Clearable from '../../../../docs/examples/KTextbox/Clearable';
-  import InvalidText from '../../../../docs/examples/KTextbox/InvalidText';
-
   export default {
     name: 'KIconVisualTest',
-    components: {
-      WithLabel,
-      Validation,
-      CharacterLimit,
-      Disabled,
-      Readonly,
-      Number,
-      Password,
-      AsTextarea,
-      Clearable,
-      InvalidText,
-    },
   };
 
 </script>


### PR DESCRIPTION
## Description
* Creates a layout for visual test suites that allows a single snapshot to show multiple visual tests cases, to provide more structure for multiple visual tests in a single snapshot.
* Refactor the existing visual test components to the new layout.
* Documentation will be handled separately by @MisRob.

<img width="788" height="1098" alt="image" src="https://github.com/user-attachments/assets/769bf199-a29b-45c4-b655-7014ef8f9f35" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Refactors visual test layout
  - **Products impact:** none.
  - **Addresses:** -.
  - **Components:** -.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
