### PR TITLE
Add custom option slot to KDropdownMenu and update documentation

### DIFF
--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -263,13 +263,13 @@
           <!-- prettier-ignore -->
           <DocsShowCode language="javascript">
               export default {
-                computed: {
-                  options() {
-                    return [
+                data() {
+                  return {
+                    options: [
                       { label: 'Edit', value: 'edit', icon: 'edit', color: null },
                       { label: 'Delete', value: 'delete', icon: 'delete', color: this.$themeTokens.error },
-                    ];
-                  },
+                    ],
+                  };
                 },
               };
             </DocsShowCode>

--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -244,12 +244,14 @@
                   ...
                 >
                   <template #option="{ option }">
-                    <KLabeledIcon
-                      :icon="option.icon"
-                      :label="option.label"
-                      :color="option.color"
-                      :style="{ color: option.color }"
-                    />
+                    <div style="display: flex; align-items: center; padding: 0 16px">
+                      <KLabeledIcon
+                        :icon="option.icon"
+                        :label="option.label"
+                        :color="option.color"
+                        :style="{ color: option.color }"
+                      />
+                    </div>
                   </template>
                 </KDropdownMenu>
               </template>

--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -228,6 +228,7 @@
         loadExample="KDropdownMenu/CustomOption.vue"
         exampleId="custom-option-slot"
         block
+        :hideOnClick="true"
         :openOnMount="false"
       >
         <template #html>
@@ -243,13 +244,12 @@
                   ...
                 >
                   <template #option="{ option }">
-                    <div style="display: flex; align-items: center; padding: 0 16px">
-                      <KIcon
-                        :icon="option.icon"
-                        :style="{ color: option.color, marginInlineEnd: '8px' }"
-                      />
-                      <span :style="{ color: option.color }">{{ option.label }}</span>
-                    </div>
+                    <KLabeledIcon
+                      :icon="option.icon"
+                      :label="option.label"
+                      :color="option.color"
+                      :style="{ color: option.color }"
+                    />
                   </template>
                 </KDropdownMenu>
               </template>

--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -25,6 +25,7 @@
           { text: 'Icon button with dropdown', href: '#icon-button-with-dropdown' },
           { text: 'Options with icons', href: '#options-with-icons' },
           { text: 'Context menu', href: '#context-menu' },
+          { text: 'Custom option slot', href: '#custom-option-slot' },
         ]"
       />
 
@@ -211,6 +212,23 @@
         loadExample="KDropdownMenu/ContextMenu.vue"
         exampleId="context-menu"
         block
+      />
+
+      <h3>
+        Custom option slot
+        <DocsAnchorTarget anchor="#custom-option-slot" />
+      </h3>
+
+      <p>
+        Use the <code>#option</code> scoped slot to customize the rendering of each menu item. The
+        slot receives <code>{ option }</code> — the option object — as a slot prop.
+      </p>
+
+      <DocsExample
+        loadExample="KDropdownMenu/CustomOption.vue"
+        exampleId="custom-option-slot"
+        block
+        :openOnMount="false"
       />
     </DocsPageSection>
   </DocsPageTemplate>

--- a/docs/pages/kdropdownmenu.vue
+++ b/docs/pages/kdropdownmenu.vue
@@ -220,8 +220,8 @@
       </h3>
 
       <p>
-        Use the <code>#option</code> scoped slot to customize the rendering of each menu item. The
-        slot receives <code>{ option }</code> — the option object — as a slot prop.
+        Use the <code>#option</code> scoped slot to customize each menu item. The slot provides the
+        option object via the <code>option</code> prop.
       </p>
 
       <DocsExample
@@ -229,7 +229,53 @@
         exampleId="custom-option-slot"
         block
         :openOnMount="false"
-      />
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KButton
+              text="Options"
+              hasDropdown
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :options="options"
+                  ...
+                >
+                  <template #option="{ option }">
+                    <div style="display: flex; align-items: center; padding: 0 16px">
+                      <KIcon
+                        :icon="option.icon"
+                        :style="{ color: option.color, marginInlineEnd: '8px' }"
+                      />
+                      <span :style="{ color: option.color }">{{ option.label }}</span>
+                    </div>
+                  </template>
+                </KDropdownMenu>
+              </template>
+            </KButton>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+
+        <template #javascript>
+          <!-- eslint-disable -->
+          <!-- prettier-ignore -->
+          <DocsShowCode language="javascript">
+              export default {
+                computed: {
+                  options() {
+                    return [
+                      { label: 'Edit', value: 'edit', icon: 'edit', color: null },
+                      { label: 'Delete', value: 'delete', icon: 'delete', color: this.$themeTokens.error },
+                    ];
+                  },
+                },
+              };
+            </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
     </DocsPageSection>
   </DocsPageTemplate>
 

--- a/examples/KDropdownMenu/CustomOption.vue
+++ b/examples/KDropdownMenu/CustomOption.vue
@@ -1,0 +1,70 @@
+<template>
+
+  <KButton
+    text="Options"
+    hasDropdown
+  >
+    <template #menu>
+      <KDropdownMenu
+        :hideOnClick="hideOnClick"
+        :constrainToScrollParent="constrainToScrollParent"
+        :options="options"
+        @select="onOptionSelect"
+      >
+        <template #option="{ option }">
+          <div style="display: flex; align-items: center; height: 40px; padding: 0 16px">
+            <KIcon
+              :icon="option.icon"
+              :style="{ color: option.color, marginInlineEnd: '8px' }"
+            />
+            <span :style="{ color: option.color }">{{ option.label }}</span>
+          </div>
+        </template>
+      </KDropdownMenu>
+    </template>
+  </KButton>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'CustomOption',
+    props: {
+      openOnMount: {
+        type: Boolean,
+        default: true,
+      },
+      hideOnClick: {
+        type: Boolean,
+        default: false,
+      },
+      constrainToScrollParent: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    data() {
+      return {
+        options: [
+          { label: 'Edit', value: 'edit', icon: 'edit', color: null },
+          { label: 'Delete', value: 'delete', icon: 'delete', color: '#e74c3c' },
+        ],
+      };
+    },
+    mounted() {
+      if (this.openOnMount) {
+        this.$nextTick(() => {
+          this.$el.click();
+        });
+      }
+    },
+    methods: {
+      onOptionSelect(option) {
+        console.log('Selected option:', option);
+      },
+    },
+  };
+
+</script>

