### PR TITLE
KBreadcrumbs visual tests in one file

### DIFF
--- a/examples/KBreadcrumbs/HiddenSingleItem.vue
+++ b/examples/KBreadcrumbs/HiddenSingleItem.vue
@@ -1,0 +1,5 @@
+<template>
+
+  <KBreadcrumbs :items="[{ text: 'Home', link: null }]" />
+
+</template>

--- a/examples/KBreadcrumbs/LongText.vue
+++ b/examples/KBreadcrumbs/LongText.vue
@@ -1,0 +1,14 @@
+<template>
+
+  <KBreadcrumbs
+    :items="[
+      { text: 'Home', link: { path: '/' } },
+      { text: 'Data', link: { path: '/' } },
+      {
+        text: 'Very long breadcrumb that should truncate properly when displayed in the component',
+        link: { path: '/long' },
+      },
+    ]"
+  />
+
+</template>

--- a/examples/KBreadcrumbs/NoOverflow.vue
+++ b/examples/KBreadcrumbs/NoOverflow.vue
@@ -1,0 +1,11 @@
+<template>
+
+  <KBreadcrumbs
+    :items="[
+      { text: 'Home', link: { path: '/' } },
+      { text: 'Library', link: { path: '/lib' } },
+      { text: 'Data', link: null },
+    ]"
+  />
+
+</template>

--- a/examples/KBreadcrumbs/ShowSingleItem.vue
+++ b/examples/KBreadcrumbs/ShowSingleItem.vue
@@ -1,0 +1,8 @@
+<template>
+
+  <KBreadcrumbs
+    showSingleItem
+    :items="[{ text: 'Home', link: null }]"
+  />
+
+</template>

--- a/examples/KBreadcrumbs/WithLinks.vue
+++ b/examples/KBreadcrumbs/WithLinks.vue
@@ -1,0 +1,11 @@
+<template>
+
+  <KBreadcrumbs
+    :items="[
+      { text: 'Home', link: { path: '/' } },
+      { text: 'Library', link: { path: '/lib' } },
+      { text: 'Files', link: { path: '/files' } },
+    ]"
+  />
+
+</template>

--- a/examples/KBreadcrumbs/WithOverflow.vue
+++ b/examples/KBreadcrumbs/WithOverflow.vue
@@ -1,0 +1,13 @@
+<template>
+
+  <KBreadcrumbs
+    :items="[
+      { text: 'Home', link: { path: '/' } },
+      { text: 'Library', link: null },
+      { text: 'Category', link: { path: '/category' } },
+      { text: 'Subcategory', link: { path: '/subcategory' } },
+      { text: 'Files', link: null },
+    ]"
+  />
+
+</template>

--- a/jest.conf/visual.load-test-components.js
+++ b/jest.conf/visual.load-test-components.js
@@ -6,7 +6,6 @@ import KButtonWithDropdownTest from '~~/lib/buttons-and-links/__tests__/componen
 import KDropdownMenuVisualTest from '~~/lib/KDropdownMenu/__tests__/components/KDropdownMenuVisualTest.vue';
 import KCheckboxSlotTest from '~~/lib/KCheckbox/__tests__/components/KCheckboxSlotTest.vue';
 import KCheckboxVisualTest from '~~/lib/KCheckbox/__tests__/components/KCheckboxVisualTest.vue';
-import KBreadcrumbs from '~~/lib/KBreadcrumbs/index.vue';
 import KImgTest from '~~/examples/KImg/Base.vue';
 import KImgAspectRatioTest from '~~/examples/KImg/AspectRatio.vue';
 import KImgContentOnTopTest from '~~/examples/KImg/ContentOnTop.vue';
@@ -46,7 +45,6 @@ Vue.component('KIconVisualTest', KIconVisualTest);
 Vue.component('KTextboxVisualTest', KTextboxVisualTest);
 Vue.component('KTableVisualTest', KTableVisualTest);
 Vue.component('CardsVisualTest', CardsVisualTest);
