### PR TITLE
Align loading states and documentation to the latest design guidance

### DIFF
--- a/docs/pages/kcardgrid.vue
+++ b/docs/pages/kcardgrid.vue
@@ -592,15 +592,13 @@
       </h3>
 
       <p>
-        While data is loading, <code>KCardGrid</code> shows loading skeleton cards. Use the
-        <code>loading</code> prop to toggle the state. Note that <code>KCardGrid</code> internal
-        optimizations may affect how closely the visual loading experience matches the
-        <code>loading</code> value:
+        While data is loading, <code>KCardGrid</code> shows loading skeleton cards.Loading
+        experience is internally already optimized according to our
+        <DocsInternalLink
+          href="/loaders"
+          text="loading guidance"
+        />. Simply use the <code>loading</code> prop to toggle the loading state.
       </p>
-      <ul>
-        <li>The loading skeletons won't be displayed for short loading times (&lt; 300ms)</li>
-        <li>When the loading skeletons are displayed, they will be visible for at least 300ms</li>
-      </ul>
 
       <h4>Loading skeletons configuration</h4>
 

--- a/docs/pages/kcircularloader.vue
+++ b/docs/pages/kcircularloader.vue
@@ -6,59 +6,59 @@
       anchor="#overview"
     >
       <p>Circular loaders illustrate progress by moving an indicator along a circular track.</p>
-      <DocsShow>
-        <KCircularLoader style="margin: 24px" />
-      </DocsShow>
 
-      See the
-      <DocsInternalLink
-        href="/loaders"
-        text="loaders page"
-      />
-      for more information.
+      <p>
+        See the
+        <DocsInternalLink
+          href="/loaders"
+          text="loaders page"
+        />
+        for more information and guidelines.
+      </p>
     </DocsPageSection>
 
     <DocsPageSection
-      title="Specifications"
-      anchor="#specifications"
+      title="Usage"
+      anchor="#usage"
     >
-      <ul>
-        <li>Dimensions do not exceed 48x48px</li>
-        <li>Progress indicator uses palette.grey.v_800</li>
-        <li>Track width is 4px</li>
-      </ul>
-    </DocsPageSection>
+      <section>
+        <h3>
+          Determinate
+          <DocsAnchorTarget anchor="#determinate" />
+        </h3>
 
-    <DocsPageSection
-      title="Placement"
-      anchor="#placement"
-    >
-      <ul>
-        <li>When loading new content, center the loader</li>
-        <li>The loader can routinely appear and disappear when indicating a background task</li>
-        <li>
-          Do not break the flow of information or content by placing between items (e.g. list items,
-          content cards, table rows)
-        </li>
-      </ul>
-    </DocsPageSection>
+        <DocsExample
+          loadExample="KCircularLoader/Determinate.vue"
+          exampleId="kcircularloader-determinate"
+        >
+          <template #html>
+            <DocsShowCode language="html">
+              <KCircularLoader
+                type="determinate"
+                :progress="75"
+              />
+            </DocsShowCode>
+          </template>
+        </DocsExample>
+      </section>
 
-    <DocsPageSection
-      title="Related"
-      anchor="#related"
-    >
-      <ul>
-        <li>
-          <code>KCircularLoader</code>'s <code>minVisibleTime</code> isn't sufficient when switching
-          between more components, for example as part of <code>v-if/v-else</code> blocks. In such
-          situations,
-          <DocsInternalLink
-            text="useKShow"
-            href="/usekshow"
-          />
-          may come handy.
-        </li>
-      </ul>
+      <section>
+        <h3>
+          Indeterminate
+          <DocsAnchorTarget anchor="#indeterminate" />
+        </h3>
+
+        <DocsExample
+          loadExample="KCircularLoader/Indeterminate.vue"
+          exampleId="kcircularloader-indeterminate"
+        >
+          <template #html>
+            <DocsShowCode language="html">
+              <KCircularLoader type="indeterminate" />
+            </DocsShowCode>
+          </template>
+        </DocsExample>
+      </section>
     </DocsPageSection>
   </DocsPageTemplate>
 

--- a/docs/pages/klinearloader.vue
+++ b/docs/pages/klinearloader.vue
@@ -5,69 +5,60 @@
       title="Overview"
       anchor="#overview"
     >
+      <p>Linear loaders illustrate progress by moving an indicator along a horizontal track.</p>
+
       <p>