--- a/examples/KDropdownMenu/CustomOption.vue
+++ b/examples/KDropdownMenu/CustomOption.vue
@@ -12,7 +12,7 @@
         @select="onOptionSelect"
       >
         <template #option="{ option }">
-          <div style="display: flex; align-items: center; height: 40px; padding: 0 16px">
+          <div style="display: flex; align-items: center; padding: 0 16px">
             <KIcon
               :icon="option.icon"
               :style="{ color: option.color, marginInlineEnd: '8px' }"
@@ -45,13 +45,13 @@
         default: false,
       },
     },
-    data() {
-      return {
-        options: [
+    computed: {
+      options() {
+        return [
           { label: 'Edit', value: 'edit', icon: 'edit', color: null },
-          { label: 'Delete', value: 'delete', icon: 'delete', color: '#e74c3c' },
-        ],
-      };
+          { label: 'Delete', value: 'delete', icon: 'delete', color: this.$themeTokens.error },
+        ];
+      },
     },
     mounted() {
       if (this.openOnMount) {

--- a/examples/KDropdownMenu/CustomOption.vue
+++ b/examples/KDropdownMenu/CustomOption.vue
@@ -12,12 +12,14 @@
         @select="onOptionSelect"
       >
         <template #option="{ option }">
-          <KLabeledIcon
-            :icon="option.icon"
-            :label="option.label"
-            :color="option.color"
-            :style="{ color: option.color }"
-          />
+          <div style="display: flex; align-items: center; padding: 0 16px">
+            <KLabeledIcon
+              :icon="option.icon"
+              :label="option.label"
+              :color="option.color"
+              :style="{ color: option.color }"
+            />
+          </div>
         </template>
       </KDropdownMenu>
     </template>

--- a/examples/KDropdownMenu/CustomOption.vue
+++ b/examples/KDropdownMenu/CustomOption.vue
@@ -12,13 +12,12 @@
         @select="onOptionSelect"
       >
         <template #option="{ option }">
-          <div style="display: flex; align-items: center; padding: 0 16px">
-            <KIcon
-              :icon="option.icon"
-              :style="{ color: option.color, marginInlineEnd: '8px' }"
-            />
-            <span :style="{ color: option.color }">{{ option.label }}</span>
-          </div>
+          <KLabeledIcon
+            :icon="option.icon"
+            :label="option.label"
+            :color="option.color"
+            :style="{ color: option.color }"
+          />
         </template>
       </KDropdownMenu>
     </template>

--- a/lib/KDropdownMenu/__tests__/components/KDropdownMenuVisualTest.vue
+++ b/lib/KDropdownMenu/__tests__/components/KDropdownMenuVisualTest.vue
@@ -37,6 +37,12 @@
       width="200px"
       height="125px"
     />
+    <VisualTestExample
+      title="Custom option slot"
+      loadExample="KDropdownMenu/CustomOption.vue"
+      width="200px"
+      height="200px"
+    />
   </VisualTestLayout>
 
 </template>

--- a/lib/KDropdownMenu/index.vue
+++ b/lib/KDropdownMenu/index.vue
@@ -24,7 +24,15 @@
         :hasIcons="hasIcons"
         :maxWidth="maxWidth"
         @select="handleSelection"
-      />
+      >
+        <template #option="{ option }">
+          <!-- @slot Optional slot to customize the rendering of each menu option -->
+          <slot
+            name="option"
+            :option="option"
+          ></slot>
+        </template>
+      </UiMenu>
     </UiPopover>
   </div>
 

--- a/lib/keen/UiMenuOption.vue
+++ b/lib/keen/UiMenuOption.vue
@@ -119,6 +119,8 @@
     }
 
     &:not(.is-divider) {
+      display: flex;
+      flex-direction: column;
       min-height: rem(40px);
       font-size: $ui-dropdown-item-font-size;
       font-weight: normal;
@@ -145,6 +147,10 @@
         .ui-menu-option-secondary-text {
           color: $secondary-text-color;
         }
+      }
+
+      & > * {
+        flex-grow: 1;
       }
     }
   }


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
Exposes UiMenu's existing option scoped slot through KDropdownMenu, allowing consumers to customize the rendering of each menu item.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1200

### Before/after screenshots
<!-- Insert images here if applicable -->
<img width="1255" height="854" alt="Screenshot 2026-02-23 at 4 18 38 AM" src="https://github.com/user-attachments/assets/2f3ab22a-d2ec-4202-b9ef-1ff676aefb01" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:**  New option scoped slot on KDropdownMenu. Use <template #option="{ option }"> to customize how each menu item renders (icon placement, color, text size, etc.).
  - **Products impact:** new API
  - **Addresses:** learningequality/kolibri-design-system#1200.
  - **Components:** KDropdownMenu
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:**Use #option when the options array config isn't sufficient. Existing behavior is unchanged when the slot is not used.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. yarn dev → go to KDropdownMenu docs page
2. Verify the new "Custom option slot" section appears with a working live example
3. Verify the API Slots table lists both header and option
4. Verify all existing examples still work (no regressions)
5. yarn test and yarn lint — both pass

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?