-Vue.component('KBreadcrumbs', KBreadcrumbs);
 Vue.component('KLogoVisualTest', KLogoVisualTest);
 Vue.component('KDropdownMenuVisualTest', KDropdownMenuVisualTest);
 Vue.component('KBreadcrumbsVisualTest', KBreadcrumbsVisualTest);

--- a/jest.conf/visual.load-test-components.js
+++ b/jest.conf/visual.load-test-components.js
@@ -22,6 +22,7 @@ import KTextboxVisualTest from '~~/lib/KTextbox/__tests__/components/KTextboxVis
 import KTableVisualTest from '~~/lib/KTable/__tests__/components/KTableVisualTest.vue';
 import CardsVisualTest from '~~/lib/cards/__tests__/components/CardsVisualTest.vue';
 import KLogoVisualTest from '~~/lib/KLogo/__tests__/components/KLogoVisualTest.vue';
+import KBreadcrumbsVisualTest from '~~/lib/KBreadcrumbs/__tests__/components/KBreadcrumbsVisualTest.vue';
 
 // Visual tests helper components
 Vue.component('VisualTestExample', VisualTestExample);
@@ -48,3 +49,4 @@ Vue.component('CardsVisualTest', CardsVisualTest);
 Vue.component('KBreadcrumbs', KBreadcrumbs);
 Vue.component('KLogoVisualTest', KLogoVisualTest);
 Vue.component('KDropdownMenuVisualTest', KDropdownMenuVisualTest);
+Vue.component('KBreadcrumbsVisualTest', KBreadcrumbsVisualTest);