-        Linear loaders illustrate progress by moving an indicator along a horizontal track. There
-        are two types of linear loaders:
+        See the
+        <DocsInternalLink
+          href="/loaders"
+          text="loaders page"
+        />
+        for more information and guidelines.
       </p>
-
-      <ul>
-        <li>
-          Determinate: these loaders show a visual indicator of detectable and measurable progress
-          percentage
-        </li>
-        <DocsShow>
-          <KLinearLoader
-            :progress="75"
-            type="determinate"
-            class="loader"
-            style="width: 400px; margin: 24px"
-          />
-        </DocsShow>
-        <li>
-          Indeterminate: these loaders show an ongoing process with an unspecified or undetectable
-          percentage completion
-        </li>
-        <DocsShow>
-          <KLinearLoader
-            :progress="75"
-            type="indeterminate"
-            class="loader"
-            style="width: 400px; margin: 24px"
-          />
-        </DocsShow>
-      </ul>
-
-      See the
-      <DocsInternalLink
-        href="/loaders"
-        text="loaders page"
-      />
-      for more information.
     </DocsPageSection>
 
     <DocsPageSection
-      title="Specifications"
-      anchor="#specifications"
+      title="Usage"
+      anchor="#usage"
     >
-      <ul>
-        <li>Progress track uses palette.grey.v_200</li>
-        <li>Progress indicator uses palette.grey.v_800</li>
-        <li>Progress track height is 4px</li>
-        <li>Include a 2px corner radius</li>
-        <li>
-          Remove the corner radius when appended to other components, such as appbars or data tables
-        </li>
-      </ul>
-    </DocsPageSection>
+      <section>
+        <h3>
+          Determinate
+          <DocsAnchorTarget anchor="#determinate" />
+        </h3>
 
-    <DocsPageSection
-      title="Placement"
-      anchor="#placement"
-    >
-      <ul>
-        <li>Can be attached to existing components such as appbars or table rows</li>
-        <li>As a progress bar, should be near task-related metadata</li>
-      </ul>
+        <DocsExample
+          loadExample="KLinearLoader/Determinate.vue"
+          exampleId="klinearloader-determinate"
+        >
+          <template #html>
+            <DocsShowCode language="html">
+              <KLinearLoader
+                type="determinate"
+                :progress="75"
+              />
+            </DocsShowCode>
+          </template>
+        </DocsExample>
+      </section>
+
+      <section>
+        <h3>
+          Indeterminate
+          <DocsAnchorTarget anchor="#indeterminate" />
+        </h3>
+
+        <DocsExample
+          loadExample="KLinearLoader/Indeterminate.vue"
+          exampleId="klinearloader-indeterminate"
+        >
+          <template #html>
+            <DocsShowCode language="html">
+              <KLinearLoader type="indeterminate" />
+            </DocsShowCode>
+          </template>
+        </DocsExample>
+      </section>
     </DocsPageSection>
   </DocsPageTemplate>
 

--- a/docs/pages/loaders/index.vue
+++ b/docs/pages/loaders/index.vue
@@ -6,98 +6,265 @@
       anchor="#overview"
     >
       <p>
-        Loading indicators are used to convey to the user that they will need to wait some time for
-        a software- or hardware-related operation to complete. They can be used to convey a range of
-        ongoing processes, including network, disk and CPU operations.
-      </p>
-      <p>
-        Generally, loading indicators should be used if the wait period is longer than a second.
+        Loading state is used to convey the need to wait some time for a software- or
+        hardware-related operation to complete. They can be used for a range of ongoing processes,
+        including network, disk and CPU operations.
       </p>
     </DocsPageSection>
 
     <DocsPageSection
-      title="Using linear loaders"
-      anchor="#linearloaders"
+      title="Guidelines"
+      anchor="#guidelines"
     >
