### PR TITLE
Upgrade workflows to .github#35

### DIFF
--- a/.github/workflows/call-contributor-pr-reply.yml
+++ b/.github/workflows/call-contributor-pr-reply.yml
@@ -1,0 +1,13 @@
+name: Send reply on a new contributor pull request
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  call-workflow:
+    name: Call shared workflow
+    uses: learningequality/.github/.github/workflows/contributor-pr-reply.yml@main
+    secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+      SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL }}

--- a/.github/workflows/call-holiday-message.yml
+++ b/.github/workflows/call-holiday-message.yml
@@ -1,0 +1,15 @@
+name: Post holiday message on pull request or issue comment
+on:
+  pull_request_target:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-workflow:
+    name: Call shared workflow
+    uses: learningequality/.github/.github/workflows/holiday-message.yml@main
+    secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}
+      SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL: ${{ secrets.SLACK_COMMUNITY_NOTIFICATIONS_WEBHOOK_URL }}

--- a/.github/workflows/call-update-pr-spreadsheet.yml
+++ b/.github/workflows/call-update-pr-spreadsheet.yml
@@ -1,12 +1,15 @@
 name: Update community pull requests spreadsheet
 on:
   pull_request_target:
-    types: [assigned,unassigned,opened,closed,reopened]
+    types: [assigned, unassigned, opened, closed, reopened, edited, review_requested, review_request_removed]
 
 jobs:
-  call-update-spreadsheet:
+  call-workflow:
+    name: Call shared workflow
     uses: learningequality/.github/.github/workflows/update-pr-spreadsheet.yml@main
     secrets:
+      LE_BOT_APP_ID: ${{ secrets.LE_BOT_APP_ID }}
+      LE_BOT_PRIVATE_KEY: ${{ secrets.LE_BOT_PRIVATE_KEY }}
       CONTRIBUTIONS_SPREADSHEET_ID: ${{ secrets.CONTRIBUTIONS_SPREADSHEET_ID }}
       CONTRIBUTIONS_SHEET_NAME: ${{ secrets.CONTRIBUTIONS_SHEET_NAME }}
       GH_UPLOADER_GCP_SA_CREDENTIALS: ${{ secrets.GH_UPLOADER_GCP_SA_CREDENTIALS }}


### PR DESCRIPTION
A companion to https://github.com/learningequality/.github/pull/35

**Disclosure**
@MisRob created https://github.com/learningequality/kolibri/pull/13966 and then asked Jules to replicate the PR in this repository. She reviewed all changes, and adjusted commit message.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Upgrade workflows to .github#35
  - **Products impact:** None
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
