### PR TITLE
Update dependabot to monthly schedule with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "00:00"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       babel:
         patterns:
@@ -19,9 +19,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "00:00"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       github:
         patterns:


### PR DESCRIPTION
- Change schedule from weekly to monthly (triggers on 1st of each month)
- Add 7-day cooldown to avoid upgrading to freshly released versions
- Applied to both npm and github-actions ecosystems

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Update dependabot configuration
  - **Products impact:** none 
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 