+      <ul>
+        <li><strong>Apply 300ms delay</strong> before showing loading state</li>
+        <li>
+          Guarantee that loading state will be <strong>visible for at least 400ms</strong> once
+          shown
+        </li>
+        <li>
+          For card grids, utilize
+          <DocsInternalLink
+            href="/kcardgrid#loading-state"
+            text="loading skeletons"
+          />
+        </li>
+        <li>In other cases, use circular or linear loader according to the usages below</li>
+        <li>
+          When switching between a loading indicator and another component via
+          <code>v-if/v-else</code>, utilize
+          <DocsInternalLink
+            href="/usekshow#example"
+            text="useKShow with KTransition"
+          />
+        </li>
+      </ul>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Delay"
+      anchor="#delay"
+    >
+      <p>
+        Displaying loading state for fast operations can cause visual disruption resulting in worse
+        experience than showing nothing at all. To avoid this, wait 300ms before showing a loading
+        indicator.
+      </p>
+
+      <p>
+        <code>KCardGrid</code>'s loading skeletons already have this behavior implemented by
+        default. <code>KCircularLoader</code> and <code>KLinearLoader</code> provide the
+        <code>delay</code> prop.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Minimum visible time"
+      anchor="#minimum-visible-time"
+    >
+      <p>
+        After a loading indicator appears, it should remain visible for at least 400ms before being
+        replaced by content to prevent a brief flash of loading state causing a jarring visual
+        experience.
+      </p>
+
+      <p>
+        <code>KCardGrid</code>'s loading skeletons already have this behavior implemented by
+        default. <code>KCircularLoader</code> provides a <code>minimumVisibleTime</code> prop.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Linear loaders"
+      anchor="#linear-loaders"
+    >
+      <p>
+        Linear loaders illustrate progress by moving an indicator along a horizontal track. There
+        are two types of linear loaders:
+      </p>
+
+      <ul>
+        <li>
+          Determinate: these loaders show a visual indicator of detectable and measurable progress
+          percentage
+        </li>
+        <DocsShow>
+          <KLinearLoader
+            :progress="75"
+            type="determinate"
+            class="loader"
+            style="width: 400px; margin: 24px"
+          />
+        </DocsShow>
+        <li>
+          Indeterminate: these loaders show an ongoing process with an unspecified or undetectable
+          percentage completion
+        </li>
+        <DocsShow>
+          <KLinearLoader
+            :progress="75"
+            type="indeterminate"
+            class="loader"
+            style="width: 400px; margin: 24px"
+          />
+        </DocsShow>
+      </ul>
+
+      <p>Use <DocsLibraryLink component="KLinearLoader" />.</p>
+
+      <h3>Usages</h3>
+
       <p>Use linear loaders for the following:</p>
+
       <ul>
         <li>Loading initial page content</li>
         <li>Representing the progress of a measurable task</li>
       </ul>
-    </DocsPageSection>
 
-    <DocsDoNot>
-      <template #do>
-        <img
-          src="../loaders/topbar.png"
-          style="max-width: 400px"
-        >
-        <p>Append linear loaders to appbars to load page content</p>
-      </template>
-    </DocsDoNot>
+      <DocsDoNot>
+        <template #do>
+          <img
+            src="../loaders/topbar.png"
+            style="max-width: 400px"
+          >
+          <p>Append linear loaders to appbars to load page content</p>
+        </template>
+      </DocsDoNot>
 
-    <DocsDoNot>
-      <template #do>
-        <img
-          src="../loaders/tasks.png"
-          style="max-width: 400px"
-        >
-        <p>Place linear loaders near information related to the task being measured</p>
-      </template>
-    </DocsDoNot>
+      <DocsDoNot>
+        <template #do>
+          <img
+            src="../loaders/tasks.png"
+            style="max-width: 400px"
+          >
+          <p>Place linear loaders near information related to the task being measured</p>
+        </template>
+      </DocsDoNot>
 
-    <DocsDoNot>
-      <template #do>
-        <img
-          src="../loaders/tables.png"
-          style="max-width: 400px"
-        >
-        <p>Append linear loaders to data tables</p>
-      </template>
-    </DocsDoNot>
+      <DocsDoNot>
+        <template #do>
+          <img
+            src="../loaders/tables.png"
+            style="max-width: 400px"
+          >
+          <p>Append linear loaders to data tables</p>
+        </template>
+      </DocsDoNot>
 
-    <DocsPageSection
-      title="Using circular loaders"
-      anchor="#circularloaders"
-    >
-      <p>Use circular loaders for the following:</p>
+      <h3>Specification</h3>
       <ul>
-        <li>Loading learning content renderers</li>
-        <li>Indicating the presence of a working background task</li>
-        <li>Loading a set of new information</li>
-        <li>Pull-to-refresh behaviors on mobile</li>
+        <li>
+          Track color:
+          <DocsInternalLink
+            text="palette.grey.v_200"
+            code
+            href="/colors#palette-grey-v_200"
+          />
+        </li>
+        <li>
+          Indicator color:
+          <DocsInternalLink
+            text="tokens.loading"
+            code
+            href="/colors#tokens-loading"
+          />
+        </li>
+        <li>Height: <code>4px</code></li>
+        <li>
+          Corner radius: <code>2px</code>. Remove the corner radius when appended to other
+          components, such as appbars or data tables.
+        </li>
       </ul>
     </DocsPageSection>
 
