### PR TITLE
KTable: Set min height during loading to prevent table height inconsistencies 

### DIFF
--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -3,151 +3,148 @@
   <div
     ref="tableWrapper"
     class="k-table-wrapper"
+    :style="wrapperInlineStyle"
   >
-    <template v-if="dataLoading">
-      <p><KCircularLoader /></p>
-    </template>
-    <template v-else>
-      <table
-        v-if="!isTableEmpty"
-        ref="tableElement"
-        class="k-table"
-        role="grid"
+    <div
+      v-show="loaderVisible"
+      class="k-table-loader"
+    >
+      <KCircularLoader />
+    </div>
+    <table
+      v-show="!loaderVisible && !isTableEmpty"
+      ref="tableElement"
+      class="k-table"
+      role="grid"
+    >
+      <caption
+        v-if="caption"
+        class="visuallyhidden"
       >
-        <caption
-          v-if="caption"
-          class="visuallyhidden"
-        >
-          {{
-            caption
-          }}
-        </caption>
-        <thead>
-          <tr ref="stickyHeader">
-            <th
-              v-for="(header, index) in headers"
-              :ref="'header-' + index"
-              :key="index"
-              tabindex="0"
-              :aria-sort="isColumnSortable(index) ? getAriaSort(index) : null"
-              :class="{
-                [$computedClass(coreOutlineFocus)]: true,
-                sortable: isColumnSortable(index),
-                'sticky-header': true,
-                'sticky-column': colIndexIsSticky(index),
-                'sticky-column-shadow-right':
-                  isTableScrollable && isRightmostLeftStickyColumn(index),
-                'sticky-column-shadow-left': isTableScrollable && isLastStickyColumn(index),
-              }"
-              :style="[
-                getHeaderStyle(header),
-                getStickyColumnStyle(-1, index), // Use -1 for header row
-                isColumnSortActive(index)
-                  ? { color: $themeBrand.primary.v_500 }
-                  : { color: $themePalette.grey.v_800 },
-                isColumnFocused(index) ? { backgroundColor: $themePalette.grey.v_100 } : {},
-                { textAlign: getTextAlign(header.dataType) },
-                { borderBottom: `1px solid ${$themeTokens.fineLine}` },
-              ]"
-              role="columnheader"
-              data-focus="true"
-              :aria-colindex="index + 1"
-              @click="sortable ? handleSort(index) : null"
-              @keydown="handleKeydown($event, -1, index)"
-            >
-              <!--@slot Scoped slot for customizing the content of each header cell.
-               Provides a header object `header` and its column index `colIndex`.-->
-              <slot
-                name="header"
-                :header="header"
-                :colIndex="index"
-              >
-                {{ header.label }}
-              </slot>
-              <span
-                v-if="isColumnSortable(index)"
-                class="sort-icon"
-              >
-                <span v-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_ASC"><KIcon
-                  icon="dropup"
-                  :color="
-                    isColumnSortActive(index)
-                      ? $themeBrand.primary.v_600
-                      : $themePalette.grey.v_800
-                  "
-                /></span>
-                <span v-else-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_DESC"><KIcon
-                  icon="dropdown"
-                  :color="
-                    isColumnSortActive(index)
-                      ? $themeBrand.primary.v_600
-                      : $themePalette.grey.v_800
-                  "
-                /></span>
-                <span v-else><KIcon
-                  icon="sortColumn"
-                  :color="$themePalette.grey.v_800"
-                /></span>
-              </span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            v-for="(row, rowIndex) in finalRows"
-            :key="rowIndex"
-            :style="getRowStyle(rowIndex)"
-            @mouseover="handleRowMouseOver(rowIndex)"
-            @mouseleave="handleRowMouseLeave"
+        {{
+          caption
+        }}
+      </caption>
+      <thead>
+        <tr ref="stickyHeader">
+          <th
+            v-for="(header, index) in headers"
+            :ref="'header-' + index"
+            :key="index"
+            tabindex="0"
+            :aria-sort="isColumnSortable(index) ? getAriaSort(index) : null"
+            :class="{
+              [$computedClass(coreOutlineFocus)]: true,
+              sortable: isColumnSortable(index),
+              'sticky-header': true,
+              'sticky-column': colIndexIsSticky(index),
+              'sticky-column-shadow-right': isTableScrollable && isRightmostLeftStickyColumn(index),
+              'sticky-column-shadow-left': isTableScrollable && isLastStickyColumn(index),
+            }"
+            :style="[
+              getHeaderStyle(header),
+              getStickyColumnStyle(-1, index), // Use -1 for header row
+              isColumnSortActive(index)
+                ? { color: $themeBrand.primary.v_500 }
+                : { color: $themePalette.grey.v_800 },
+              isColumnFocused(index) ? { backgroundColor: $themePalette.grey.v_100 } : {},
+              { textAlign: getTextAlign(header.dataType) },
+              { borderBottom: `1px solid ${$themeTokens.fineLine}` },
+            ]"
+            role="columnheader"
+            data-focus="true"
+            :aria-colindex="index + 1"
+            @click="sortable ? handleSort(index) : null"
+            @keydown="handleKeydown($event, -1, index)"
           >
