### PR TITLE
Documentation updates

### DIFF
--- a/dev_docs/03_how_to_update_library.md
+++ b/dev_docs/03_how_to_update_library.md
@@ -49,35 +49,20 @@ If there is already a documentation page for a component, please ensure that any
 
 When creating a new component, it is recommended to add a new documentation page for it as described in the "Create a documentation page for a new component" section of [How to update the documentation website](./04_how_to_update_docs.md). Even if you are not specifically writing documentation, certain sections of the documentation page will be automatically generated from the component's props and related.
 
-### (2) Preview updates in a product
+### (2) Preview updates in Kolibri apps
 
-You can test local Kolibri Design System updates reflected in a product that is using it, such as [Kolibri Learning Platform](https://github.com/learningequality/kolibri) or [Kolibri Studio](https://github.com/learningequality/studio).
+You can test local Kolibri Design System updates in apps that use it, such as [Kolibri Learning Platform](https://github.com/learningequality/kolibri) or [Kolibri Studio](https://github.com/learningequality/studio).
 
-For Kolibri Learning Platform, we recommend `devserver-with-kds` command. See ["Running Kolibri with local Kolibri Design System"](https://kolibri-dev.readthedocs.io/en/develop/howtos/development_with_kds.html) guide.
+### Kolibri Learning Platform
 
-In other products, you can use `yarn link`:
+We recommend using the `devserver-with-kds` command. See [Running Kolibri with local Kolibri Design System](https://kolibri-dev.readthedocs.io/en/develop/howtos/development_with_kds.html).
 
-1. While in the root of your local `kolibri-design-system` repository, run `yarn link`.
-2. In the root of a product where you intend to use `kolibri-design-system` run `yarn link kolibri-design-system` and then `yarn install`.
+Alternatively, you can use `yarn link`:
 
-Now, when you run the product your changes in `kolibri-design-system` will be updated live when running the product's development server.
+1. In `kolibri-design-system` repository, run `yarn link`
+2. In `kolibri` repository, run `yarn link kolibri-design-system` and then `yarn install`
 
-For example, to test Kolibri Design System in Kolibri Studio (local `studio` repository):
+### Kolibri Studio
 
-```bash
-# change to the Kolibri Design System repository and add it to yarn's local package registry
-cd ./kolibri-design-system
-yarn link
-
-# change to the Kolibri repository and link it to the local Kolibri Design System package
-cd ../studio
-yarn link kolibri-design-system
-
-# re-install Studio dependencies
-yarn install
-
-# run the Studio development server
-yarn run devserver
-```
-
-Now you're all set to see your changes to the Kolibri Design System working live in Studio!
+1. In `studio` repository, run `pnpm install file:../kolibri-design-system`
+2. When you make changes in `kolibri-design-system`, you may need to stop your Studio development server, run the `pnpm` command above again, and restart the server for changes to take effect.

--- a/docs/common/DocsExample.vue
+++ b/docs/common/DocsExample.vue
@@ -65,7 +65,10 @@
         :block="block"
       >
         <slot>
-          <component :is="loadedComponent" />
+          <component
+            v-bind="$attrs"
+            :is="loadedComponent"
+          />
         </slot>
       </DocsShow>
     </KTransition>
@@ -81,6 +84,7 @@
 
   export default {
     name: 'DocsExample',
+    inheritAttrs: false,
     setup() {
       const { show } = useKShow();
       return {

--- a/docs/pages/buttons.vue
+++ b/docs/pages/buttons.vue
@@ -233,60 +233,10 @@
       title="Dropdowns"
       anchor="#dropdowns"
     >
-      <p>Buttons can also have drop-down menus.</p>
       <p>
-        <code>KDropdownMenu</code> component can be added using <code>#menu</code> slot in either a
-        <code>KButton</code> or a <code>KIconButton</code>.
+        Buttons can also have drop-down menus. See <DocsLibraryLink component="KDropdownMenu" />.
       </p>
-
-      <DocsShow>
-        <KButtonGroup>
-          <KButton
-            text="Options"
-            :primary="true"
-            iconAfter="chevronDown"
-          >
-            <KDropdownMenu
-              style="margin-right: 16px"
-              text="Primary"
-              :primary="true"
-              :options="['Option 1', 'Option 2']"
-              appearance="raised-button"
-            />
-          </KButton>
-          <KIconButton
-            tooltip="Dropdown options"
-            icon="optionsHorizontal"
-            appearance="flat-button"
-            :primary="false"
-          >
-            <template #menu>
-              <KDropdownMenu
-                style="margin-right: 16px"
-                text="Primary"
-                :primary="true"
-                :options="['Option 1', 'Option 2']"
-                appearance="raised-button"
-              />
-            </template>
-          </KIconButton>
-        </KButtonGroup>
-      </DocsShow>
-      <p>For more guidance, see the <DocsLibraryLink component="KDropdownMenu" /> component.</p>
     </DocsPageSection>
-
-    <DocsPageSection
-      title="Visual specs"
-      anchor="#specs"
-    />
-    <ul>
-      <li>Border radius: 2px</li>
-      <li>Elevation: 4dp</li>
-      <li>Font size: 14px</li>
-      <li>Icon size: 14px</li>
-      <li>Text button padding: 8px 16px</li>
-      <li>Icon button padding: 8px</li>
-    </ul>
   </DocsPageTemplate>
 
 </template>

--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -6,64 +6,212 @@
       anchor="#overview"
     >
       <p>
-        Implements a dropdown set of options, based on
+        Dropdown set of options, based on
         <DocsExternalLink
           text="Keen's UI Menu"
           href="https://josephuspaye.github.io/Keen-UI/#/ui-menu"
         />. See these docs to understand the current implementation of the options object array.
+        Notable possible for configuring the menu include icons, text, secondary text, and dividers.
       </p>
-      <p>
-        Notable possible for configuring the menu include: icons, text, secondary text, and
-        dividers.
-      </p>
-      <p>
-        Please see the
-        <DocsInternalLink
-          href="/buttons#dropdowns"
-          text="Dropdown section of the Buttons and links page"
-        />
-        on the buttons page for more details about how to use with a button, and a code example.
-      </p>
+    </DocsPageSection>
 
-      <h3>Context menu</h3>
+    <DocsPageSection
+      title="Usage"
+      anchor="#usage"
+    >
+      <DocsSubNav
+        :items="[
+          { text: 'Button with dropdown', href: '#button-with-dropdown' },
+          { text: 'Icon button with dropdown', href: '#icon-button-with-dropdown' },
+          { text: 'Options with icons', href: '#options-with-icons' },
+          { text: 'Context menu', href: '#context-menu' },
+        ]"
+      />
+
+      <h3>
+        Button with dropdown
+        <DocsAnchorTarget anchor="#button-with-dropdown" />
+      </h3>
+
+      <DocsExample
+        loadExample="KDropdownMenu/MultipleItems.vue"
+        exampleId="button-with-dropdown"
+        block
+        :hideOnClick="true"
+        :openOnMount="false"
+        :constrainToScrollParent="false"
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KButton
+              text="Options"
+              hasDropdown
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :options="options"
+                  @select="onOptionSelect"
+                />
+              </template>
+            </KButton>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+
+        <template #javascript>
+          <!-- eslint-disable -->
+          <!-- prettier-ignore -->
+          <DocsShowCode language="javascript">
+              export default {
+                data() {
+                  return {
+                    options: [
+                      { label: 'Option 1', value: 'option1' },
+                      { label: 'Option 2', value: 'option2' },
+                      { label: 'Option 3', value: 'option3' },
+                    ],
+                  };
+                },
+                methods: {
+                  onOptionSelect(option) {
+                    console.log('Selected option:', option);
+                  },
+                },
+              };
+            </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
+
+      <h3>
+        Icon button with dropdown
+        <DocsAnchorTarget anchor="#icon-button-with-dropdown" />
+      </h3>
+      <DocsExample
+        loadExample="KDropdownMenu/IconButton.vue"
+        exampleId="icon-button-with-dropdown"
+        block
+        :hideOnClick="true"
+        :openOnMount="false"
+        :constrainToScrollParent="false"
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KIconButton
+              tooltip="Dropdown options"
+              icon="optionsHorizontal"
+              appearance="flat-button"
+              :primary="false"
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :options="options"
+                  @select="onOptionSelect"
+                />
+              </template>
+            </KIconButton>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+        <template #javascript>
+          <!-- eslint-disable -->
+          <!-- prettier-ignore -->
+          <DocsShowCode language="javascript">
+              export default {
+                data() {
+                  return {
+                    options: [
+                      { label: 'Option 1', value: 'option1' },
+                      { label: 'Option 2', value: 'option2' },
+                      { label: 'Option 3', value: 'option3' },
+                    ],
+                  };
+                },
+                methods: {
+                  onOptionSelect(option) {
+                    console.log('Selected option:', option);
+                  },
+                },
+              };
+            </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
+
+      <h3>
+        Options with icons
+        <DocsAnchorTarget anchor="#options-with-icons" />
+      </h3>
+
+      <DocsExample
+        loadExample="KDropdownMenu/WithIcons.vue"
+        exampleId="options-with-icons"
+        block
+        :hideOnClick="true"
+        :openOnMount="false"
+        :constrainToScrollParent="false"
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KButton
+              text="Options"
+              hasDropdown
+            >
+              <template #menu>
+                <KDropdownMenu
+                  hasIcons
+                  :options="options"
+                  @select="onOptionSelect"
+                />
+              </template>
+            </KButton>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+
+        <template #javascript>
+          <!-- eslint-disable -->
+          <!-- prettier-ignore -->
+          <DocsShowCode language="javascript">
+              export default {
+                data() {
+                  return {
+                    options: [
+                      { label: 'Option 1', value: 'option1', icon: 'add' },
+                      { label: 'Option 2', value: 'option2', icon: 'delete' },
+                    ],
+                  };
+                },
+                methods: {
+                  onOptionSelect(option) {
+                    console.log('Selected option:', option);
+                  },
+                },
+              };
+            </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
+
+      <h3>
+        Context menu
+        <DocsAnchorTarget anchor="#context-menu" />
+      </h3>
 
       <p>
         This component can be also used to create a context menu, which is a dropdown menu that
-        appears when a user right-clicks on an element.
+        appears when a user right-clicks on an element. The context menu will then be attached to
+        the parent element.
       </p>
 
-      <DocsShow block>
-        <p>For example, you can right click on this paragraph to see a context menu.</p>
-        <KDropdownMenu
-          isContextMenu
-          :options="[{ label: 'Option 1' }, { label: 'Option 2' }, { label: 'Option 3' }]"
-        />
-      </DocsShow>
-
-      <DocsShow block>
-        <p>
-          Note that just one context menu can be open at a time. If you right-click on this
-          paragraph, any other context menu will close.
-        </p>
-        <KDropdownMenu
-          isContextMenu
-          :options="[{ label: 'Option 1' }, { label: 'Option 2' }]"
-        />
-      </DocsShow>
-
-      <p>
-        To achieve this, set the <code>isContextMenu</code> prop to true. The context menu will then
-        be attached to the parent element.
-      </p>
-      <DocsShowCode language="html">
-        <div>
-          <p>...</p>
-          <KDropdownMenu
-            isContextMenu
-            :options="[{ label: 'Option 1' }, { label: 'Option 2' }, { label: 'Option 3' }]"
-          />
-        </div>
-      </DocsShowCode>
+      <DocsExample
+        loadExample="KDropdownMenu/ContextMenu.vue"
+        exampleId="context-menu"
+        block
+      />
     </DocsPageSection>
   </DocsPageTemplate>
 

--- a/docs/pages/kmodal.vue
+++ b/docs/pages/kmodal.vue
@@ -17,7 +17,7 @@
     >
       <DocsSubNav
         :items="[
-          { text: 'With description', href: '#description' },
+          { text: 'With description and actions', href: '#description' },
           { text: 'With enabled / disabled submit', href: '#enabled-disabled-submit' },
           { text: 'With predefined sizes', href: '#predefined-sizes' },
           { text: 'With precise size', href: '#precise-size' },
@@ -26,7 +26,7 @@
       />
 
       <h3>
-        With description
+        With description and actions
         <DocsAnchorTarget anchor="#description" />
       </h3>
       <p>To show information, warnings, or notifications.</p>

--- a/examples/KDropdownMenu/ContextMenu.vue
+++ b/examples/KDropdownMenu/ContextMenu.vue
@@ -1,0 +1,44 @@
+<template>
+
+  <div>
+    <p>
+      Right click on this paragraph to see a context menu.
+      <KDropdownMenu
+        isContextMenu
+        :options="options"
+        @select="onOptionSelect"
+      />
+    </p>
+    <p>
+      Just one context menu can be open at a time. If you right-click on this paragraph, any other
+      context menu will close.
+      <KDropdownMenu
+        isContextMenu
+        :options="['Another option']"
+        @select="onOptionSelect"
+      />
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        options: [
+          { label: 'Option 1', value: 'option1' },
+          { label: 'Option 2', value: 'option2' },
+        ],
+      };
+    },
+    methods: {
+      onOptionSelect(option) {
+        console.log('Selected option:', option);
+      },
+    },
+  };
+
+</script>

--- a/examples/KDropdownMenu/IconButton.vue
+++ b/examples/KDropdownMenu/IconButton.vue
@@ -1,19 +1,20 @@
 <template>
 
-  <KButton
-    text="Options"
-    hasDropdown
+  <KIconButton
+    tooltip="Dropdown options"
+    icon="optionsHorizontal"
+    appearance="flat-button"
+    :primary="false"
   >
     <template #menu>
       <KDropdownMenu
-        hasIcons
         :hideOnClick="hideOnClick"
         :constrainToScrollParent="constrainToScrollParent"
         :options="options"
         @select="onOptionSelect"
       />
     </template>
-  </KButton>
+  </KIconButton>
 
 </template>
 
@@ -21,7 +22,6 @@
 <script>
 
   export default {
-    name: 'MultipleItems',
     props: {
       openOnMount: {
         type: Boolean,
@@ -39,8 +39,9 @@
     data() {
       return {
         options: [
-          { label: 'Option 1', value: 'option1', icon: 'add' },
-          { label: 'Option 2', value: 'option2', icon: 'delete' },
+          { label: 'Option 1', value: 'option1' },
+          { label: 'Option 2', value: 'option2' },
+          { label: 'Option 3', value: 'option3' },
         ],
       };
     },

--- a/examples/KDropdownMenu/MultipleItems.vue
+++ b/examples/KDropdownMenu/MultipleItems.vue
@@ -6,9 +6,10 @@
   >
     <template #menu>
       <KDropdownMenu
-        :hideOnClick="false"
-        :constrainToScrollParent="false"
-        :options="['Option 1', 'Option 2', 'Option 3']"
+        :hideOnClick="hideOnClick"
+        :constrainToScrollParent="constrainToScrollParent"
+        :options="options"
+        @select="onOptionSelect"
       />
     </template>
   </KButton>
@@ -20,10 +21,40 @@
 
   export default {
     name: 'MultipleItems',
+    props: {
+      openOnMount: {
+        type: Boolean,
+        default: true,
+      },
+      hideOnClick: {
+        type: Boolean,
+        default: false,
+      },
+      constrainToScrollParent: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    data() {
+      return {
+        options: [
+          { label: 'Option 1', value: 'option1' },
+          { label: 'Option 2', value: 'option2' },
+          { label: 'Option 3', value: 'option3' },
+        ],
+      };
+    },
     mounted() {
-      this.$nextTick(() => {
-        this.$el.click();
-      });
+      if (this.openOnMount) {
+        this.$nextTick(() => {
+          this.$el.click();
+        });
+      }
+    },
+    methods: {
+      onOptionSelect(option) {
+        console.log('Selected option:', option);
+      },
     },
   };
 

--- a/examples/KModal/ModalWithDescription.vue
+++ b/examples/KModal/ModalWithDescription.vue
@@ -5,7 +5,9 @@
     <KModal
       v-if="showModal"
       title="Title"
+      submitText="Submit"
       cancelText="Close"
+      @submit="closeModal"
       @cancel="closeModal"
     >
       Description

--- a/examples/KModal/ModalWithDifferentSizes.vue
+++ b/examples/KModal/ModalWithDifferentSizes.vue
@@ -8,7 +8,9 @@
       v-if="showModal"
       :size="modalSize"
       title="Title"
+      submitText="Submit"
       cancelText="Close"
+      @submit="closeModal"
       @cancel="closeModal"
     >
       {{ `Modal with ${modalSize} size` }}

--- a/examples/KModal/ModalWithDynamicWidth.vue
+++ b/examples/KModal/ModalWithDynamicWidth.vue
@@ -6,7 +6,9 @@
       v-if="showModal"
       title="Title"
       size="600"
+      submitText="Submit"
       cancelText="Close"
+      @submit="closeModal"
       @cancel="closeModal"
     >
       Modal with 600px size

--- a/lib/KDropdownMenu/__tests__/components/KDropdownMenuVisualTest.vue
+++ b/lib/KDropdownMenu/__tests__/components/KDropdownMenuVisualTest.vue
@@ -14,6 +14,12 @@
       height="200px"
     />
     <VisualTestExample
+      title="Icon button"
+      loadExample="KDropdownMenu/IconButton.vue"
+      width="200px"
+      height="200px"
+    />
+    <VisualTestExample
       title="With icons"
       loadExample="KDropdownMenu/WithIcons.vue"
       width="200px"


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

Website and developer documentation improvements:

- Adds `KDropdownMenu` examples
- Make `KModal` examples show submit button
- Updates dev docs to have the latest information on how to preview local KDS changes in Kolibri apps

#### Issue addressed

During KDS to Studio project, I noticed that these areas were unclear.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Improve `KDropdownMenu` and `KModal` documentation, and adds new `KDropdownMenu` visual tests
  - **Products impact:** none
  - **Addresses:** -
  - **Components:**  `KDropdownMenu`, `KModal`
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

  - **Description:** Update dev docs to have the latest information on how to preview local KDS changes in Kolibri apps
  - **Products impact:** none
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -
  - 
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

- Preview [KDropdownMenu documentation](https://deploy-preview-1155--kolibri-design-system.netlify.app/kdropdownmenu/)
- Preview [KModal documentation](https://deploy-preview-1155--kolibri-design-system.netlify.app/kmodal)
- See [_Preview updates in Kolibri apps_](https://github.com/learningequality/kolibri-design-system/blob/fdf7b6d9b75bb044456ac81885c3395d644515d8/dev_docs/03_how_to_update_library.md#2-preview-updates-in-kolibri-apps)
