### PR TITLE
Set containerAppearanceOverrides to ktextbox

### DIFF
--- a/lib/KTextbox/index.vue
+++ b/lib/KTextbox/index.vue
@@ -16,7 +16,7 @@
       :maxlength="maxlength"
       :autocomplete="autocomplete"
       :autocapitalize="autocapitalize"
-      :style="changedOrFocused ? $coreOutline : {}"
+      :style="[changedOrFocused ? $coreOutline : {}, appearanceOverrides]"
       :type="type"
       :min="min"
       :max="max"
@@ -163,6 +163,13 @@
       clearable: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * CSS styles to apply to the container
+       */
+      appearanceOverrides: {
+        type: Object,
+        default: null,
       },
       /**
        * @ignore


### PR DESCRIPTION
## Description
* KTextbox has an inner style `.textbox` that sets its max-width to 400px and cannot be changed.
* For some designs we need this max-width to change. So adding a `containerAppearanceOverrides` props could achieve it in a general way.
* There are several instances in Kolibri that have handled this by using [deep styles](https://github.com/search?q=repo%3Alearningequality%2Fkolibri%20%2Fdeep%2F%20.textbox&type=code), so this new prop should solve this in a more robust way.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Adds `containerAppearanceOverrides` prop to KTextbox to override its container styles without using deep selectors.
  - **Products impact:** new API.
  - **Addresses:** Will help with https://github.com/learningequality/studio/issues/5209.
  - **Components:** KTextbox.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