-            <KTableGridItem
-              v-for="(col, colIndex) in row"
-              :ref="'cell-' + rowIndex + '-' + colIndex"
-              :key="colIndex"
-              :content="col"
-              :dataType="headers[colIndex].dataType"
-              :minWidth="headers[colIndex].minWidth"
-              :width="headers[colIndex].width"
-              :rowIndex="rowIndex"
-              :colIndex="colIndex"
-              :textAlign="getTextAlign(headers[colIndex].dataType)"
-              :class="{
-                'sticky-column': colIndexIsSticky(colIndex),
-                'sticky-column-shadow-right':
-                  isTableScrollable && isRightmostLeftStickyColumn(colIndex),
-                'sticky-column-shadow-left': isTableScrollable && isLastStickyColumn(colIndex),
-              }"
-              :style="[getCellStyle(rowIndex, colIndex), getStickyColumnStyle(rowIndex, colIndex)]"
-              data-focus="true"
-              role="gridcell"
-              :aria-colindex="colIndex + 1"
-              @keydown="handleKeydown($event, rowIndex, colIndex)"
+            <!--@slot Scoped slot for customizing the content of each header cell.
+               Provides a header object `header` and its column index `colIndex`.-->
+            <slot
+              name="header"
+              :header="header"
+              :colIndex="index"
             >
-              <template #default="slotProps">
-                <!--@slot Scoped slot for customizing the content of each data cell.
+              {{ header.label }}
+            </slot>
+            <span
+              v-if="isColumnSortable(index)"
+              class="sort-icon"
+            >
+              <span v-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_ASC"><KIcon
+                icon="dropup"
+                :color="
+                  isColumnSortActive(index) ? $themeBrand.primary.v_600 : $themePalette.grey.v_800
+                "
+              /></span>
+              <span v-else-if="isColumnSortActive(index) && sortOrder === SORT_ORDER_DESC"><KIcon
+                icon="dropdown"
+                :color="
+                  isColumnSortActive(index) ? $themeBrand.primary.v_600 : $themePalette.grey.v_800
+                "
+              /></span>
+              <span v-else><KIcon
+                icon="sortColumn"
+                :color="$themePalette.grey.v_800"
+              /></span>
+            </span>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(row, rowIndex) in finalRows"
+          :key="rowIndex"
+          :style="getRowStyle(rowIndex)"
+          @mouseover="handleRowMouseOver(rowIndex)"
+          @mouseleave="handleRowMouseLeave"
+        >
+          <KTableGridItem
+            v-for="(col, colIndex) in row"
+            :ref="'cell-' + rowIndex + '-' + colIndex"
+            :key="colIndex"
+            :content="col"
+            :dataType="headers[colIndex].dataType"
+            :minWidth="headers[colIndex].minWidth"
+            :width="headers[colIndex].width"
+            :rowIndex="rowIndex"
+            :colIndex="colIndex"
+            :textAlign="getTextAlign(headers[colIndex].dataType)"
+            :class="{
+              'sticky-column': colIndexIsSticky(colIndex),
+              'sticky-column-shadow-right':
+                isTableScrollable && isRightmostLeftStickyColumn(colIndex),
+              'sticky-column-shadow-left': isTableScrollable && isLastStickyColumn(colIndex),
+            }"
+            :style="[getCellStyle(rowIndex, colIndex), getStickyColumnStyle(rowIndex, colIndex)]"
+            data-focus="true"
+            role="gridcell"
+            :aria-colindex="colIndex + 1"
+            @keydown="handleKeydown($event, rowIndex, colIndex)"
+          >
+            <template #default="slotProps">
+              <!--@slot Scoped slot for customizing the content of each data cell.
                  Provides the content of a data cell `content`, its row index `rowIndex`,
                  its column index `colIndex`, and the corresponding whole row object `row`.-->
