### PR TITLE
Prevent external link icon from becoming tiny

### DIFF
--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -118,6 +118,7 @@
 
   .icon {
     top: 4px;
+    flex-shrink: 0;
   }
 
 </style>

--- a/lib/buttons-and-links/KExternalLink.vue
+++ b/lib/buttons-and-links/KExternalLink.vue
@@ -17,8 +17,8 @@
       <slot name="icon">
         <KIcon
           v-if="icon"
+          class="icon"
           :icon="icon"
-          style="top: 4px"
           :color="iconColor"
         />
       </slot>
@@ -32,15 +32,15 @@
       <slot name="iconAfter">
         <KIcon
           v-if="iconAfter"
+          class="icon"
           :icon="iconAfter"
-          style="top: 4px"
           :color="iconColor"
         />
       </slot>
       <KIcon
         v-if="openInNewTab"
+        class="icon"
         icon="openNewTab"
-        style="top: 4px"
         :color="iconColor"
       />
     </span>
@@ -114,6 +114,10 @@
     display: inline-flex;
     gap: 8px;
     align-items: baseline;
+  }
+
+  .icon {
+    top: 4px;
   }
 
 </style>


### PR DESCRIPTION
## Description

This fixes an issue I observed in Studio when an external link icon shrinks to tiny or even to nearly invisible in smaller container. Icon size should stay the same. Same problem can be seen on the KDS documentation website. 

### Before/after screenshots

| Before | After |
| --- | --- |
|  <img width="171" height="197" alt="Screenshot from 2026-01-29 20-02-52" src="https://github.com/user-attachments/assets/767f1aa4-f0fa-46e1-b917-7aff1d3e6a7e" /> | <img width="171" height="197" alt="Screenshot from 2026-01-29 20-03-13" src="https://github.com/user-attachments/assets/69d85764-920a-48d9-8ba3-65c500615b7e" /> |

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Prevent external link icon from becoming tiny
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** KExternalLink
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

Preview https://deploy-preview-1198--kolibri-design-system.netlify.app/kexternallink on small screen 
