### PR TITLE
Fix/kexternal unexpected margin 

### DIFF
--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -12,39 +12,37 @@
     @mouseenter="hovering = true"
     @mouseleave="hovering = false"
   >
-    <!-- @slot Slot alternative to the `icon` prop -->
-    <slot name="icon">
+    <span class="kexlink-inner">
+      <!-- @slot Slot alternative to the `icon` prop -->
+      <slot name="icon">
+        <KIcon
+          v-if="icon"
+          :icon="icon"
+          :color="iconColor"
+        />
+      </slot>
+
+      <slot v-if="$slots.default"></slot>
+
+      <template v-else>
+        <span
+          class="link-text"
+        >{{ text }}</span>
+      </template>
+
+      <slot name="iconAfter">
+        <KIcon
+          v-if="iconAfter"
+          :icon="iconAfter"
+          :color="iconColor"
+        />
+      </slot>
       <KIcon
-        v-if="icon"
-        :icon="icon"
-        style="top: 4px"
+        v-if="openInNewTab"
+        icon="openNewTab"
         :color="iconColor"
       />
-    </slot>
-
-    <slot v-if="$slots.default"></slot>
-
-    <template v-else>
-      <span
-        class="link-text"
-        :style="spanStyle"
-      >{{ text }}</span>
-    </template>
-
-    <slot name="iconAfter">
-      <KIcon
-        v-if="iconAfter"
-        :icon="iconAfter"
-        style="top: 4px"
-        :color="iconColor"
-      />
-    </slot>
-    <KIcon
-      v-if="openInNewTab"
-      icon="openNewTab"
-      style="top: 4px"
-      :color="iconColor"
-    />
+    </span>
   </a>
 
 </template>
@@ -102,37 +100,6 @@
         hovering: false,
       };
     },
-    computed: {
-      /**
-       * If link opens in new tab or if icon is provided,
-       * add 8px margin between the icon and the text
-       */
-      spanStyle() {
-        const styles = {};
-        if (this.openInNewTab || this.icon) {
-          if (this.isRtl) {
-            // If RTL-language, but English link, displays correct margins
-            styles['marginRight'] = '8px';
-            // Checks to see if link for new tab is in same dir as page lang
-            if (this.text !== this.href) {
-              styles['marginRight'] = '0px';
-              styles['marginLeft'] = '8px';
-            }
-          } else {
-            if (this.text === this.href) {
-              styles['marginRight'] = '8px';
-            } else {
-              styles['marginLeft'] = '8px';
-            }
-          }
-        }
-
-        if (this.iconAfter) {
-          styles['marginRight'] = '8px';
-        }
-        return { ...styles };
-      },
-    },
   };
 
 </script>
@@ -141,5 +108,11 @@
 <style lang="scss" scoped>
 
   @import './buttons';
+
+.kexlink-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
 
 </style>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -25,9 +25,7 @@
       <slot v-if="$slots.default"></slot>
 
       <template v-else>
-        <span
-          class="link-text"
-        >{{ text }}</span>
+        <span class="link-text">{{ text }}</span>
       </template>
 
       <slot name="iconAfter">
@@ -109,10 +107,10 @@
 
   @import './buttons';
 
-.kexlink-inner {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
+  .kexlink-inner {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+  }
 
 </style>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -18,6 +18,7 @@
         <KIcon
           v-if="icon"
           :icon="icon"
+          style="top: 4px"
           :color="iconColor"
         />
       </slot>
@@ -32,12 +33,14 @@
         <KIcon
           v-if="iconAfter"
           :icon="iconAfter"
+          style="top: 4px"
           :color="iconColor"
         />
       </slot>
       <KIcon
         v-if="openInNewTab"
         icon="openNewTab"
+        style="top: 4px"
         :color="iconColor"
       />
     </span>
@@ -110,7 +113,7 @@
   .kexlink-inner {
     display: inline-flex;
     gap: 8px;
-    align-items: center;
+    align-items: baseline;
   }
 
 </style>


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Fixes KExternalLink layout by moving flex styles from anchor element to inner wrapper span, preventing conflicts when external CSS forces anchors to `display: block`.
Here We make kexternal-redirect in studio side to set it with 0 with this help gap are fixed with all requirements.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1055

### Before/after screenshots
<!-- Insert images here if applicable -->

-  Before (with spanStyle logic):

<img width="1512" height="982" alt="kds-before" src="https://github.com/user-attachments/assets/42b61a4e-3983-4494-815c-06e23684ecd1" />

- After - English LTR:
<img width="1512" height="982" alt="Screenshot 2025-09-14 at 11 02 49 AM" src="https://github.com/user-attachments/assets/f7bc90ea-51cd-4d21-9053-f09b0f92019b" />

- After - Arabic RTL:
<img width="1512" height="982" alt="Screenshot 2025-09-14 at 11 03 16 AM" src="https://github.com/user-attachments/assets/67063543-5aa4-4263-a0ad-98dc80f8eb0a" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Fix KExternalLink's unexpected margin
  - **Products impact:** bugfix
  - **Addresses:** #1055 
  - **Components:** KExternalLink
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1.	Navigate to Studio Settings > About Studio page
2.	Verify KExternalLink components display properly aligned icons and text
3.	Test with both LTR and RTL languages

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [x] Are all UI components LTR and RTL compliant (if applicable)?


