### PR TITLE
Fix KToolbar documentation examples not loaded

### DIFF
--- a/examples/KToolbar/DarkTheme.vue
+++ b/examples/KToolbar/DarkTheme.vue
@@ -20,18 +20,3 @@
   </KToolbar>
 
 </template>
-
-
-<script>
-
-  import KToolbar from '../../../lib/KToolbar.vue';
-  import KIconButton from '../../../lib/KIcon/index.vue';
-
-  export default {
-    components: {
-      KToolbar,
-      KIconButton,
-    },
-  };
-
-</script>

--- a/examples/KToolbar/LightTheme.vue
+++ b/examples/KToolbar/LightTheme.vue
@@ -15,18 +15,3 @@
   </KToolbar>
 
 </template>
-
-
-<script>
-
-  import KToolbar from '../../../lib/KToolbar.vue';
-  import KIconButton from '../../../lib/KIcon/index.vue';
-
-  export default {
-    components: {
-      KToolbar,
-      KIconButton,
-    },
-  };
-
-</script>


### PR DESCRIPTION
## Description

Cherry-picks a commit from https://github.com/learningequality/kolibri-design-system/pull/1153 that fixes `KToolbar` documentation examples not being loaded. Also removes unnecessary imports.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Fix KToolbar documentation examples not loaded
  - **Products impact:** none
  - **Addresses:** -
  - **Components:** KToolbar
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

Preview `KToolbar` examples in the documentation build
