### PR TITLE
Add thumbnail slot to KCard

### DIFF
--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -685,6 +685,48 @@
         />.
       </p>
 
+      <h4>
+        Thumbnail slot
+        <DocsAnchorTarget anchor="#thumbnail-slot" />
+      </h4>
+
+      <p>
+        When the thumbnail configuration options are insufficient, the <code>thumbnail</code> slot
+        can be utilized. It is typically used to gain full access to
+        <code>KImg</code> configurations, such as aspect ratio.
+      </p>
+
+      <p>
+        If providing <code>KImg</code>, set <code>isDecorative</code> to <code>true</code> on
+        <code>KImg</code> for correct accessibility.
+      </p>
+
+      <DocsExample
+        loadExample="cards/ThumbnailSlotSmall.vue"
+        exampleId="kcard-thumbnail-slot-small"
+        hideScript
+        block
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KCardGrid ...>
+              <KCard ...>
+                <template #thumbnail>
+                  <KImg
+                    :src="..."
+                    :style="{ width: '100%', height: '100%' }"
+                    aspectRatio="16:9"
+                    isDecorative
+                  />
+                </template>
+              </KCard>
+            </KCardGrid>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
+
       <h3>
         Interactive elements
         <DocsAnchorTarget anchor="#interactive-elements" />

--- a/examples/cards/Card.vue
+++ b/examples/cards/Card.vue
@@ -12,6 +12,12 @@
     :title="cardTitle"
   >
     <template
+      v-if="$slots.thumbnail"
+      #thumbnail
+    >
+      <slot name="thumbnail"></slot>
+    </template>
+    <template
       v-if="$slots.thumbnailPlaceholder"
       #thumbnailPlaceholder
     >

--- a/examples/cards/ThumbnailSlotLargeHorizontal.vue
+++ b/examples/cards/ThumbnailSlotLargeHorizontal.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <KCardGrid layout="1-1-1">
+    <Card
+      :headingLevel="2"
+      orientation="horizontal"
+      thumbnailDisplay="large"
+    >
+      <template #thumbnail>
+        <KImg
+          :src="require('../common/hummingbird-large-cc-by-sa-4.jpg')"
+          :style="{ width: '100%', height: '100%' }"
+          aspectRatio="16:9"
+          isDecorative
+        />
+      </template>
+    </Card>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  import Card from './Card';
+
+  export default {
+    components: {
+      Card,
+    },
+  };
+
+</script>

--- a/examples/cards/ThumbnailSlotLargeVertical.vue
+++ b/examples/cards/ThumbnailSlotLargeVertical.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <KCardGrid layout="1-1-1">
+    <Card
+      :headingLevel="2"
+      orientation="vertical"
+      thumbnailDisplay="large"
+    >
+      <template #thumbnail>
+        <KImg
+          :src="require('../common/hummingbird-large-cc-by-sa-4.jpg')"
+          :style="{ width: '100%', height: '100%' }"
+          aspectRatio="16:9"
+          isDecorative
+        />
+      </template>
+    </Card>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  import Card from './Card';
+
+  export default {
+    components: {
+      Card,
+    },
+  };
+
+</script>

--- a/examples/cards/ThumbnailSlotSmall.vue
+++ b/examples/cards/ThumbnailSlotSmall.vue
@@ -1,0 +1,28 @@
+<template>
+
+  <div>
+    <ThumbnailSlotSmallHorizontal v-if="windowBreakpoint > 2" />
+    <ThumbnailSlotSmallVertical v-else />
+  </div>
+
+</template>
+
+
+<script>
+
+  import useKResponsiveWindow from '../../lib/composables/useKResponsiveWindow';
+  import ThumbnailSlotSmallHorizontal from './ThumbnailSlotSmallHorizontal.vue';
+  import ThumbnailSlotSmallVertical from './ThumbnailSlotSmallVertical.vue';
+
+  export default {
+    components: {
+      ThumbnailSlotSmallHorizontal,
+      ThumbnailSlotSmallVertical,
+    },
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return { windowBreakpoint };
+    },
+  };
+
+</script>

