### PR TITLE
Bump KDS version to 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@ Changelog is rather internal in nature. See release notes for the public overvie
 
 
 - [#1131]
-  - **Description:** Bumps KDS version to 5.3.0.
+  - **Description:** Bumps KDS version to 5.4.0.
   - **Products impact:** .
   - **Addresses:** .
   - **Components:** .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-design-system",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "private": false,
   "description": "The Kolibri Design System defines common design patterns and code for use in Kolibri applications",
   "repository": {


### PR DESCRIPTION
## Description
* Bumps KDS version to 5.4.1.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Bumps KDS version to 5.4.1.
  - **Products impact:** .
  - **Addresses:** .
  - **Components:** .
  - **Breaking:**
  - **Impacts a11y:**
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