--- a/lib/KBreadcrumbs/__tests__/KBreadcrumbs.spec.js
+++ b/lib/KBreadcrumbs/__tests__/KBreadcrumbs.spec.js
@@ -2,117 +2,16 @@ import {
   renderComponentForVisualTest,
   takeSnapshot,
   click,
-  waitFor,
 } from '../../../jest.conf/visual.testUtils';
 
 describe.visual('KBreadcrumbs Visual Tests', () => {
-  const snapshotOptions = { widths: [375, 768], minHeight: 200 };
+  const snapshotOptions = { widths: [800], minHeight: 1000 };
 
-  it('Breadcrumbs - Single Item (showSingleItem)', async () => {
-    await renderComponentForVisualTest('KBreadcrumbs', {
-      items: [{ text: 'Single Item', link: null }],
-      showSingleItem: true,
-    });
-    await takeSnapshot('KBreadcrumbs - Single Item', snapshotOptions);
-  });
+  it('Breadcrumbs - Visual Tests', async () => {
+    await renderComponentForVisualTest('KBreadcrumbsVisualTest');
 
-  it('Breadcrumbs - Single Item (hidden)', async () => {
-    await renderComponentForVisualTest('KBreadcrumbs', {
-      items: [{ text: 'Single Item', link: null }],
-      showSingleItem: false,
-    });
-    await takeSnapshot('KBreadcrumbs - Single Item Hidden', snapshotOptions);
-  });
+    await click('#with-overflow .breadcrumbs-dropdown-wrapper button');
 
-  it('Breadcrumbs - Multiple Items (no overflow)', async () => {
-    await renderComponentForVisualTest('KBreadcrumbs', {
-      items: [
-        { text: 'Home', link: { path: '/' } },
-        { text: 'Library', link: { path: '/lib' } },
-        { text: 'Data', link: null },
-      ],
-    });
-    await takeSnapshot('KBreadcrumbs - No Overflow', snapshotOptions);
-  });
-
-  it('Breadcrumbs - Multiple Items with Long Text', async () => {
-    await renderComponentForVisualTest('KBreadcrumbs', {
-      items: [
-        { text: 'Home', link: { path: '/' } },
-        {
-          text: 'A very long breadcrumb text that should truncate properly when displayed in the component',
-          link: { path: '/long' },
-        },
-        { text: 'Data', link: null },
-      ],
-    });
-    await takeSnapshot('KBreadcrumbs - Long Text', snapshotOptions);
-  });
-
-  it('Breadcrumbs - With Links', async () => {
-    await renderComponentForVisualTest('KBreadcrumbs', {
-      items: [
-        { text: 'Home', link: { path: '/' } },
-        { text: 'Library', link: { path: '/lib' } },
-        { text: 'Files', link: { path: '/files' } },
-      ],
-    });
-    await takeSnapshot('KBreadcrumbs - With Links', snapshotOptions);
-  });
-
-  it('Breadcrumbs - Overflow with Dropdown Open (with links)', async () => {
-    const narrowSnapshotOptions = { widths: [300], minHeight: 200 };
-
-    await renderComponentForVisualTest('KBreadcrumbs', {
-      items: [
-        { text: 'Home', link: { path: '/' } },
-        { text: 'Library', link: { path: '/lib' } },
-        { text: 'Category', link: { path: '/category' } },
-        { text: 'Subcategory', link: { path: '/subcategory' } },
-        { text: 'Files', link: null },
-      ],
-    });
-
-    // First, check if dropdown button exists, if not, take snapshot without dropdown
-    try {
-      await waitFor('.breadcrumbs-dropdown-wrapper button');
-      await click('.breadcrumbs-dropdown-wrapper button');
-      await waitFor('.breadcrumbs-dropdown-menu');
-    } catch (error) {
-      // Dropdown button not found, component may not be overflowing
-    }
-
-    await takeSnapshot(
-      'KBreadcrumbs - Overflow with Dropdown Open (with links)',
-      narrowSnapshotOptions,
-    );
-  });
-
-  it('Breadcrumbs - Overflow with Dropdown Open (without links)', async () => {
-    const narrowSnapshotOptions = { widths: [300], minHeight: 200 };
-
-    await renderComponentForVisualTest('KBreadcrumbs', {
-      items: [
-        { text: 'Home', link: null },
-        { text: 'Library', link: null },
-        { text: 'Category', link: null },
-        { text: 'Subcategory', link: null },
-        { text: 'Files', link: null },
-      ],
-    });
-
-    // First, check if dropdown button exists
-    try {
-      await waitFor('.breadcrumbs-dropdown-wrapper button');
-      await click('.breadcrumbs-dropdown-wrapper button');
-      await waitFor('.breadcrumbs-dropdown-menu');
-    } catch (error) {
-      // Dropdown button not found, component may not be overflowing
-    }
-
-    await takeSnapshot(
-      'KBreadcrumbs - Overflow with Dropdown Open (without links)',
-      narrowSnapshotOptions,
-    );
+    await takeSnapshot('KBreadcrumbs visual tests', snapshotOptions);
   });
 });

--- a/lib/KBreadcrumbs/__tests__/components/KBreadcrumbsVisualTest.vue
+++ b/lib/KBreadcrumbs/__tests__/components/KBreadcrumbsVisualTest.vue
@@ -1,0 +1,37 @@
+<template>
+
+  <VisualTestLayout>
+    <VisualTestExample
+      title="Show single item"
+      loadExample="KBreadcrumbs/ShowSingleItem.vue"
+      width="300px"
+    />
+    <VisualTestExample
+      title="Hidden single item"
+      loadExample="KBreadcrumbs/HiddenSingleItem.vue"
+      width="300px"
+    />
+    <VisualTestExample
+      title="Multiple items, no overflow"
+      loadExample="KBreadcrumbs/NoOverflow.vue"
+      width="300px"
+    />
+    <VisualTestExample
+      title="Long text"
+      loadExample="KBreadcrumbs/LongText.vue"
+      width="700px"
+    />
+    <VisualTestExample
+      title="With links"
+      loadExample="KBreadcrumbs/WithLinks.vue"
+      width="300px"
+    />
+    <VisualTestExample
+      id="with-overflow"
+      title="With overflow"
+      loadExample="KBreadcrumbs/WithOverflow.vue"
+      width="300px"
+    />
+  </VisualTestLayout>
+
+</template>


### PR DESCRIPTION
## Description
KBreadcrumbs visual tests in one file


#### Issue addressed
Closes #1098

### Screenshots

<img width="536" height="682" alt="image" src="https://github.com/user-attachments/assets/5abea277-bc74-446c-a0da-da33012d0f98" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** KBreadcrumbs visual tests in one file
  - **Products impact:* none.
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1098.
  - **Components:** -.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** 

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
