### PR TITLE
KCard and KImg updates in support of Studio's channel cards

### DIFF
--- a/docs/pages/kcard.vue
+++ b/docs/pages/kcard.vue
@@ -912,17 +912,17 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '490px',
+            minHeight: '490px',
           },
           {
             breakpoints: [2],
-            height: '430px',
+            minHeight: '430px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
             orientation: 'horizontal',
             thumbnailAlign: 'right',
-            height: '220px',
+            minHeight: '220px',
           },
         ],
       };

--- a/docs/pages/kcardgrid.vue
+++ b/docs/pages/kcardgrid.vue
@@ -598,8 +598,8 @@
         <code>loading</code> value:
       </p>
       <ul>
-        <li>The loading skeletons won't be displayed for short loading times (&lt; 1s)</li>
-        <li>When the loading skeletons are displayed, they will be visible for at least 1s</li>
+        <li>The loading skeletons won't be displayed for short loading times (&lt; 300ms)</li>
+        <li>When the loading skeletons are displayed, they will be visible for at least 300ms</li>
       </ul>
       <p>Use the buttons in the example below to preview.</p>
 

--- a/docs/pages/kcardgrid.vue
+++ b/docs/pages/kcardgrid.vue
@@ -601,18 +601,6 @@
         <li>The loading skeletons won't be displayed for short loading times (&lt; 300ms)</li>
         <li>When the loading skeletons are displayed, they will be visible for at least 300ms</li>
       </ul>
-      <p>Use the buttons in the example below to preview.</p>
-
-      <h4>
-        Number of loading skeletons <DocsAnchorTarget anchor="#loading-state-skeletons-count" />
-      </h4>
-
-      <p>
-        By default, the number of loading skeletons corresponds to the number of cards in a single
-        grid row if it were full. This behavior can be overridden via the
-        <code>count</code> attribute (below), however do not override it unless indicated in the
-        designs.
-      </p>
 
       <h4>Loading skeletons configuration</h4>
 
@@ -624,7 +612,8 @@
 
       <p>
         <code>skeletonsConfig</code> takes an array of objects
-        <code>{ breakpoints, count, minHeight, orientation, thumbnailDisplay, thumbnailAlign }</code>, where:
+        <code>{ breakpoints, count, minHeight, orientation, thumbnailDisplay, thumbnailAlign,
+          thumbnailAspectRatio }</code>, where:
       </p>
 
       <ul>
@@ -636,11 +625,8 @@
           />. All other attributes in the same object take effect on these breakpoints.
         </li>
         <li>
-          <code>count</code> sets the number of skeleton cards for the specified breakpoints. See
-          <DocsInternalLink
-            text="Number of loading skeletons"
-            href="#loading-state-skeletons-count"
-          />.
+          <code>count</code> sets the number of skeleton cards for the specified breakpoints.
+          Corresponds to the number of cards in a single grid row by default.
         </li>
         <li>
           <code>minHeight</code> sets the minimum height of skeleton cards for the specified
@@ -670,6 +656,15 @@
           <DocsInternalLink
             text="KCard's thumbnailAlign"
             href="/kcard#prop:thumbnailAlign"
+            code
+          />.
+        </li>
+        <li>
+          <code>thumbnailAspectRatio</code> sets the thumbnail area aspect ratio for the specified
+          breakpoints. Corresponds to
+          <DocsInternalLink
+            text="KImg's aspectRatio"
+            href="/kimg#prop:aspectRatio"
             code
           />.
         </li>

--- a/docs/pages/kcardgrid.vue
+++ b/docs/pages/kcardgrid.vue
@@ -624,8 +624,7 @@
 
       <p>
         <code>skeletonsConfig</code> takes an array of objects
-        <code>{ breakpoints, count, height, orientation, thumbnailDisplay, thumbnailAlign }</code>,
-        where:
+        <code>{ breakpoints, count, minHeight, orientation, thumbnailDisplay, thumbnailAlign }</code>, where:
       </p>
 
       <ul>
@@ -644,7 +643,8 @@
           />.
         </li>
         <li>
-          <code>height</code> sets the height of skeleton cards for the specified breakpoints.
+          <code>minHeight</code> sets the minimum height of skeleton cards for the specified
+          breakpoints.
         </li>
         <li>
           <code>orientation</code> sets the orientation of skeleton cards for the specified
@@ -718,14 +718,14 @@
                   skeletonsConfig: [
                     {
                       breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-                      height: '400px',
+                      minHeight: '400px',
                       orientation: 'vertical',
                       thumbnailDisplay: 'large',
                       thumbnailAlign: 'left'
                     },
                     {
                       breakpoints: [4, 5, 6, 7],
-                      height: '220px',
+                      minHeight: '220px',
                       orientation: 'horizontal'
                     }
                   ],
@@ -738,12 +738,12 @@
       </DocsExample>
 
       <p>
-        Here, the height of loading skeleton cards is <code>400px</code> with vertical orientation
-        on breakpoints <code>0-3</code>, and <code>220px</code> with horizontal orientation on
-        breakpoints <code>4-7</code>. This makes skeleton cards resemble loaded cards at all
-        breakpoints, creating a smooth transition for users during data loading. Note the bottom-up
-        approach where we begin with a base setup for all breakpoints and gradually override on
-        higher breakpoints. This simplifies the configuration object.
+        Here, the minimum height of loading skeleton cards is <code>400px</code> with vertical
+        orientation on breakpoints <code>0-3</code>, and <code>220px</code> with horizontal
+        orientation on breakpoints <code>4-7</code>. This makes skeleton cards resemble loaded cards
+        at all breakpoints, creating a smooth transition for users during data loading. Note the
+        bottom-up approach where we begin with a base setup for all breakpoints and gradually
+        override on higher breakpoints. This simplifies the configuration object.
       </p>
 
       <p>

--- a/examples/cards/ContentSlots.vue
+++ b/examples/cards/ContentSlots.vue
@@ -65,11 +65,11 @@
             orientation: 'horizontal',
             thumbnailDisplay: 'large',
             thumbnailAlign: 'left',
-            height: '300px',
+            minHeight: '300px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
-            height: '190px',
+            minHeight: '190px',
           },
         ],
       };

--- a/examples/cards/Grid111.vue
+++ b/examples/cards/Grid111.vue
@@ -41,7 +41,7 @@
         skeletonsConfig: [
           {
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            height: '220px',
+            minHeight: '220px',
             orientation: 'horizontal',
             thumbnailDisplay: 'large',
             thumbnailAlign: 'left',

--- a/examples/cards/Grid122.vue
+++ b/examples/cards/Grid122.vue
@@ -40,7 +40,7 @@
         skeletonsConfig: [
           {
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            height: '380px',
+            minHeight: '380px',
             orientation: 'vertical',
             thumbnailDisplay: 'large',
           },

--- a/examples/cards/Grid123.vue
+++ b/examples/cards/Grid123.vue
@@ -40,7 +40,7 @@
         skeletonsConfig: [
           {
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            height: '380px',
+            minHeight: '380px',
             orientation: 'vertical',
             thumbnailDisplay: 'large',
           },

--- a/examples/cards/HeightAndAlignment.vue
+++ b/examples/cards/HeightAndAlignment.vue
@@ -150,7 +150,7 @@
         skeletonsConfig: [
           {
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
-            height: '380px',
+            minHeight: '380px',
             orientation: 'vertical',
             thumbnailDisplay: 'large',
           },

--- a/examples/cards/HorizontalLayout.vue
+++ b/examples/cards/HorizontalLayout.vue
@@ -52,11 +52,11 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '490px',
+            minHeight: '490px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
-            height: '420px',
+            minHeight: '420px',
           },
         ],
       };

--- a/examples/cards/InteractiveElements.vue
+++ b/examples/cards/InteractiveElements.vue
@@ -70,17 +70,17 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '460px',
+            minHeight: '460px',
           },
           {
             breakpoints: [2],
-            height: '390px',
+            minHeight: '390px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
             orientation: 'horizontal',
             thumbnailAlign: 'right',
-            height: '170px',
+            minHeight: '170px',
           },
         ],
       };

--- a/examples/cards/LoadingState.vue
+++ b/examples/cards/LoadingState.vue
@@ -65,11 +65,11 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '400px',
+            minHeight: '400px',
           },
           {
             breakpoints: [4, 5, 6, 7],
-            height: '220px',
+            minHeight: '220px',
             orientation: 'horizontal',
             thumbnailAlign: 'left',
           },

--- a/examples/cards/LoadingState.vue
+++ b/examples/cards/LoadingState.vue
@@ -5,15 +5,15 @@
       <KButtonGroup>
         <KButton
           primary
-          @click="load500"
+          @click="load200"
         >
-          Load (0.5 s)
+          Load (0.2 s)
         </KButton>
         <KButton
           primary
-          @click="load1200"
+          @click="load400"
         >
-          Load (1.2 s)
+          Load (0.4 s)
         </KButton>
         <KButton
           primary
@@ -82,17 +82,17 @@
       }, 3000);
     },
     methods: {
-      load500() {
+      load200() {
         this.loading = true;
         setTimeout(() => {
           this.loading = false;
-        }, 500);
+        }, 200);
       },
-      load1200() {
+      load400() {
         this.loading = true;
         setTimeout(() => {
           this.loading = false;
-        }, 1200);
+        }, 400);
       },
       load4000() {
         this.loading = true;

--- a/examples/cards/Placeholder.vue
+++ b/examples/cards/Placeholder.vue
@@ -48,17 +48,17 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '460px',
+            minHeight: '460px',
           },
           {
             breakpoints: [2],
-            height: '390px',
+            minHeight: '390px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
             orientation: 'horizontal',
             thumbnailAlign: 'right',
-            height: '170px',
+            minHeight: '170px',
           },
         ],
       };

--- a/examples/cards/ResponsiveFooter.vue
+++ b/examples/cards/ResponsiveFooter.vue
@@ -110,11 +110,11 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '430px',
+            minHeight: '430px',
           },
           {
             breakpoints: [4, 5, 6, 7],
-            height: '370px',
+            minHeight: '370px',
           },
         ],
       };

--- a/examples/cards/ResponsiveOrientation.vue
+++ b/examples/cards/ResponsiveOrientation.vue
@@ -48,11 +48,11 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '440px',
+            minHeight: '440px',
           },
           {
             breakpoints: [4, 5, 6, 7],
-            height: '220px',
+            minHeight: '220px',
             orientation: 'horizontal',
             thumbnailAlign: 'left',
           },

--- a/examples/cards/SelectionControls.vue
+++ b/examples/cards/SelectionControls.vue
@@ -94,17 +94,17 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '400px',
+            minHeight: '400px',
           },
           {
             breakpoints: [2],
-            height: '380px',
+            minHeight: '380px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
             orientation: 'horizontal',
             thumbnailAlign: 'right',
-            height: '180px',
+            minHeight: '180px',
           },
         ],
       };

--- a/examples/cards/Title.vue
+++ b/examples/cards/Title.vue
@@ -54,7 +54,7 @@
             orientation: 'horizontal',
             thumbnailDisplay: 'small',
             thumbnailAlign: 'right',
-            height: '130px',
+            minHeight: '130px',
           },
         ],
       };

--- a/examples/cards/VerticalLayoutLargeThumbnail.vue
+++ b/examples/cards/VerticalLayoutLargeThumbnail.vue
@@ -94,11 +94,11 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '490px',
+            minHeight: '490px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
-            height: '420px',
+            minHeight: '420px',
           },
         ],
       };

--- a/examples/cards/VerticalLayoutNoThumbnail.vue
+++ b/examples/cards/VerticalLayoutNoThumbnail.vue
@@ -60,11 +60,11 @@
             breakpoints: [0, 1, 2, 3, 4, 5, 6, 7],
             orientation: 'vertical',
             thumbnailDisplay: 'large',
-            height: '490px',
+            minHeight: '490px',
           },
           {
             breakpoints: [3, 4, 5, 6, 7],
-            height: '420px',
+            minHeight: '420px',
           },
         ],
       };

--- a/lib/KImg/index.vue
+++ b/lib/KImg/index.vue
@@ -3,6 +3,7 @@
   <span :style="outerContainerStyles">
     <span :style="innerContainerStyles">
       <img
+        v-if="src"
         :src="src"
         :alt="alternativeText"
         :style="imgStyles"

--- a/lib/cards/KCard.vue
+++ b/lib/cards/KCard.vue
@@ -634,8 +634,7 @@
   }
 
   .k-title {
-    display: inline-block; // allows title placeholder in the skeleton card
-    width: 100%; // allows title placeholder in the skeleton card
+    width: 100%;
     color: inherit;
     text-decoration: none;
     outline: none; // the focus ring is moved to the whole <li>

--- a/lib/cards/KCard.vue
+++ b/lib/cards/KCard.vue
@@ -130,7 +130,7 @@
 
         <div
           v-if="thumbnailDisplay !== ThumbnailDisplays.NONE"
-          class="k-thumbnail"
+          :class="{ 'k-thumbnail': true, 'k-default-thumbnail': !$slots.thumbnail }"
         >
           <!-- @slot Overrides the default thumbnail image. -->
           <div
@@ -723,6 +723,9 @@
 
     .k-thumbnail {
       order: 1;
+    }
+
+    .k-default-thumbnail {
       height: 180px;
     }
 
@@ -737,8 +740,11 @@
     /* stylelint-enable scss/at-extend-no-missing-placeholder */
 
     .k-thumbnail {
-      height: calc(180px - #{$spacer});
       margin: $spacer $spacer 0;
+    }
+
+    .k-default-thumbnail {
+      height: calc(180px - #{$spacer});
     }
   }
 

--- a/lib/cards/KCardGrid.vue
+++ b/lib/cards/KCardGrid.vue
@@ -22,6 +22,7 @@
             :orientation="skeletonOrientation"
             :thumbnailDisplay="skeletonThumbnailDisplay"
             :thumbnailAlign="skeletonThumbnailAlign"
+            :thumbnailAspectRatio="skeletonThumbnailAspectRatio"
           />
         </ul>
         <ul
@@ -78,6 +79,7 @@
         skeletonOrientation,
         skeletonThumbnailDisplay,
         skeletonThumbnailAlign,
+        skeletonThumbnailAspectRatio,
       } = useGridLoading(props);
 
       const gridStyle = ref({});
@@ -123,6 +125,7 @@
         skeletonOrientation,
         skeletonThumbnailDisplay,
         skeletonThumbnailAlign,
+        skeletonThumbnailAspectRatio,
       };
     },
     props: {

--- a/lib/cards/KCardGrid.vue
+++ b/lib/cards/KCardGrid.vue
@@ -18,7 +18,7 @@
           <SkeletonCard
             v-for="i in skeletonCount"
             :key="i"
-            :height="skeletonHeight"
+            :minHeight="skeletonMinHeight"
             :orientation="skeletonOrientation"
             :thumbnailDisplay="skeletonThumbnailDisplay"
             :thumbnailAlign="skeletonThumbnailAlign"
@@ -74,7 +74,7 @@
         showGrid,
         isLoading,
         skeletonCount,
-        skeletonHeight,
+        skeletonMinHeight,
         skeletonOrientation,
         skeletonThumbnailDisplay,
         skeletonThumbnailAlign,
@@ -119,7 +119,7 @@
         isLoading,
         showGrid,
         skeletonCount,
-        skeletonHeight,
+        skeletonMinHeight,
         skeletonOrientation,
         skeletonThumbnailDisplay,
         skeletonThumbnailAlign,

--- a/lib/cards/SkeletonCard.vue
+++ b/lib/cards/SkeletonCard.vue
@@ -10,7 +10,7 @@
     aria-hidden="true"
     class="k-skeleton-card"
     title="_"
-    :style="{ height: height }"
+    :style="{ minHeight: minHeight }"
     :orientation="orientation"
     :thumbnailDisplay="thumbnailDisplay"
     :thumbnailAlign="thumbnailAlign"
@@ -46,9 +46,9 @@
     name: 'SkeletonCard',
     props: {
       /**
-       * Card height
+       * Card minimum height
        */
-      height: {
+      minHeight: {
         required: false,
         type: String,
         default: '300px',

--- a/lib/cards/SkeletonCard.vue
+++ b/lib/cards/SkeletonCard.vue
@@ -15,6 +15,16 @@
     :thumbnailDisplay="thumbnailDisplay"
     :thumbnailAlign="thumbnailAlign"
   >
+    <template
+      v-if="thumbnailAspectRatio"
+      #thumbnail
+    >
+      <KImg
+        :style="{ width: '100%', height: '100%' }"
+        :aspectRatio="thumbnailAspectRatio"
+        isDecorative
+      />
+    </template>
     <template #title>
       <span
         class="k-title-placeholder"
@@ -76,6 +86,14 @@
         required: false,
         type: String,
         default: 'left',
+      },
+      /**
+       * Thumbnail area aspect ratio
+       */
+      thumbnailAspectRatio: {
+        required: false,
+        type: String,
+        default: null,
       },
     },
   };

--- a/lib/cards/useGridLoading.js
+++ b/lib/cards/useGridLoading.js
@@ -11,7 +11,7 @@ const MIN_LOADING_TIME = 300;
 
 const DEFAULT_SKELETON = {
   count: undefined, // default determined by the grid layout and the current breakpoint
-  height: '200px',
+  minHeight: '200px',
   orientation: 'horizontal',
   thumbnailDisplay: 'none',
   thumbnailAlign: 'left',
@@ -25,7 +25,7 @@ export default function useGridLoading(props) {
   const { loading, skeletonsConfig } = toRefs(props);
 
   const skeletonCount = ref(DEFAULT_SKELETON.count);
-  const skeletonHeight = ref(DEFAULT_SKELETON.height);
+  const skeletonMinHeight = ref(DEFAULT_SKELETON.minHeight);
   const skeletonOrientation = ref(DEFAULT_SKELETON.orientation);
   const skeletonThumbnailDisplay = ref(DEFAULT_SKELETON.thumbnailDisplay);
   const skeletonThumbnailAlign = ref(DEFAULT_SKELETON.thumbnailAlign);
@@ -111,8 +111,8 @@ export default function useGridLoading(props) {
         if (breakpointSkeletonConfig.count) {
           skeletonCount.value = breakpointSkeletonConfig.count;
         }
-        if (breakpointSkeletonConfig.height) {
-          skeletonHeight.value = breakpointSkeletonConfig.height;
+        if (breakpointSkeletonConfig.minHeight) {
+          skeletonMinHeight.value = breakpointSkeletonConfig.minHeight;
         }
         if (breakpointSkeletonConfig.orientation) {
           skeletonOrientation.value = breakpointSkeletonConfig.orientation;
@@ -132,7 +132,7 @@ export default function useGridLoading(props) {
     showGrid,
     isLoading,
     skeletonCount,
-    skeletonHeight,
+    skeletonMinHeight,
     skeletonOrientation,
     skeletonThumbnailDisplay,
     skeletonThumbnailAlign,

--- a/lib/cards/useGridLoading.js
+++ b/lib/cards/useGridLoading.js
@@ -6,8 +6,8 @@ import { getBreakpointConfig } from './utils';
 // The skeleton loaders will be displayed after `LOADING_DELAY`
 // for a duration of `MIN_LOADING_TIME`
 // (https://www.nngroup.com/articles/skeleton-screens/)
-const LOADING_DELAY = 1000;
-const MIN_LOADING_TIME = 1000;
+const LOADING_DELAY = 300;
+const MIN_LOADING_TIME = 300;
 
 const DEFAULT_SKELETON = {
   count: undefined, // default determined by the grid layout and the current breakpoint

--- a/lib/cards/useGridLoading.js
+++ b/lib/cards/useGridLoading.js
@@ -15,6 +15,7 @@ const DEFAULT_SKELETON = {
   orientation: 'horizontal',
   thumbnailDisplay: 'none',
   thumbnailAlign: 'left',
+  thumbnailAspectRatio: undefined,
 };
 
 /**
@@ -29,6 +30,7 @@ export default function useGridLoading(props) {
   const skeletonOrientation = ref(DEFAULT_SKELETON.orientation);
   const skeletonThumbnailDisplay = ref(DEFAULT_SKELETON.thumbnailDisplay);
   const skeletonThumbnailAlign = ref(DEFAULT_SKELETON.thumbnailAlign);
+  const skeletonThumbnailAspectRatio = ref(DEFAULT_SKELETON.thumbnailAspectRatio);
 
   const isLoading = ref(false); // Used by `KCardGrid` to determine whether to display loading skeletons
   const finishedMounting = ref(false);
@@ -123,6 +125,9 @@ export default function useGridLoading(props) {
         if (breakpointSkeletonConfig.thumbnailAlign) {
           skeletonThumbnailAlign.value = breakpointSkeletonConfig.thumbnailAlign;
         }
+        if (breakpointSkeletonConfig.thumbnailAspectRatio) {
+          skeletonThumbnailAspectRatio.value = breakpointSkeletonConfig.thumbnailAspectRatio;
+        }
       }
     },
     { immediate: true, deep: true },
@@ -136,5 +141,6 @@ export default function useGridLoading(props) {
     skeletonOrientation,
     skeletonThumbnailDisplay,
     skeletonThumbnailAlign,
+    skeletonThumbnailAspectRatio,
   };
 }


### PR DESCRIPTION
## Description

Fixes or fine-tunes issues discovered during work on https://github.com/learningequality/studio/pull/5696.

### KImg
- Do not render `<img>` when `src` not provided
  - Fixes unexpected border around placeholder thumbnail area
  - Also fixes the problem described in https://github.com/learningequality/kolibri-design-system/pull/1201 

### KCard + KCardGrid

- Do not enforce fixed height of a thumbnail area when a custom thumbnail is provided via the `thumbnail` slot
  - A follow-up to https://github.com/learningequality/kolibri-design-system/pull/1194
  - Enforcing fixed height doesn't make sense when using the `thumbnail` slot and can cause problems, e.g. unexpected overflows and inability to achieve the correct aspect ratio set on `KImg`.

- Optimize skeleton loading times
  - To make card grid loading feel more swift
  - Chosen values based on agreement with design

- Don't set fixed height on loading skeletons and change `skeletonsConfig.height` to `skeletonsConfig.minHeight`
  - Fixes overflow problems when the chosen height was insufficient or inaccurate, e.g. when the thumbnail area needed more space
  - Instead, change the configuration option to setting just minimum height

- Add `skeletonsConfig.thumbnailAspectRatio` option for configuring aspect ratio of the thumbnail area in loading skeletons
  - A follow-up to https://github.com/learningequality/kolibri-design-system/pull/1194
  - Allows loading skeletons have accurate shape even when `thumbnail` slot + `KImg` with custom aspect ratio utilized

#### Issue addressed

In support of https://github.com/learningequality/studio/pull/5696

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Do not render `<img>` when `src` not provided
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** `KImg`
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

  - **Description:** Do not enforce fixed height of a thumbnail area when a custom thumbnail is provided via the `thumbnail` slot
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** `KCard`
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -
  
  - **Description:** Optimize skeleton loading times
  - **Products impact:** optimization
  - **Addresses:** -
  - **Components:** `KCard`, `KCardGrid`
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

  - **Description:** Don't set fixed height on loading skeletons and change `skeletonsConfig.height` to `skeletonsConfig.minHeight`
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** `KCard`, `KCardGrid`
  - **Breaking:** no (skeletonsConfig is not yet used in production)
  - **Impacts a11y:** no
  - **Guidance:**  Change `skeletonsConfig.height` to `skeletonsConfig.minHeight`
  
  - **Description:** Add `skeletonsConfig.thumbnailAspectRatio` option for configuring aspect ratio of the thumbnail area in loading skeletons
  - **Products impact:** new API
  - **Addresses:** -
  - **Components:** `KCard`, `KCardGrid`
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -
  
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

- The issues addressed above were visible only in the new Studio channel card use-case, so best to preview together with https://github.com/learningequality/studio/pull/5696.

- You may also preview updated KDS documentation
  - https://deploy-preview-1203--kolibri-design-system.netlify.app/kcardgrid#loading-state