-    <DocsDoNot>
-      <template #do>
-        <img
-          src="../loaders/loading-more.png"
-          style="max-width: 400px"
-        >
-        <p>Place below existing content to indicate where new content appears</p>
-      </template>
-    </DocsDoNot>
+    <DocsPageSection
+      title="Circular loaders"
+      anchor="#circular-loaders"
+    >
+      <DocsShow>
+        <KCircularLoader style="margin: 24px" />
+      </DocsShow>
+      <p>Circular loaders illustrate progress by moving an indicator along a circular track.</p>
 
-    <DocsDoNot>
-      <template #do>
-        <img
-          src="../loaders/centering.png"
-          style="max-width: 400px"
-        >
-        <p>Center circular loaders when loading new information</p>
-      </template>
-    </DocsDoNot>
+      <p>Use <DocsLibraryLink component="KCircularLoader" />.</p>
+
+      <h3>Usages</h3>
+
+      <p>Use circular loaders for the following:</p>
+
+      <ul>
+        <li>Loading learning content renderers</li>
+        <li>
+          Indicating the presence of a working background task (can routinely appear and disappear)
+        </li>
+        <li>Loading a set of new information</li>
+        <li>Pull-to-refresh behaviors on mobile</li>
+      </ul>
+
+      <DocsDoNot>
+        <template #do>
+          <img
+            src="../loaders/loading-more.png"
+            style="max-width: 400px"
+          >
+          <p>Place below existing content to indicate where new content appears</p>
+        </template>
+      </DocsDoNot>
+
+      <DocsDoNot>
+        <template #do>
+          <img
+            src="../loaders/centering.png"
+            style="max-width: 400px"
+          >
+          <p>Center circular loaders when loading new information</p>
+        </template>
+      </DocsDoNot>
+
+      <DocsDoNot>
+        <template #not>
+          <p>
+            Do not break the flow of information or content by placing between items (e.g. list
+            items, content cards, table rows)
+          </p>
+        </template>
+      </DocsDoNot>
+
+      <h3>Specification</h3>
+      <ul>
+        <li>
+          Indicator color:
+          <DocsInternalLink
+            text="tokens.loading"
+            code
+            href="/colors#tokens-loading"
+          />
+        </li>
+        <li>Dimensions do not exceed 48x48px</li>
+        <li>Width: <code>4px</code></li>
+      </ul>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Related"
+      anchor="#related"
+    >
+      <ul>
+        <li><DocsLibraryLink component="KCircularLoader" /> is a circular loader</li>
+        <li><DocsLibraryLink component="KLinearLoader" /> is a linear loader</li>
+        <li>
+          <DocsLibraryLink component="useKShow" /> manages the display of loading indicators and
+          content when switching via <code>v-if/v-else</code>
+        </li>
+        <li>
+          <code>KCardGrid</code> provides
+          <DocsInternalLink
+            href="/kcardgrid#loading-state"
+            text="loading skeletons"
+          />
+        </li>
+      </ul>
+    </DocsPageSection>
   </DocsPageTemplate>
 
 </template>
-
-
-<script>
-
-  export default {};
-
-</script>
-
-
-<style lang="scss" scoped></style>

--- a/docs/pages/usekshow.vue
+++ b/docs/pages/usekshow.vue
@@ -6,11 +6,22 @@
       anchor="#overview"
     >
       <p>
-        A composable that offers the <code>show</code> reactive function. This function guarantees
-        that something will be displayed at least for a specified duration after an initial trigger.
-        This is typically used to prevent a jarring user experience when showing or hiding certain
-        elements. For example, it can be used to ensure that a loader remains visible for a certain
-        amount of time, even when the related data has already been loaded.
+        A composable that offers the <code>show</code> reactive function which guarantees that
+        something will be displayed at least for a specified duration after an initial trigger. It
+        is typically used to guarantee
+        <DocsInternalLink href="/loaders#minimum-visible-time">
+          minimum visible time
+        </DocsInternalLink>
+        behavior of loading state.
+      </p>
+
+      <p>
+        See the
+        <DocsInternalLink
+          href="/loaders"
+          text="loaders page"
+        />
+        for more information and guidelines.
       </p>
     </DocsPageSection>
 