-                <slot
-                  name="cell"
-                  :content="slotProps.content"
-                  :rowIndex="rowIndex"
-                  :colIndex="colIndex"
-                  :row="row"
-                >
-                  {{ slotProps.content }}
-                </slot>
-              </template>
-            </KTableGridItem>
-          </tr>
-        </tbody>
-      </table>
-      <div
-        v-else
-        class="empty-message"
-      >
-        {{ emptyMessage }}
-      </div>
-    </template>
+              <slot
+                name="cell"
+                :content="slotProps.content"
+                :rowIndex="rowIndex"
+                :colIndex="colIndex"
+                :row="row"
+              >
+                {{ slotProps.content }}
+              </slot>
+            </template>
+          </KTableGridItem>
+        </tr>
+      </tbody>
+    </table>
+    <div
+      v-show="!loaderVisible && isTableEmpty"
+      class="empty-message"
+    >
+      {{ emptyMessage }}
+    </div>
   </div>
 
 </template>
@@ -156,8 +153,9 @@
 <script>
 
   import debounce from 'lodash/debounce';
-  import { onMounted, ref, computed, watch, nextTick } from 'vue';
+  import { onMounted, onBeforeUnmount, ref, computed, watch, nextTick } from 'vue';
   import useKResponsiveElement from '../composables/useKResponsiveElement';
