### PR TITLE
Update grey v_50 to FAFAFA instead of FFFFFF in line with latest spec

### DIFF
--- a/lib/styles/colorsMaterial.js
+++ b/lib/styles/colorsMaterial.js
@@ -1,9 +1,8 @@
 const BLACK = '#000000';
-const WHITE = '#ffffff';
 
 export default {
   black: BLACK,
-  white: WHITE,
+  white: '#FFFFFF',
   red: {
     v_100: '#FFD9D3',
     v_200: '#FFB4A7',
@@ -69,7 +68,7 @@ export default {
     v_600: '#E5B700',
   },
   grey: {
-    v_50: WHITE,
+    v_50: '#FAFAFA',
     v_100: '#F5F5F5',
     v_200: '#E6E6E6',
     v_300: '#CCCCCC',


### PR DESCRIPTION
## Description
The most recent token updates were working with a spec that contained an error, where it set grey v50 to white instead of a very light grey. This fixes this.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Update grey v_50 to #FAFAFA
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** None
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** Bug fix to make grey v_50 actually grey

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Check the documentation colours page and check that v_50 is now not white