@@ -128,21 +139,6 @@
     </DocsPageSection>
 
     <DocsPageSection
-      title="Related"
-      anchor="#related"
-    >
-      <ul>
-        <li>
-          Some components offer a simpler interfance to achieve the same effect when there is no
-          need to be switching between more components. For example, see
-          <DocsInternalLink href="/kcircularloader#prop:minVisibleTime">
-            KCircularLoader's <code>minVisibleTime</code>
-          </DocsInternalLink>.
-        </li>
-      </ul>
-    </DocsPageSection>
-
-    <DocsPageSection
       title="Parameters"
       anchor="#parameters"
     >
@@ -183,11 +179,11 @@
       let timeoutId;
       const isFetching = ref(false);
 
-      const minVisibleTime = ref(5000);
-      const minVisibleTimeInput = ref(5000);
+      const minVisibleTime = ref(400);
+      const minVisibleTimeInput = ref(400);
 
-      const fetchingTime = ref(1000);
-      const fetchingTimeInput = ref(1000);
+      const fetchingTime = ref(100);
+      const fetchingTimeInput = ref(100);
 
       function fetchData() {
         clearTimeout(timeoutId);
@@ -234,7 +230,8 @@
             required: false,
             default: 0,
             type: { name: 'number' },
-            description: 'For how long should `show` return `true` after an initial trigger',
+            description:
+              'For how long should `show` return `true` after an initial trigger. Recommended value for loaders is `400ms`.',
           },
         ],
       };

--- a/examples/KCircularLoader/Determinate.vue
+++ b/examples/KCircularLoader/Determinate.vue
@@ -1,0 +1,10 @@
+<template>
+
+  <div style="padding: 24px">
+    <KCircularLoader
+      type="determinate"
+      :progress="75"
+    />
+  </div>
+
+</template>

--- a/examples/KCircularLoader/Indeterminate.vue
+++ b/examples/KCircularLoader/Indeterminate.vue
@@ -1,0 +1,7 @@
+<template>
+
+  <div style="padding: 24px">
+    <KCircularLoader type="indeterminate" />
+  </div>
+
+</template>

--- a/examples/KLinearLoader/Determinate.vue
+++ b/examples/KLinearLoader/Determinate.vue
@@ -1,0 +1,10 @@
+<template>
+
+  <div style="width: 400px; padding: 24px 0">
+    <KLinearLoader
+      type="determinate"
+      :progress="75"
+    />
+  </div>
+
+</template>

--- a/examples/KLinearLoader/Indeterminate.vue
+++ b/examples/KLinearLoader/Indeterminate.vue
@@ -1,0 +1,7 @@
+<template>
+
+  <div style="width: 400px; padding: 24px 0">
+    <KLinearLoader type="indeterminate" />
+  </div>
+
+</template>

--- a/lib/cards/useGridLoading.js
+++ b/lib/cards/useGridLoading.js
@@ -5,9 +5,9 @@ import { getBreakpointConfig } from './utils';
 
 // The skeleton loaders will be displayed after `LOADING_DELAY`
 // for a duration of `MIN_LOADING_TIME`
-// (https://www.nngroup.com/articles/skeleton-screens/)
+// https://design-system.learningequality.org/loaders
 const LOADING_DELAY = 300;
