### PR TITLE
Prevent KModal's title and content text to unexpectedly inherit parent styles

### DIFF
--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -27,6 +27,7 @@
               id="modal-title"
               ref="title"
               class="title"
+              :style="titleStyles"
             >
               {{ title }}
               <!-- Accessible error reporting per @radina -->
@@ -214,6 +215,8 @@
         delayedEnough: false,
       };
     },
+    // Add this to the computed section of KModal/index.vue
+
     computed: {
       modalStyles() {
         return {
@@ -240,6 +243,14 @@
       },
       wrapper() {
         return this.appendToOverlay ? 'KOverlay' : 'div';
+      },
+      // ADD THIS NEW COMPUTED PROPERTY:
+      titleStyles() {
+        return {
+          color: this.$themeTokens.text,
+          fontWeight: 'bold',
+          textAlign: 'left',
+        };
       },
     },
     created() {

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -246,7 +246,6 @@
       titleStyles() {
         return {
           color: this.$themeTokens.text,
-          
         };
       },
       contentStyles() {
@@ -439,15 +438,15 @@
     padding: 24px;
     margin: 0;
     font-size: 24px;
-    font-Weight: bold;
-    text-Align: start;
+    font-weight: bold;
+    text-align: start;
   }
 
   .content {
     padding: 0 24px;
     overflow-x: hidden;
+    text-align: start;
     white-space: normal;
-    text-Align: start,
   }
 
   .scroll-shadow {

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -249,7 +249,7 @@
         return {
           color: this.$themeTokens.text,
           fontWeight: 'bold',
-          textAlign: 'left',
+          textAlign: 'start',
         };
       },
     },
@@ -442,6 +442,8 @@
   .content {
     padding: 0 24px;
     overflow-x: hidden;
+    white-space: normal;
+    text-align: start;
   }
 
   .scroll-shadow {

--- a/lib/KModal.vue
+++ b/lib/KModal.vue
@@ -52,6 +52,7 @@
                 class="content"
                 :style="[
                   contentSectionMaxHeight,
+                  contentStyles,
                   scrollShadow
                     ? {
                       borderTop: `1px solid ${$themeTokens.fineLine}`,
@@ -215,8 +216,6 @@
         delayedEnough: false,
       };
     },
-    // Add this to the computed section of KModal/index.vue
-
     computed: {
       modalStyles() {
         return {
@@ -244,12 +243,15 @@
       wrapper() {
         return this.appendToOverlay ? 'KOverlay' : 'div';
       },
-      // ADD THIS NEW COMPUTED PROPERTY:
       titleStyles() {
         return {
           color: this.$themeTokens.text,
-          fontWeight: 'bold',
-          textAlign: 'start',
+          
+        };
+      },
+      contentStyles() {
+        return {
+          color: this.$themeTokens.text,
         };
       },
     },
@@ -437,13 +439,15 @@
     padding: 24px;
     margin: 0;
     font-size: 24px;
+    font-Weight: bold;
+    text-Align: start;
   }
 
   .content {
     padding: 0 24px;
     overflow-x: hidden;
     white-space: normal;
-    text-align: start;
+    text-Align: start,
   }
 
   .scroll-shadow {


### PR DESCRIPTION
<!-- Please remove any unused sections -->


## Description
Please refer to https://github.com/learningequality/studio/pull/5416 for cross Reference on the issue(@AllanOXDi )
The KModal component was inheriting red text color and center alignment from parent table components when used in delete/restore dialogs, causing:


1) Title and content text appearing red when they shouldn't
2) Text being center-aligned instead of properly aligned for LTR/RTL

when used in Admin->channels due to inherited parent property .

Fixed this by adding proper styles directly to the KModal component in KDS repository.
#### Issue addressed


Before/After
<img width="480" height="270" alt="Screenshot From 2025-10-06 21-23-49" src="https://github.com/user-attachments/assets/6ce96594-b5eb-4a76-be56-e8131838d99b" />
<img width="480" height="270" alt="Screenshot From 2025-10-06 21-23-58" src="https://github.com/user-attachments/assets/f219600a-7773-4153-97ce-218bab628809" />


<img width="1150" height="428" alt="Screenshot From 2025-10-08 15-04-43" src="https://github.com/user-attachments/assets/457a06ed-cb98-40b9-acc9-b192be419b00" />
<img width="1150" height="428" alt="Screenshot From 2025-10-08 15-04-33" src="https://github.com/user-attachments/assets/8c27dfa8-c690-4c5d-aab4-625401289419" />



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->
fixed this by adding proper styles directly to the KModal component


<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Prevent KModal's title and content text to unexpectedly inherit parent styles (by explicitly defining proper styles)
  - **Products impact:** bugfix
  - **Addresses:** KModal text color inheritance and RTL alignment issues in Studio admin dialogs
  - **Components:** KModal
  - **Breaking:** no
  - **Impacts a11y:** Proper RTL support
  - **Guidance:** -

