### PR TITLE
[KImg] Do not add img element to DOM when src not provided

### DIFF
--- a/lib/KImg/index.vue
+++ b/lib/KImg/index.vue
@@ -3,6 +3,7 @@
   <span :style="outerContainerStyles">
     <span :style="innerContainerStyles">
       <img
+        v-if="src"
         :src="src"
         :alt="alternativeText"
         :style="imgStyles"


### PR DESCRIPTION
## Description

When `src` undefined or null, `KImg` added `<img src ... />` to DOM.

This is generally not intuitive and caused me some confusion when I was [debugging Studio channel pdf generation](https://github.com/learningequality/studio/pull/5690) problems - when parsing the page, the pdf generation library wasn't able to work with an image element without a source, naturally.

This adds a condition to prevent from `img` element being added to DOM when there's no source provided.

## Changelog

  - **Description:** Do not add img element to DOM when src not provided
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** KImg
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -
