### PR TITLE
Fix KSelect absent value check

### DIFF
--- a/lib/KSelect/index.vue
+++ b/lib/KSelect/index.vue
@@ -275,7 +275,7 @@
           if (Array.isArray(value)) {
             return value.every(item => item && typeof item === 'object' && 'value' in item);
           }
-          return value && typeof value === 'object' && 'value' in value;
+          return value && typeof value === 'object';
         },
       },
       /**


### PR DESCRIPTION
## Description

- Historically, the way we've had to represent that KSelect doesn't have any option selected is by passing an empty object as its `value`, right now the prop validator requires this `value` prop to have a `value` property defined, but it is not necessary when the KSelect doesn't have any value.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Fixes KSelect `value` prop validator forcing a `value` key to be defined.
  - **Products impact:** bugfix.
  - **Addresses:** -.
  - **Components:** KSelect.
  - **Breaking:** no
  - **Impacts a11y:**  no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

Create a `KSelect` with an empty value (i.e., `{}`) and check that no error appears in the console.
