### PR TITLE
Update lodash import to be selective.

### DIFF
--- a/lib/KTable/useSorting.js
+++ b/lib/KTable/useSorting.js
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import _ from 'lodash';
+import orderBy from 'lodash/orderBy';
 
 export const SORT_ORDER_ASC = 'asc';
 export const SORT_ORDER_DESC = 'desc';
@@ -49,14 +49,14 @@ export default function useSorting(headers, rows, defaultSort, disableBuiltinSor
     if (sortKey.value === null || sortOrder.value === null) {
       if (defaultSort.value.index === -1) return rows.value;
 
-      return _.orderBy(
+      return orderBy(
         rows.value,
         [row => getSortValue(row, defaultSort.value.index)],
         [defaultSort.value.direction],
       );
     }
 
-    return _.orderBy(rows.value, [row => getSortValue(row, sortKey.value)], [sortOrder.value]);
+    return orderBy(rows.value, [row => getSortValue(row, sortKey.value)], [sortOrder.value]);
   });
 
   /**


### PR DESCRIPTION
## Description
Fixes lodash import to import specific function rather than entire library (1-2KB vs ~500KB)

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Updates lodash import to use specific module path
  - **Products impact:** bugfix
  - **Addresses:** Bloated asset size due to import of entire lodash library
  - **Components:** KTable
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** N/A

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Ensure KTable sorting is still the same