-const MIN_LOADING_TIME = 300;
+const MIN_LOADING_TIME = 400;
 
 const DEFAULT_SKELETON = {
   count: undefined, // default determined by the grid layout and the current breakpoint

--- a/lib/loaders/KCircularLoader.vue
+++ b/lib/loaders/KCircularLoader.vue
@@ -110,19 +110,19 @@
         default: 0,
       },
       /**
-       * Whether there should be a delay before the loader displays.
-       * Useful if the action often takes less than a second or two.
+       * Apply 300ms delay before showing loading state.
+       * Recommended in majority of cases.
        */
       delay: {
         type: Boolean,
         default: false,
       },
       /**
-       * Do not hide the loader until `minVisibleTime` in milliseconds.
-       * Useful to avoid jarring UX when the actions finishes very fast.
-       * In comparison to `delay`, `minVisibleTime` emphasizes that an
-       * action associated with the loader is indeed taking place.
-       * `shouldShow` prop needs to be used instead of `v-if/v-show` for this to work.
+       * Guarantee that loading state will be visible for at least this
+       * value in milliseconds once shown. Recommended in majority of cases.
+       * Recommended value `400ms`.
+       * `shouldShow` prop needs to be used instead of `v-if/v-show`
+       * for this to work.
        */
       minVisibleTime: {
         type: Number,
@@ -215,7 +215,7 @@
   @import '../keen/styles/imports';
 
   .delay {
-    animation-delay: 1s;
+    animation-delay: 300ms;
   }
 
   @keyframes fade-in {

--- a/lib/loaders/KLinearLoader.vue
+++ b/lib/loaders/KLinearLoader.vue
@@ -68,8 +68,8 @@
         default: 0,
       },
       /**
-       * Whether there should be a delay before the loader displays.
-       * Useful if the action often takes less than a second or two.
+       * Apply `300ms` delay before showing loading state.
+       * Recommended in majority of cases.
        */
       delay: {
         type: Boolean,
@@ -105,7 +105,7 @@
   @import '../styles/definitions';
 
   .delay {
-    animation-delay: 1s;
+    animation-delay: 300ms;
   }
 
   @keyframes fade-in {


### PR DESCRIPTION
## Description

**Documentation**

- Updates the _Loaders_ documentation page to the latest design guidance (especially delay and minimum visible time values)
- Centralizes general guidance on the _Loaders_ page, while leaving component pages to focus only on Vue-specific usage. Removes duplicate or obsolete sections from other pages related to loading states. 
- Few smaller improvements on pages related to loading states

**User experience**

- Align minimum visible time value for card skeleton loader with the guidance
- Align `KCircularLoader` and `KLinearLoader` delay value with the guidance (change from 1s delay to 300ms delay)
  - Since we very rarely use truthy `delay` ([search results](https://github.com/search?q=org%3Alearningequality+%2FK%28Linear%7CCircular%29Loader%2F+%2F%3Adelay%3D%2F&type=code&p=1)), likely due to 1s being to long, impact will be minimal. I only see 3 places ([here](https://github.com/learningequality/kolibri/blob/f4b587e109a3985adcf7468ac5afead55919d58a/kolibri/plugins/device/frontend/views/ManageContentPage/TaskProgress.vue#L11), [here](https://github.com/learningequality/kolibri/blob/f4b587e109a3985adcf7468ac5afead55919d58a/kolibri/plugins/media_player/frontend/views/MediaPlayerIndex.vue#L31), and [here](https://github.com/learningequality/kolibri/blob/f4b587e109a3985adcf7468ac5afead55919d58a/kolibri/plugins/media_player/frontend/views/MediaPlayerTranscript/index.vue#L18)) that have truthy value.

#### Issue addressed

Based on past conversations with designers & recent fine-tuning loading state with Tomiwa during work on Studio. While delay and minimum visible time values may change, we've at least arrived to values that felt good enough as a universal guidance for majority of our use-cases.

However it only addresses KDS side. The idea is for future or refactored features to follow this guidance. To align all previously existing places fully, we'd need to make further updates in Kolibri. 

## Changelog

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Align minimum visible time value for card skeleton loader with the design guidance
  - **Products impact:** ux
  - **Addresses:** -
  - **Components:** `KCardGrid`, `KCard`
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

  - **Description:** Align `delay` value for `KCircularLoader` and `KLinearLoader` with the design guidance
  - **Products impact:** ux
  - **Addresses:** -
  - **Components:** `KCircularLoader`, `KLinearLoader` 
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

  - **Description:** Updates the _Loaders_ documentation page to the latest design guidance. Centralizes general guidance on the _Loaders_ page, while leaving component pages to focus only on Vue-specific usage. Removes duplicate or obsolete sections from other pages related to loading states. 
  - **Products impact:** documentation
  - **Addresses:** -
  - **Components:**  Loaders page, `KCircularLoader`, `KLinearLoader` , `useKShow`,  `KCardGrid`, `KCard`
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

Preview affected places at the following pages:
- https://deploy-preview-1218--kolibri-design-system.netlify.app/loaders
- https://deploy-preview-1218--kolibri-design-system.netlify.app/kcircularloader
- https://deploy-preview-1218--kolibri-design-system.netlify.app/klinearloader
- https://deploy-preview-1218--kolibri-design-system.netlify.app/usekshow
- https://deploy-preview-1218--kolibri-design-system.netlify.app/kcardgrid/#loading-state