### PR TITLE
Upgrade nodejs for the npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,7 @@ name: Publish (pre)release to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   id-token: write  # Required for OIDC
@@ -15,6 +16,5 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm publish


### PR DESCRIPTION
## Description

* Upgrade nodejs on the npm-publish workflow so that we can use the npm trusted publishers workflow.
* Temporarily add a `workflow_dispatch:` trigger to test publish until it works.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** * Upgrades nodejs on the npm-publish workflow
  - **Products impact:** none.
  - **Addresses:** -
  - **Components:** -.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