+  import useKShow from '../composables/useKShow';
   import useSorting, {
     SORT_ORDER_ASC,
     SORT_ORDER_DESC,
@@ -177,8 +175,13 @@
       const disableBuiltinSorting = ref(props.disableBuiltinSorting);
       const tableWrapper = ref(null);
       const tableElement = ref(null);
+      const MIN_HEIGHT_PX = 120;
+      const MIN_VISIBLE_MS = 300;
+      const lastStableHeight = ref(0);
+      let resizeObserver = null;
 
       const { elementWidth } = useKResponsiveElement();
+      const { show } = useKShow();
 
       const defaultSort = ref({
         index: props.headers.findIndex(h => h.columnId === props.defaultSort.columnId),
@@ -194,6 +197,14 @@
       } = useSorting(headers, rows, defaultSort, disableBuiltinSorting);
 
       const isTableEmpty = computed(() => sortedRows.value.length === 0);
+
+      const loaderVisible = computed(() => show('KTableLoader', props.dataLoading, MIN_VISIBLE_MS));
+
+      const wrapperInlineStyle = computed(() => {
+        if (!loaderVisible.value) return {};
+        const height = Math.max(lastStableHeight.value, MIN_HEIGHT_PX);
+        return { minHeight: `${height}px` };
+      });
 
       const isTableScrollable = ref(false);
 
@@ -240,7 +251,22 @@
       onMounted(() => {
         nextTick(() => {
           debouncedCheckScrollable();
+          // Initialize ResizeObserver if browser supports it
+          if (typeof window !== 'undefined' && window.ResizeObserver) {
+            resizeObserver = new ResizeObserver(entries => {
+              if (!loaderVisible.value && entries[0]) {
+                lastStableHeight.value = tableWrapper.value.offsetHeight || 0;
+              }
+            });
+            if (tableWrapper.value) resizeObserver.observe(tableWrapper.value);
+          }
         });
+      });
+
+      onBeforeUnmount(() => {
+        if (resizeObserver) {
+          resizeObserver.disconnect();
+        }
       });
 
       return {
@@ -257,6 +283,8 @@
         isTableScrollable,
         tableWrapper,
         tableElement,
+        loaderVisible,
+        wrapperInlineStyle,
       };
     },
     props: {
@@ -994,6 +1022,14 @@
   .empty-message {
     margin-top: 16px;
     margin-bottom: 16px;
+  }
+
+  .k-table-loader {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin: 0;
+    transform: translate(-50%, -50%);
   }
 
 </style>

--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -140,7 +140,7 @@
       </tbody>
     </table>
     <div
-      v-show="!loaderVisible && isTableEmpty"
+      v-show="!(loaderVisible || delayActive) && isTableEmpty"
       class="empty-message"
     >
       {{ emptyMessage }}
@@ -191,7 +191,7 @@
         getAriaSort,
       } = useSorting(headers, rows, defaultSort, disableBuiltinSorting);
 
-      const { loaderVisible, wrapperInlineStyle } = useLoading(props, {
+      const { delayActive, loaderVisible, wrapperInlineStyle } = useLoading(props, {
         wrapperRef: tableWrapper,
         loadingDelay: 300, // delay showing loader by 300ms
         minVisibleMs: 350, // keep loader visible for at least 350ms
@@ -262,6 +262,7 @@
         isTableScrollable,
         tableWrapper,
         tableElement,
+        delayActive,
         loaderVisible,
         wrapperInlineStyle,
       };

--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -12,7 +12,7 @@
       <KCircularLoader />
     </div>
     <table
-      v-show="!loaderVisible && !isTableEmpty"
+      v-show="canShowTable && !isTableEmpty"
       ref="tableElement"
       class="k-table"
       role="grid"
@@ -140,7 +140,7 @@
       </tbody>
     </table>
     <div
-      v-show="!(loaderVisible || delayActive) && isTableEmpty"
+      v-show="canShowTable && isTableEmpty"
       class="empty-message"
     >
       {{ emptyMessage }}
@@ -197,6 +197,8 @@
         minVisibleMs: 350, // keep loader visible for at least 350ms
         minHeightPx: 120,
       });
+
+      const canShowTable = computed(() => !loaderVisible.value && !delayActive.value);
 
       const isTableEmpty = computed(() => sortedRows.value.length === 0);
 
@@ -262,7 +264,7 @@
         isTableScrollable,
         tableWrapper,
         tableElement,
-        delayActive,
+        canShowTable,
         loaderVisible,
         wrapperInlineStyle,
       };

--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -252,16 +252,16 @@
         nextTick(() => {
           debouncedCheckScrollable();
           // Initialize ResizeObserver if browser supports it
-            if (typeof window !== 'undefined' && window.ResizeObserver) {
-              resizeObserver = new ResizeObserver(entries => {
-                requestAnimationFrame(() => {
-                  if (!loaderVisible.value && entries[0]) {
-                    lastStableHeight.value = tableWrapper.value.offsetHeight || 0;
-                  }
-                });
+          if (typeof window !== 'undefined' && window.ResizeObserver) {
+            resizeObserver = new ResizeObserver(entries => {
+              requestAnimationFrame(() => {
+                if (!loaderVisible.value && entries[0]) {
+                  lastStableHeight.value = tableWrapper.value.offsetHeight || 0;
+                }
               });
-              if (tableWrapper.value) resizeObserver.observe(tableWrapper.value); 
-            }
+            });
+            if (tableWrapper.value) resizeObserver.observe(tableWrapper.value);
+          }
         });
       });
 

--- a/lib/KTable/index.vue
+++ b/lib/KTable/index.vue
@@ -176,7 +176,7 @@
       const tableWrapper = ref(null);
       const tableElement = ref(null);
       const MIN_HEIGHT_PX = 120;
-      const MIN_VISIBLE_MS = 300;
+      const MIN_VISIBLE_MS = 175;
       const lastStableHeight = ref(0);
       let resizeObserver = null;
 
@@ -252,14 +252,16 @@
         nextTick(() => {
           debouncedCheckScrollable();
           // Initialize ResizeObserver if browser supports it
-          if (typeof window !== 'undefined' && window.ResizeObserver) {
-            resizeObserver = new ResizeObserver(entries => {
-              if (!loaderVisible.value && entries[0]) {
-                lastStableHeight.value = tableWrapper.value.offsetHeight || 0;
-              }
-            });
-            if (tableWrapper.value) resizeObserver.observe(tableWrapper.value);
-          }
+            if (typeof window !== 'undefined' && window.ResizeObserver) {
+              resizeObserver = new ResizeObserver(entries => {
+                requestAnimationFrame(() => {
+                  if (!loaderVisible.value && entries[0]) {
+                    lastStableHeight.value = tableWrapper.value.offsetHeight || 0;
+                  }
+                });
+              });
+              if (tableWrapper.value) resizeObserver.observe(tableWrapper.value); 
+            }
         });
       });
 

