### PR TITLE
Wrap `iconAfter` slot in same `span.icon-container` on `icon` slot

### DIFF
--- a/lib/buttons-and-links/KButton.vue
+++ b/lib/buttons-and-links/KButton.vue
@@ -32,7 +32,10 @@
     </template>
 
     <!-- @slot Slot alternative to the `iconAfter` prop -->
-    <slot name="iconAfter"></slot>
+    <span class="icon-container">
+      <slot name="iconAfter"></slot>
+    </span>
+
     <KIcon
       v-if="iconAfter"
       :icon="iconAfter"


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->

I found while trying to setup some `[<- Prev] [Next ->]` type buttons that only the `icon` slot had a wrapping span w/ a class that sets a `top` value and `relative` position but the `iconAfter` does not have it. This meant that I'd need to have two separate classes with two separate values to align the icons but fixing this makes that easier and makes KButton more consistent.

### (Possibly) Breaking changes in Kolibri 

Here is everywhere I found that uses the `#iconAfter` prop - some definitely have applied styles to address the problem that this PR fixes and would likely be able to be simplified quite a bit.

- https://github.com/learningequality/kolibri/blob/release-v0.19.x/kolibri/plugins/device/frontend/views/SelectContentPage/ChannelContentsSummary.vue#L21
- https://github.com/learningequality/kolibri/blob/release-v0.19.x/kolibri/plugins/coach/frontend/views/lessons/LessonSelectionContentPreviewPage/LessonContentPreview/index.vue#L16
- https://github.com/learningequality/kolibri/blob/releasev0.19.x/kolibri/plugins/learn/frontend/views/PrevNextBar/index.vue#L50
- https://github.com/learningequality/kolibri/blob/release-v0.19.x/kolibri/plugins/learn/frontend/views/ExamPage/index.vue#L231
- https://github.com/learningequality/kolibri/blob/release-v0.19.x/packages/kolibri-common/components/syncComponentSet/FacilityNameAndSyncStatus/index.vue#L8
- https://github.com/learningequality/kolibri/blob/release-v0.19.x/kolibri/plugins/learn/frontend/views/TopicsPage/TopicSubsection.vue#L26
- https://github.com/learningequality/kolibri/blob/release-v0.19.x/kolibri/plugins/learn/frontend/views/QuizRenderer/index.vue#L87



## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->
  - **Description:** Wraps KButton `iconAfter` slot in same `span.icon-container` that `icon` slot is already wrapped in.
  - **Products impact:** bugfix
  - **Addresses:** -
  - **Components:** KButton
  - **Breaking:** yes - styles may be broken in some cases
  - **Impacts a11y:** No
  - **Guidance:** Identify places where the `#iconAfter` slot is used in Kolibri and update styles as needed

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