--- a/examples/cards/ThumbnailSlotSmallHorizontal.vue
+++ b/examples/cards/ThumbnailSlotSmallHorizontal.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <KCardGrid layout="1-1-1">
+    <Card
+      :headingLevel="2"
+      orientation="horizontal"
+      thumbnailDisplay="small"
+    >
+      <template #thumbnail>
+        <KImg
+          :src="require('../common/hummingbird-large-cc-by-sa-4.jpg')"
+          :style="{ width: '100%', height: '100%' }"
+          aspectRatio="16:9"
+          isDecorative
+        />
+      </template>
+    </Card>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  import Card from './Card';
+
+  export default {
+    components: {
+      Card,
+    },
+  };
+
+</script>

--- a/examples/cards/ThumbnailSlotSmallVertical.vue
+++ b/examples/cards/ThumbnailSlotSmallVertical.vue
@@ -1,0 +1,33 @@
+<template>
+
+  <KCardGrid layout="1-1-1">
+    <Card
+      :headingLevel="2"
+      orientation="vertical"
+      thumbnailDisplay="small"
+    >
+      <template #thumbnail>
+        <KImg
+          :src="require('../common/hummingbird-large-cc-by-sa-4.jpg')"
+          :style="{ width: '100%', height: '100%' }"
+          aspectRatio="16:9"
+          isDecorative
+        />
+      </template>
+    </Card>
+  </KCardGrid>
+
+</template>
+
+
+<script>
+
+  import Card from './Card';
+
+  export default {
+    components: {
+      Card,
+    },
+  };
+
+</script>

--- a/lib/cards/KCard.vue
+++ b/lib/cards/KCard.vue
@@ -132,11 +132,19 @@
           v-if="thumbnailDisplay !== ThumbnailDisplays.NONE"
           class="k-thumbnail"
         >
+          <!-- @slot Overrides the default thumbnail image. -->
+          <div
+            v-if="$slots.thumbnail"
+            :style="{ width: '100%', height: '100%' }"
+          >
+            <slot name="thumbnail"></slot>
+          </div>
           <!--
             Render KImg even if thumbnailSrc is not provided since in that case
             KImg takes care of showing the gray placeholder area.
           -->
           <KImg
+            v-else
             data-test="thumbnail-img"
             :src="thumbnailSrc"
             :scaleType="thumbnailScaleType"
@@ -146,7 +154,7 @@
             @error="onThumbnailError"
           />
           <span
-            v-if="!thumbnailSrc || thumbnailError"
+            v-if="(!thumbnailSrc || thumbnailError) && !$slots.thumbnail"
             class="k-thumbnail-placeholder"
           >
             <!-- @slot Places content to the thumbnail placeholder area. -->

--- a/lib/cards/__tests__/components/CardsVisualTest.vue
+++ b/lib/cards/__tests__/components/CardsVisualTest.vue
@@ -52,6 +52,26 @@
     />
 
     <VisualTestExample
+      title="Thumbnail slot with 16:9 KImg, small thumbnail area, horizontal orientation"
+      loadExample="cards/ThumbnailSlotSmallHorizontal.vue"
+    />
+
+    <VisualTestExample
+      title="Thumbnail slot with 16:9 KImg, large thumbnail area, horizontal orientation"
+      loadExample="cards/ThumbnailSlotLargeHorizontal.vue"
+    />
+
+    <VisualTestExample
+      title="Thumbnail slot with 16:9 KImg, small thumbnail area, vertical orientation"
+      loadExample="cards/ThumbnailSlotSmallVertical.vue"
+    />
+
+    <VisualTestExample
+      title="Thumbnail slot with 16:9 KImg, large thumbnail area, vertical orientation"
+      loadExample="cards/ThumbnailSlotLargeVertical.vue"
+    />
+
+    <VisualTestExample
       title="Thumbnail placeholder"
       loadExample="cards/Placeholder.vue"
       :loadFor="0"


### PR DESCRIPTION
## Description

In support of migrating Studio channel cards to `KCard`, we need to achieve 16:9 thumbnail aspect ratio. This PR

- Adds the `thumbnail` slot to `KCard`
- Updates documentation and adds an example of how to achieve 16:9 thumbnail area
- Adds visual tests for the slot in combination with various card layout configurations

#### Issue addressed

Resolves https://github.com/learningequality/kolibri-design-system/issues/1162

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Add the `thumbnail` slot to `KCard`
  - **Products impact:** new API
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1162
  - **Components:** `KCard`
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

- Preview the [new documentation section](https://deploy-preview-1194--kolibri-design-system.netlify.app/kcard#thumbnail-slot)
- Preview visual tests