--- a/lib/KTable/useLoading.js
+++ b/lib/KTable/useLoading.js
@@ -22,7 +22,7 @@ export default function useLoading(
   const canRecordHeight = () => !loaderVisible.value && !delayActive.value;
 
   const wrapperInlineStyle = computed(() => {
-    if (!loaderVisible.value) return {};
+    if (!(loaderVisible.value || delayActive.value)) return {};
     const height = Math.max(lastStableHeight.value, minHeightPx);
     return { minHeight: `${height}px` };
   });
@@ -97,6 +97,7 @@ export default function useLoading(
   });
 
   return {
+    delayActive,
     loaderVisible,
     wrapperInlineStyle,
   };

--- a/lib/KTable/useLoading.js
+++ b/lib/KTable/useLoading.js
@@ -1,0 +1,103 @@
+import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue';
+
+/**
+ * Manages `KTable`'s loading state and visibility:
+ * - Suppress loader if loading finishes within loadingDelay (300ms)
+ * - If shown, keep loader visible for at least minVisibleMs (350ms)
+ * - Reserve the wrapper height (minHeightPx or last stable table height) while loader visible
+ * - Measures stable height via ResizeObserver only when loader isn't visible/delayed
+ */
+export default function useLoading(
+  props,
+  { wrapperRef, loadingDelay = 300, minVisibleMs = 350, minHeightPx = 120 } = {},
+) {
+  const loaderVisible = ref(false); // Determines whether to display table loader
+  const delayActive = ref(false); // True during the delay window
+  let delayTimer = null; // setTimeout id for delay
+  let holdTimer = null; // setTimeout id for min visible time
+  let loadingStartTime = null; // Timestamp when loader actually becames visible
+  const lastStableHeight = ref(0);
+  let resizeObserver = null;
+
+  const canRecordHeight = () => !loaderVisible.value && !delayActive.value;
+
+  const wrapperInlineStyle = computed(() => {
+    if (!loaderVisible.value) return {};
+    const height = Math.max(lastStableHeight.value, minHeightPx);
+    return { minHeight: `${height}px` };
+  });
+
+  watch(
+    () => props.dataLoading,
+    isLoading => {
+      if (delayTimer) {
+        clearTimeout(delayTimer);
+        delayTimer = null;
+      }
+      if (holdTimer) {
+        clearTimeout(holdTimer);
+        holdTimer = null;
+      }
+      // Start delay window, loader isn't displayed yet
+      if (isLoading) {
+        delayActive.value = true;
+        loadingStartTime = null;
+
+        delayTimer = setTimeout(() => {
+          // Delay elapsed and still loading, show loader
+          if (props.dataLoading) {
+            loaderVisible.value = true;
+            delayActive.value = false;
+            loadingStartTime = Date.now();
+          } else {
+            // Loading ended during delay — loader will never show
+            delayActive.value = false;
+            loaderVisible.value = false;
+          }
+          delayTimer = null;
+        }, loadingDelay);
+      } else {
+        delayActive.value = false;
+
+        if (loaderVisible.value && loadingStartTime) {
+          const elapsed = Date.now() - loadingStartTime;
+          const remaining = Math.max(0, minVisibleMs - elapsed);
+          holdTimer = setTimeout(() => {
+            loaderVisible.value = false;
+            loadingStartTime = null;
+            holdTimer = null;
+          }, remaining);
+        } else {
+          loaderVisible.value = false;
+          loadingStartTime = null;
+        }
+      }
+    },
+    { immediate: true },
+  );
+
+  onMounted(() => {
+    // Initialize ResizeObserver if browser supports it
+    if (typeof window !== 'undefined' && window.ResizeObserver) {
+      resizeObserver = new ResizeObserver(entries => {
+        requestAnimationFrame(() => {
+          if (canRecordHeight() && entries[0]) {
+            lastStableHeight.value = wrapperRef.value.offsetHeight || 0;
+          }
+        });
+      });
+      if (wrapperRef?.value) resizeObserver.observe(wrapperRef.value);
+    }
+  });
+
+  onBeforeUnmount(() => {
+    if (resizeObserver) resizeObserver.disconnect();
+    if (delayTimer) clearTimeout(delayTimer);
+    if (holdTimer) clearTimeout(holdTimer);
+  });
+
+  return {
+    loaderVisible,
+    wrapperInlineStyle,
+  };
+}


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
This pull request introduces an improved loading state within KTable. These changes reduce the height inconsistency while the table is reloading and improve the user experience when the table updates very quickly.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses Kolibri issue [#13766](https://github.com/learningequality/kolibri/issues/13766)

### Before/after screenshots
<!-- Insert images here if applicable -->
Before:

https://github.com/user-attachments/assets/a07ef3be-8e4e-4cef-b088-be260e97ee55

After:


https://github.com/user-attachments/assets/ca65a5ae-ba51-47d5-8c99-366bc8666790



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Updates KTable's loading state, reducing height inconsistencies and improving user experience.
  - **Products impact:** -
  - **Addresses:** https://github.com/learningequality/kolibri/issues/13766
  - **Components:** KTable
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Run Kolibri with these changes: https://github.com/learningequality/kolibri/pull/13795
2. Navigate to Facility > Users
3. Observe that the table height stays consistent while reloading the data

## (optional) Implementation notes

### At a high level, how did you implement this?
- Introduced new `useLoading` composable to KTable to manage the loading state and delay showing the circular loader if loading < 300ms
- On initial load, the minimum height (`minHeightPx`) is set to the pixel height of the table header, plus one row.
- After the table finishes loading, `ResizeObserver` is used to set and watch the height of the `tableWrapper`, allowing the table height to stay the same on subsequent loads.
- The `KCircularLoader` is now wrapped in a div and centered within the table.
- `useLoading` ensures that the loader remains visible for a certain amount of time (`minVisibleMs`) to prevent a jarring user experience, if the loader is displayed.
- The table has been updated to be displayed with `v-show` instead of `v-if` to offset the higher toggle costs when the table is sortable

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
