### PR TITLE
Fix KSelect focus outline

### DIFF
--- a/lib/KSelect/KSelectOption.vue
+++ b/lib/KSelect/KSelectOption.vue
@@ -125,6 +125,9 @@
           { 'is-highlighted': this.highlighted },
           { 'is-selected': this.selected },
           { 'is-disabled': this.option.disabled },
+          this.highlighted
+            ? this.$computedClass({ ...this.$coreOutline, outlineOffset: '-2px' })
+            : '',
         ];
       },
 
@@ -169,7 +172,8 @@
       background-color: rgba(black, 0.05);
     }
 
-    &.is-highlighted:not(.is-disabled) {
+    &.is-highlighted:not(.is-disabled),
+    &:hover:not(.is-disabled) {
       background-color: rgba(black, 0.1);
     }
 

--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -28,7 +28,8 @@
       <div
         ref="label"
         class="ui-select-label"
-        :class="$computedClass({ ':focus': $coreOutline })"
+        :class="isAnyOptionHighlighted ? '' : $computedClass({ ':focus': $coreOutline })"
+        supports-modality="keyboard"
         :tabindex="disabled ? null : '0'"
         @focus="onFocus"
         @blur="selectBlur"
@@ -86,16 +87,21 @@
               <path d="M6.984 9.984h10.03L12 15z" />
             </svg>
           </UiIcon>
-          <KIconButton
+          <!-- Trick to stop keyboard events being propagated -->
+          <span
             v-else
-            size="small"
-            class="overlay-close-button"
-            icon="close"
-            :ariaLabel="clearText"
-            :color="$themeTokens.text"
-            :tooltip="clearText"
-            @click.stop="setValue()"
-          />
+            @keydown.stop
+          >
+            <KIconButton
+              size="small"
+              class="overlay-close-button"
+              icon="close"
+              :ariaLabel="clearText"
+              :color="$themeTokens.text"
+              :tooltip="clearText"
+              @click.stop="onClear"
+            />
+          </span>
         </div>
         <Popper
           v-if="appendToEl"
@@ -137,7 +143,6 @@
                 :truncateLabel="truncateOptionsLabel"
                 type="basic"
                 @click.native.stop="selectOption(option)"
-                @mouseover.native.stop="onMouseover(option)"
               >
                 <!-- @slot Optional slot to override the display of
                 the option in the options dropdown -->
@@ -435,6 +440,10 @@
         };
       },
 
+      isAnyOptionHighlighted() {
+        return Boolean(this.highlightedOption) && this.isDropdownOpen;
+      },
+
       hasLabel() {
         return Boolean(this.label) || Boolean(this.$slots.default);
       },
@@ -719,6 +728,13 @@
         }
       },
 
+      onClear() {
+        this.setValue();
+        this.$nextTick(() => {
+          this.$refs.label.focus();
+        });
+      },
+
       selectHighlighted() {
         if (
           this.highlightedOption &&
@@ -817,12 +833,6 @@
           await this.$nextTick();
           this.$refs.label.focus();
           this.isActive = true;
-        }
-      },
-
-      onMouseover(option) {
-        if (this.isDropdownOpen) {
-          this.highlightOption(option, { autoScroll: false });
         }
       },
 


### PR DESCRIPTION
## Description
* Fixes KSelect focus outline not being shown.
* Fixes clear button click action not being triggered when using the keyboard.


#### Issue addressed

Helps to address https://github.com/learningequality/kolibri/issues/13733.

### Before/after screenshots

Before:


https://github.com/user-attachments/assets/13406607-3686-4eab-9533-b9cc7b8bb647



After:

https://github.com/user-attachments/assets/b233b4ea-415c-4b9c-8c38-072a3820e044


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Fixes KSelect focus outline not being shown.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri/issues/13733.
  - **Components:** KSelect.
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** -.

  - **Description:** Fixes clear button click action not being triggered when using the keyboard.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/kolibri/issues/13733.
  - **Components:** KSelect.
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Go to KSelect docs.
2. Keyboard navigate the select component.
