### PR TITLE
Fix visually hidden style not taking effect, allow KTextbox label to be visually hidden

### DIFF
--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -1,15 +1,5 @@
 @import '~/assets/definitions';
-
-.visuallyhidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  border: 0;
-}
+@import '../../lib/styles/common';
 
 code {
   padding-right: 0.25em;

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -24,6 +24,12 @@
       </DocsShowCode>
       <!-- eslint-enable -->
 
+      <p>Register KDS styles in the main application stylesheet:</p>
+
+      <DocsShowCode language="scss">
+        @import '~kolibri-design-system/lib/styles/common';
+      </DocsShowCode>
+
       This ensures the following:
 
       <ul>
@@ -53,6 +59,13 @@
           Inserts the overlay container element <code>#k-overlay</code> to an application's document
           body (see <DocsLibraryLink component="KOverlay" /> or search for
           <code>appendToOverlay</code> prop on components).
+        </li>
+        <li>
+          Globally registers styles needed for components to display correctly and exposes
+          <DocsInternalLink
+            href="/styling#helper-styles"
+            text="helper styles"
+          />
         </li>
       </ul>
     </DocsPageSection>

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -24,12 +24,6 @@
       </DocsShowCode>
       <!-- eslint-enable -->
 
-      <p>Register KDS styles in the main application stylesheet:</p>
-
-      <DocsShowCode language="scss">
-        @import '~kolibri-design-system/lib/styles/common';
-      </DocsShowCode>
-
       This ensures the following:
 
       <ul>
@@ -60,18 +54,28 @@
           body (see <DocsLibraryLink component="KOverlay" /> or search for
           <code>appendToOverlay</code> prop on components).
         </li>
-        <li>
-          Globally registers styles needed for components to display correctly and exposes
-          <DocsInternalLink
-            href="/styling#helper-styles"
-            text="helper styles"
-          />
-        </li>
       </ul>
     </DocsPageSection>
 
     <DocsPageSection
-      title="2. Initialize theme"
+      title="2. Register global styles"
+      anchor="#register-global-styles"
+    >
+      <p>Import KDS styles in the main application stylesheet:</p>
+
+      <DocsShowCode language="scss">
+        @import '~kolibri-design-system/lib/styles/common';
+      </DocsShowCode>
+
+      This globally registers styles needed for components to display correctly and also exposes
+      <DocsInternalLink
+        href="/styling#helper-styles"
+        text="helper styles"
+      />.
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="3. Initialize theme"
       anchor="#initialize-theme"
     >
       <p>

--- a/docs/pages/ktextbox.vue
+++ b/docs/pages/ktextbox.vue
@@ -19,6 +19,7 @@
       <DocsSubNav
         :items="[
           { text: 'Input with label', href: '#with-label' },
+          { text: 'Visually hidden label', href: '#visually-hidden-label' },
           { text: 'Valid and invalid input', href: '#validation' },
           { text: 'Character limit', href: '#charlimit' },
           { text: 'Disabled input', href: '#disabled' },
@@ -37,12 +38,33 @@
         <DocsAnchorTarget anchor="#with-label" />
       </h3>
       <p>
-        This text box includes a visible label, providing clear guidance and context to the user
-        about the expected input.
+        The label can be provided via the <code>label</code> prop or the <code>label</code> slot.
       </p>
       <DocsExample
         loadExample="KTextbox/WithLabel.vue"
         exampleId="ktextbox-label"
+        block
+      />
+      <DocsExample
+        loadExample="KTextbox/LabelSlot.vue"
+        exampleId="ktextbox-label-slot"
+        block
+      />
+
+      <h3>
+        Visually hidden label
+        <DocsAnchorTarget anchor="#visually-hidden-label" />
+      </h3>
+
+      <p>
+        Although a visible label is preferred, occasionaly it may need to be hidden. Use the
+        <code>label</code> slot together with the <code>visuallyhidden</code> class to ensure the
+        label remains accessible to assistive technologies.
+      </p>
+
+      <DocsExample
+        loadExample="KTextbox/VisuallyHiddenLabel.vue"
+        exampleId="ktextbox-visually-hidden-label"
         block
       />
 

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -118,7 +118,7 @@
       <p>
         <code>styles/common</code> registration during the
         <DocsInternalLink
-          href="/installation"
+          href="/installation#register-global-styles"
           text="installation step"
         />
         globally exposes the following helper styles:

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -38,7 +38,8 @@
       anchor="#definitions"
     >
       <p>
-        The design system provides a set of reusable style constants, snippets, and dynamic values.
+        The design system provides a set of reusable style constants, snippets, dynamic values, and
+        helper styles.
       </p>
       <p>
         Constants are made available as
@@ -96,6 +97,22 @@
           href="/colors"
         />.
       </p>
+
+      <p>
+        Finally, <code>styles/common</code> registration during the
+        <DocsInternalLink
+          href="/installation"
+          text="installation step"
+        />
+        globally exposes the following helper styles:
+      </p>
+
+      <ul>
+        <li>
+          <code>.visuallyhidden</code> class: hides an element visually but keeps it accessible to
+          screen readers
+        </li>
+      </ul>
     </DocsPageSection>
 
     <DocsPageSection

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -41,6 +41,12 @@
         The design system provides a set of reusable style constants, snippets, dynamic values, and
         helper styles.
       </p>
+
+      <h3>
+        Constants and snippets
+        <DocsAnchorTarget anchor="#constants-and-snippets" />
+      </h3>
+
       <p>
         Constants are made available as
         <DocsExternalLink
@@ -80,6 +86,12 @@
       <DocsShow>
         <div class="box box-2dp">Hello!</div>
       </DocsShow>
+
+      <h3>
+        Dynamic values
+        <DocsAnchorTarget anchor="#dynamic-values" />
+      </h3>
+
       <p>
         In order for Kolibri to be dynamically themed colors cannot be defined as SCSS constants.
         Instead, colors are defined in Javascript. Every Vue component instance gets a few reactive
@@ -98,8 +110,13 @@
         />.
       </p>
 
+      <h3>
+        Helper styles
+        <DocsAnchorTarget anchor="#helper-styles" />
+      </h3>
+
       <p>
-        Finally, <code>styles/common</code> registration during the
+        <code>styles/common</code> registration during the
         <DocsInternalLink
           href="/installation"
           text="installation step"
@@ -129,7 +146,10 @@
         overlap.
       </p>
 
-      <h3>Drop shadows</h3>
+      <h3>
+        Drop shadows
+        <DocsAnchorTarget anchor="#drop-shadows" />
+      </h3>
       <p>
         In the real world, the shadow an object casts is often a physical manifestation of its
         elevation.
@@ -179,7 +199,10 @@
       </DocsShowCode>
       <!-- eslint-enable -->
 
-      <h3>Z-indexes</h3>
+      <h3>
+        Z-indexes
+        <DocsAnchorTarget anchor="#z-indexes" />
+      </h3>
       <p>
         CSS <code>z-index</code> is sometimes used to determine whether some element will show in
         front of or behind overlapping elements. A common challenge is that

--- a/examples/KTextbox/LabelSlot.vue
+++ b/examples/KTextbox/LabelSlot.vue
@@ -1,0 +1,7 @@
+<template>
+
+  <KTextbox>
+    <template #label>Label via slot</template>
+  </KTextbox>
+
+</template>

--- a/examples/KTextbox/VisuallyHiddenLabel.vue
+++ b/examples/KTextbox/VisuallyHiddenLabel.vue
@@ -1,0 +1,9 @@
+<template>
+
+  <KTextbox>
+    <template #label>
+      <span class="visuallyhidden">Label text</span>
+    </template>
+  </KTextbox>
+
+</template>

--- a/examples/KTextbox/WithLabel.vue
+++ b/examples/KTextbox/WithLabel.vue
@@ -1,5 +1,5 @@
 <template>
 
-  <KTextbox label="Input with label" />
+  <KTextbox label="Label via prop" />
 
 </template>

--- a/lib/KTextbox/__tests__/KTextbox.spec.js
+++ b/lib/KTextbox/__tests__/KTextbox.spec.js
@@ -8,14 +8,33 @@ describe('KTextbox component', () => {
   });
 
   describe('props', () => {
-    it(`a label should appear`, () => {
+    it(`a label should appear when passed via prop`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
-          label: 'test',
+          label: 'test label',
         },
       });
-      expect(wrapper.find('label').text()).toEqual('test');
+      expect(wrapper.find('label').text()).toEqual('test label');
     });
+
+    it(`a label should appear when passed via slot`, () => {
+      const wrapper = mount(KTextbox, {
+        slots: {
+          label: 'test label',
+        },
+      });
+      expect(wrapper.find('label').text()).toEqual('test label');
+    });
+
+    it(`should show error when neither label prop nor slot is provided`, () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mount(KTextbox);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[KTextbox] A label must be provided via prop or slot',
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
     it(`value of the text field should appear when passed in`, () => {
       const initialValue = '1234paowiejfapwoeifjapwoeijf';
       const wrapper = mount(KTextbox, {
@@ -27,6 +46,7 @@ describe('KTextbox component', () => {
       const value = wrapper.find('input').element.value;
       expect(value).toBe(initialValue);
     });
+
     it(`invalidText is not displayed if showInvalidText is false`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -38,6 +58,7 @@ describe('KTextbox component', () => {
       const errorTextField = wrapper.find('.ui-textbox-feedback-text');
       expect(errorTextField.text()).not.toBe('error!');
     });
+
     it(`invalidText is displayed through error prop if invalid and showInvalidText are both true`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -49,6 +70,7 @@ describe('KTextbox component', () => {
       const errorTextField = wrapper.find('.ui-textbox-feedback-text');
       expect(errorTextField.text()).toBe('error!');
     });
+
     it(`text field is disabled when 'disabled' is true`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -57,6 +79,7 @@ describe('KTextbox component', () => {
       });
       expect(wrapper.find('input').attributes('disabled')).toBe('disabled');
     });
+
     it(`text field is readonly when 'readonly' is true`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -65,6 +88,7 @@ describe('KTextbox component', () => {
       });
       expect(wrapper.find('input').attributes('readonly')).toBe('readonly');
     });
+
     it(`text field is autofocused when 'autofocus' is true`, () => {
       const wrapper = shallowMount(KTextbox, {
         propsData: {
@@ -74,6 +98,7 @@ describe('KTextbox component', () => {
       const textField = wrapper.findComponent({ name: 'UiTextbox' });
       expect(textField.attributes('autofocus')).toBe('true');
     });
+
     it(`length of characters for value matches maxlength prop`, () => {
       const wrapper = shallowMount(KTextbox, {
         propsData: {
@@ -83,6 +108,7 @@ describe('KTextbox component', () => {
       const textField = wrapper.findComponent({ name: 'UiTextbox' });
       expect(textField.attributes('maxlength')).toBe('13');
     });
+
     it(`HTML autocomplete attribute is passed with autocomplete prop`, () => {
       const wrapper = shallowMount(KTextbox, {
         propsData: {
@@ -92,6 +118,7 @@ describe('KTextbox component', () => {
       const textField = wrapper.findComponent({ name: 'UiTextbox' });
       expect(textField.attributes('autocomplete')).toBe('current-password');
     });
+
     it(`HTML autocapitalize attribute is passed with autocapitalize prop`, () => {
       const wrapper = shallowMount(KTextbox, {
         propsData: {
@@ -101,6 +128,7 @@ describe('KTextbox component', () => {
       const textField = wrapper.findComponent({ name: 'UiTextbox' });
       expect(textField.attributes('autocapitalize')).toBe('sentences');
     });
+
     it(`input type is 'number' when type is set to 'number'`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -110,6 +138,7 @@ describe('KTextbox component', () => {
       expect(wrapper.find('input').attributes('number')).toBe('true');
       expect(wrapper.find('input').attributes('type')).toBe('number');
     });
+
     it(`input type is 'text' when type is set to 'text'`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -118,6 +147,7 @@ describe('KTextbox component', () => {
       });
       expect(wrapper.find('input').attributes('type')).toBe('text');
     });
+
     it(`min length of value is passed as an attribute by the 'min' prop`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -129,6 +159,7 @@ describe('KTextbox component', () => {
       expect(wrapper.find('input').attributes('number')).toBe('true');
       expect(wrapper.find('input').attributes('min')).toBe('50');
     });
+
     it(`max length of value is passed as an attribute by the 'max' prop`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -140,6 +171,7 @@ describe('KTextbox component', () => {
       expect(wrapper.find('input').attributes('number')).toBe('true');
       expect(wrapper.find('input').attributes('max')).toBe('50');
     });
+
     it(`when 'true', textarea element is rendered`, () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -149,6 +181,7 @@ describe('KTextbox component', () => {
       expect(wrapper.find('textarea').exists()).toBeTruthy();
     });
   });
+
   describe('event handling', () => {
     it('should emit a input when value is updated', () => {
       const wrapper = mount(KTextbox, {
@@ -163,6 +196,7 @@ describe('KTextbox component', () => {
       expect(wrapper.emitted().input).toBeTruthy();
     });
   });
+
   describe('KTextbox with clearable', () => {
     it('should have the clear button when clearable is true and there is text in the input', async () => {
       const wrapper = mount(KTextbox, {
@@ -177,6 +211,7 @@ describe('KTextbox component', () => {
       const clearButton = wrapper.find('[data-test="clearIcon"]');
       expect(clearButton.exists()).toBeTruthy();
     });
+
     it('should not show the clear button when clearable is true and there is no text in the input', async () => {
       const wrapper = mount(KTextbox, {
         propsData: {
@@ -203,6 +238,7 @@ describe('KTextbox component', () => {
       await wrapper.vm.$nextTick();
       expect(wrapper.find('[data-test="clearIcon"]').exists()).toBeFalsy();
     });
+
     it('should clear the input when clear button is clicked', async () => {
       const wrapper = mount(KTextbox, {
         propsData: {

--- a/lib/KTextbox/__tests__/KTextbox.spec.js
+++ b/lib/KTextbox/__tests__/KTextbox.spec.js
@@ -7,203 +7,216 @@ describe('KTextbox component', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  describe('props', () => {
-    it(`a label should appear when passed via prop`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          label: 'test label',
-        },
-      });
-      expect(wrapper.find('label').text()).toEqual('test label');
+  it(`a label should appear when passed via prop`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        label: 'test label',
+      },
     });
-
-    it(`a label should appear when passed via slot`, () => {
-      const wrapper = mount(KTextbox, {
-        slots: {
-          label: 'test label',
-        },
-      });
-      expect(wrapper.find('label').text()).toEqual('test label');
-    });
-
-    it(`should show error when neither label prop nor slot is provided`, () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      mount(KTextbox);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[KTextbox] A label must be provided via prop or slot',
-      );
-      consoleErrorSpy.mockRestore();
-    });
-
-    it(`value of the text field should appear when passed in`, () => {
-      const initialValue = '1234paowiejfapwoeifjapwoeijf';
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          label: 'test',
-          value: initialValue,
-        },
-      });
-      const value = wrapper.find('input').element.value;
-      expect(value).toBe(initialValue);
-    });
-
-    it(`invalidText is not displayed if showInvalidText is false`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          invalid: true,
-          showInvalidText: false,
-          invalidText: 'error!',
-        },
-      });
-      const errorTextField = wrapper.find('.ui-textbox-feedback-text');
-      expect(errorTextField.text()).not.toBe('error!');
-    });
-
-    it(`invalidText is displayed through error prop if invalid and showInvalidText are both true`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          invalid: true,
-          showInvalidText: true,
-          invalidText: 'error!',
-        },
-      });
-      const errorTextField = wrapper.find('.ui-textbox-feedback-text');
-      expect(errorTextField.text()).toBe('error!');
-    });
-
-    it(`text field is disabled when 'disabled' is true`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          disabled: true,
-        },
-      });
-      expect(wrapper.find('input').attributes('disabled')).toBe('disabled');
-    });
-
-    it(`text field is readonly when 'readonly' is true`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          readonly: true,
-        },
-      });
-      expect(wrapper.find('input').attributes('readonly')).toBe('readonly');
-    });
-
-    it(`text field is autofocused when 'autofocus' is true`, () => {
-      const wrapper = shallowMount(KTextbox, {
-        propsData: {
-          autofocus: true,
-        },
-      });
-      const textField = wrapper.findComponent({ name: 'UiTextbox' });
-      expect(textField.attributes('autofocus')).toBe('true');
-    });
-
-    it(`length of characters for value matches maxlength prop`, () => {
-      const wrapper = shallowMount(KTextbox, {
-        propsData: {
-          maxlength: 13,
-        },
-      });
-      const textField = wrapper.findComponent({ name: 'UiTextbox' });
-      expect(textField.attributes('maxlength')).toBe('13');
-    });
-
-    it(`HTML autocomplete attribute is passed with autocomplete prop`, () => {
-      const wrapper = shallowMount(KTextbox, {
-        propsData: {
-          autocomplete: 'current-password',
-        },
-      });
-      const textField = wrapper.findComponent({ name: 'UiTextbox' });
-      expect(textField.attributes('autocomplete')).toBe('current-password');
-    });
-
-    it(`HTML autocapitalize attribute is passed with autocapitalize prop`, () => {
-      const wrapper = shallowMount(KTextbox, {
-        propsData: {
-          autocapitalize: 'sentences',
-        },
-      });
-      const textField = wrapper.findComponent({ name: 'UiTextbox' });
-      expect(textField.attributes('autocapitalize')).toBe('sentences');
-    });
-
-    it(`input type is 'number' when type is set to 'number'`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          type: 'number',
-        },
-      });
-      expect(wrapper.find('input').attributes('number')).toBe('true');
-      expect(wrapper.find('input').attributes('type')).toBe('number');
-    });
-
-    it(`input type is 'text' when type is set to 'text'`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          type: 'text',
-        },
-      });
-      expect(wrapper.find('input').attributes('type')).toBe('text');
-    });
-
-    it(`min length of value is passed as an attribute by the 'min' prop`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          type: 'number',
-          min: 50,
-        },
-      });
-      expect(wrapper.find('input').attributes('type')).toBe('number');
-      expect(wrapper.find('input').attributes('number')).toBe('true');
-      expect(wrapper.find('input').attributes('min')).toBe('50');
-    });
-
-    it(`max length of value is passed as an attribute by the 'max' prop`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          type: 'number',
-          max: 50,
-        },
-      });
-      expect(wrapper.find('input').attributes('type')).toBe('number');
-      expect(wrapper.find('input').attributes('number')).toBe('true');
-      expect(wrapper.find('input').attributes('max')).toBe('50');
-    });
-
-    it(`when 'true', textarea element is rendered`, () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          textArea: true,
-        },
-      });
-      expect(wrapper.find('textarea').exists()).toBeTruthy();
-    });
+    expect(wrapper.find('label').text()).toEqual('test label');
   });
 
-  describe('event handling', () => {
-    it('should emit a input when value is updated', () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          value: 'test',
-        },
-      });
-
-      const input = wrapper.find('input');
-      input.element.value = 'new value';
-      input.trigger('input');
-      expect(wrapper.emitted().input).toBeTruthy();
+  it(`a label should appear when passed via slot`, () => {
+    const wrapper = mount(KTextbox, {
+      slots: {
+        label: 'test label',
+      },
     });
+    expect(wrapper.find('label').text()).toEqual('test label');
   });
 
-  describe('KTextbox with clearable', () => {
-    it('should have the clear button when clearable is true and there is text in the input', async () => {
-      const wrapper = mount(KTextbox, {
+  it(`should show error when neither label prop nor slot is provided`, () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mount(KTextbox);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[KTextbox] A label must be provided via prop or slot',
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it(`value of the text field should appear when passed in`, () => {
+    const initialValue = '1234paowiejfapwoeifjapwoeijf';
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        label: 'test',
+        value: initialValue,
+      },
+    });
+    const value = wrapper.find('input').element.value;
+    expect(value).toBe(initialValue);
+  });
+
+  it(`invalidText is not displayed if showInvalidText is false`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        invalid: true,
+        showInvalidText: false,
+        invalidText: 'error!',
+      },
+    });
+    const errorTextField = wrapper.find('.ui-textbox-feedback-text');
+    expect(errorTextField.text()).not.toBe('error!');
+  });
+
+  it(`invalidText is displayed through error prop if invalid and showInvalidText are both true`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        invalid: true,
+        showInvalidText: true,
+        invalidText: 'error!',
+      },
+    });
+    const errorTextField = wrapper.find('.ui-textbox-feedback-text');
+    expect(errorTextField.text()).toBe('error!');
+  });
+
+  it(`text field is disabled when 'disabled' is true`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        disabled: true,
+      },
+    });
+    expect(wrapper.find('input').attributes('disabled')).toBe('disabled');
+  });
+
+  it(`text field is readonly when 'readonly' is true`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        readonly: true,
+      },
+    });
+    expect(wrapper.find('input').attributes('readonly')).toBe('readonly');
+  });
+
+  it(`text field is autofocused when 'autofocus' is true`, () => {
+    const wrapper = shallowMount(KTextbox, {
+      propsData: {
+        autofocus: true,
+      },
+    });
+    const textField = wrapper.findComponent({ name: 'UiTextbox' });
+    expect(textField.attributes('autofocus')).toBe('true');
+  });
+
+  it(`length of characters for value matches maxlength prop`, () => {
+    const wrapper = shallowMount(KTextbox, {
+      propsData: {
+        maxlength: 13,
+      },
+    });
+    const textField = wrapper.findComponent({ name: 'UiTextbox' });
+    expect(textField.attributes('maxlength')).toBe('13');
+  });
+
+  it(`HTML autocomplete attribute is passed with autocomplete prop`, () => {
+    const wrapper = shallowMount(KTextbox, {
+      propsData: {
+        autocomplete: 'current-password',
+      },
+    });
+    const textField = wrapper.findComponent({ name: 'UiTextbox' });
+    expect(textField.attributes('autocomplete')).toBe('current-password');
+  });
+
+  it(`HTML autocapitalize attribute is passed with autocapitalize prop`, () => {
+    const wrapper = shallowMount(KTextbox, {
+      propsData: {
+        autocapitalize: 'sentences',
+      },
+    });
+    const textField = wrapper.findComponent({ name: 'UiTextbox' });
+    expect(textField.attributes('autocapitalize')).toBe('sentences');
+  });
+
+  it(`input type is 'number' when type is set to 'number'`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        type: 'number',
+      },
+    });
+    expect(wrapper.find('input').attributes('number')).toBe('true');
+    expect(wrapper.find('input').attributes('type')).toBe('number');
+  });
+
+  it(`input type is 'text' when type is set to 'text'`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        type: 'text',
+      },
+    });
+    expect(wrapper.find('input').attributes('type')).toBe('text');
+  });
+
+  it(`min length of value is passed as an attribute by the 'min' prop`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        type: 'number',
+        min: 50,
+      },
+    });
+    expect(wrapper.find('input').attributes('type')).toBe('number');
+    expect(wrapper.find('input').attributes('number')).toBe('true');
+    expect(wrapper.find('input').attributes('min')).toBe('50');
+  });
+
+  it(`max length of value is passed as an attribute by the 'max' prop`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        type: 'number',
+        max: 50,
+      },
+    });
+    expect(wrapper.find('input').attributes('type')).toBe('number');
+    expect(wrapper.find('input').attributes('number')).toBe('true');
+    expect(wrapper.find('input').attributes('max')).toBe('50');
+  });
+
+  it(`when 'true', textarea element is rendered`, () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        textArea: true,
+      },
+    });
+    expect(wrapper.find('textarea').exists()).toBeTruthy();
+  });
+
+  it('should emit a input when value is updated', () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        value: 'test',
+      },
+    });
+
+    const input = wrapper.find('input');
+    input.element.value = 'new value';
+    input.trigger('input');
+    expect(wrapper.emitted().input).toBeTruthy();
+  });
+
+  it('should not show the clear button when clearable is false and there is text in the input', async () => {
+    const wrapper = mount(KTextbox, {
+      propsData: {
+        clearable: false,
+      },
+    });
+    const input = wrapper.find('input');
+    input.element.value = 'test';
+    input.trigger('input');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="clearIcon"]').exists()).toBeFalsy();
+  });
+
+  describe('when clearable', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = mount(KTextbox, {
         propsData: {
           clearable: true,
         },
       });
+    });
+
+    it('should have the clear button when there is text in the input', async () => {
       const input = wrapper.find('input');
       input.element.value = 'test';
       input.trigger('input');
@@ -212,13 +225,7 @@ describe('KTextbox component', () => {
       expect(clearButton.exists()).toBeTruthy();
     });
 
-    it('should not show the clear button when clearable is true and there is no text in the input', async () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          clearable: true,
-        },
-      });
-
+    it('should not show the clear button when there is no text in the input', async () => {
       const input = wrapper.find('input');
       input.element.value = '';
       input.trigger('input');
@@ -226,25 +233,7 @@ describe('KTextbox component', () => {
       expect(wrapper.find('[data-test="clearIcon"]').exists()).toBeFalsy();
     });
 
-    it('should not show the clear button when clearable is false and there is text in the input', async () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          clearable: false,
-        },
-      });
-      const input = wrapper.find('input');
-      input.element.value = 'test';
-      input.trigger('input');
-      await wrapper.vm.$nextTick();
-      expect(wrapper.find('[data-test="clearIcon"]').exists()).toBeFalsy();
-    });
-
     it('should clear the input when clear button is clicked', async () => {
-      const wrapper = mount(KTextbox, {
-        propsData: {
-          clearable: true,
-        },
-      });
       const input = wrapper.find('input');
       input.element.value = 'test';
       input.trigger('input');

--- a/lib/KTextbox/__tests__/components/KTextboxVisualTest.vue
+++ b/lib/KTextbox/__tests__/components/KTextboxVisualTest.vue
@@ -85,6 +85,18 @@
       width="400px"
       loadExample="KTextbox/Combined.vue"
     />
+
+    <VisualTestExample
+      title="Label via slot"
+      width="400px"
+      loadExample="KTextbox/LabelSlot.vue"
+    />
+
+    <VisualTestExample
+      title="Visually hidden label"
+      width="400px"
+      loadExample="KTextbox/VisuallyHiddenLabel.vue"
+    />
   </VisualTestLayout>
 
 </template>

--- a/lib/KTextbox/index.vue
+++ b/lib/KTextbox/index.vue
@@ -29,11 +29,11 @@
       @focus="emitFocus"
       @blur="emitBlur"
     >
-      <!--@slot Label. Alternative to the label prop. -->
       <template
         v-if="$slots.label"
         #default
       >
+        <!--@slot Label. Alternative to the label prop. -->
         <slot name="label"></slot>
       </template>
       <template #outerBefore>

--- a/lib/KTextbox/index.vue
+++ b/lib/KTextbox/index.vue
@@ -29,6 +29,13 @@
       @focus="emitFocus"
       @blur="emitBlur"
     >
+      <!--@slot Label. Alternative to the label prop. -->
+      <template
+        v-if="$slots.label"
+        #default
+      >
+        <slot name="label"></slot>
+      </template>
       <template #outerBefore>
         <!--@slot Places content before the input area-->
         <slot name="outerBefore"></slot>
@@ -68,7 +75,7 @@
        */
       label: {
         type: String,
-        required: true,
+        default: null,
       },
       /**
        * Value of the aria-label for clear button
@@ -214,6 +221,12 @@
       value(val) {
         this.currentText = val;
       },
+    },
+    created() {
+      if (!this.label && !this.$slots.label) {
+        // eslint-disable-next-line no-console
+        console.error('[KTextbox] A label must be provided via prop or slot');
+      }
     },
     methods: {
       updateText() {

--- a/lib/styles/common.scss
+++ b/lib/styles/common.scss
@@ -1,0 +1,10 @@
+.visuallyhidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description

- Fixes _internal_ visually hidden style (`KCard` example [here](https://github.com/learningequality/kolibri-design-system/blob/64c654cf0e246e14d4aa458fff41c5b0236758d9/lib/cards/KCard.vue#L32) + [here](https://github.com/learningequality/studio/pull/5564/files#diff-babee32b23e7321868294d22e9406a4d1a1c82e96871178bad171d1300e54163L465-L475)) not taking effect in KDS components when used from an application
  - By moving the style from documentation styles to library styles, and adding a new installation step to register library styles in applications

- As a side effect, above also exposes the `.visuallyhidden` class to be used for any component, not just KDS.

- Allows `KTextbox` label to be passed via slot and adds documentation on how to achieve visually hidden label

- Also has few maintenance commits for related documentation and test suite

#### Issue addressed

- Fixes https://github.com/learningequality/kolibri-design-system/issues/1163
- Studio companion PR https://github.com/learningequality/studio/pull/5564
- Fixes https://github.com/learningequality/kolibri-design-system/issues/1166

## Steps to test

- Preview updated documentation
  - [Installation: 2. Register global styles](https://deploy-preview-1169--kolibri-design-system.netlify.app/installation#register-global-styles)
  - [Helper styles](https://deploy-preview-1169--kolibri-design-system.netlify.app/styling#helper-styles)
  - [KTextbox: Input with label](https://deploy-preview-1169--kolibri-design-system.netlify.app/ktextbox#with-label)
  - [KTextbox: Visually hidden label](https://deploy-preview-1169--kolibri-design-system.netlify.app/ktextbox#visually-hidden-label)

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Fixes internal visually hidden style not taking effect in KDS components, and exposes the `.visuallyhidden` class as public
  - **Products impact:** bugfix
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1163
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** Import KDS styles in the main application stylesheet with `@import '~kolibri-design-system/lib/styles/common';` as described in https://design-system.learningequality.org/installation#register-global-styles. Cleanup custom `.visuallyhidden` class from application styles. See https://design-system.learningequality.org/#helper-styles.

  - **Description:** Allows `KTextbox` label to be passed via slot
  - **Products impact:** new API
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1166
  - **Components:** `KTextbox`
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** -
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->


