### PR TITLE
["floating" feature branch] Add useKFloatingPosition

### DIFF
--- a/docs/common/DocsWarning.vue
+++ b/docs/common/DocsWarning.vue
@@ -1,0 +1,50 @@
+<template>
+
+  <div
+    class="wrapper"
+    :style="{
+      backgroundColor: $themePalette.yellow.v_100,
+      borderLeftColor: $themePalette.yellow.v_500,
+    }"
+  >
+    <KIcon
+      icon="warning"
+      class="icon"
+      :color="$themePalette.yellow.v_500"
+    />
+    <div class="content">
+      <slot></slot>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'DocsWarning',
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .wrapper {
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 12px 16px;
+    margin: 16px 0;
+    border-left: 4px solid;
+    border-radius: 4px;
+  }
+
+  .icon {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+  }
+
+</style>

--- a/docs/pages/browsersupport.vue
+++ b/docs/pages/browsersupport.vue
@@ -1,0 +1,29 @@
+<template>
+
+  <DocsPageTemplate>
+    <DocsPageSection>
+      <p>
+        The design system's <strong>browser support is determined by Kolibri</strong>, which often
+        runs offline, on older devices, and with limited insight into browser usage.
+      </p>
+      <p>
+        <strong>Each library update must be strictly compatible with
+          <DocsExternalLink
+            href="https://github.com/learningequality/kolibri/blob/develop/packages/browserslist-config-kolibri/index.js"
+            text="Kolibri's browserslist"
+          /></strong>.
+      </p>
+
+      <p>The following areas require extra care to maintain compatibility:</p>
+      <ul>
+        <li>
+          Floating UI (<code>@floating-ui/dom</code>) version updates (<DocsInternalLink
+            href="/usekfloatingposition#version-update"
+            text="guidance"
+          />)
+        </li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>

--- a/docs/pages/floatingelements/index.vue
+++ b/docs/pages/floatingelements/index.vue
@@ -1,0 +1,66 @@
+<template>
+
+  <DocsPageTemplate>
+    <DocsPageSection
+      title="Overview"
+      anchor="#overview"
+    >
+      <p>
+        Floating elements are UI elements that appear above the page content, such as tooltips and
+        dropdown menus. KDS provides built-in components as well as a low-level logic for managing
+        the positioning of any floating element.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Terms"
+      anchor="#terms"
+    >
+      <ul>
+        <li>
+          <i><strong>Floating element</strong></i> appears or disappears in response to user
+          interaction with the activator element. Common examples include tooltips and dropdown
+          menus.
+        </li>
+        <li>
+          <i><strong>Activator element</strong></i> is the element that a user interacts with to
+          activate a floating element. It could be a button that opens a dropdown menu, or an
+          element that shows a tooltip on hover.
+        </li>
+
+        <li>
+          <i><strong>Anchor element</strong></i> is the element to which a floating element is
+          anchored. It is often the same as the activator element, but not always. For example, a
+          tooltip might be anchored to the info icon next to the input, but activated by focusing
+          the input itself.
+        </li>
+      </ul>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Components"
+      anchor="#components"
+    >
+      <ul>
+        <li><DocsLibraryLink component="KTooltip" /> displays a tooltip for an element</li>
+        <li><DocsLibraryLink component="KDropdownMenu" /> displays a dropdown or context menu</li>
+      </ul>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Composables"
+      anchor="#composables"
+    >
+      <ul>
+        <li>
+          <DocsLibraryLink component="useKFloatingPosition" /> manages the positioning of floating
+          elements relative to their anchor elements. Some design system components use it
+          internally, but it can also be used independently, typically (but not necessarily)
+          together with <code>useKFloatingInteraction</code>.
+        </li>
+        <li><DocsLibraryLink component="useKFloatingInteraction" /> TBD</li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>

--- a/docs/pages/usekfloatingposition.vue
+++ b/docs/pages/usekfloatingposition.vue
@@ -1,0 +1,219 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+    <DocsPageSection
+      title="Overview"
+      anchor="#overview"
+    >
+      <p>
+        A composable that manages the positioning of floating elements such as tooltips and dropdown
+        menus relative to their anchor elements. It is built with
+        <DocsExternalLink
+          href="https://floating-ui.com/"
+          text="Floating UI"
+        />.
+      </p>
+
+      <p>
+        Some design system components use it internally, but it can also be used independently,
+        typically (but not necessarily) together with
+        <DocsLibraryLink component="useKFloatingInteraction" />.
+      </p>
+
+      <p>
+        See
+        <DocsInternalLink
+          href="/floatingelements"
+          text="Floating elements"
+        />.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection
+      anchor="#version-update"
+      title="Floating UI version updates"
+    >
+      <DocsWarning>
+        Floating UI is a modern library and the design system must ensure compatibility with all
+        <DocsInternalLink
+          href="/browsersupport"
+          text="supported browsers"
+        />.
+        <strong>All version updates of <code>@floating-ui/dom</code> have to be done carefully, timed
+          with major releases, and accompanied by a detailed Kolibri QA on Browserstack</strong>
+        for all areas built with <code>useKFloatingPosition</code>.
+      </DocsWarning>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Usage"
+      anchor="#usage"
+    >
+      <DocsSubNav
+        :items="[
+          { text: 'initPosition', href: '#init-position' },
+          { text: 'destroyPosition', href: '#destroy-position' },
+          { text: 'Options', href: '#options' },
+          { text: 'Custom implementations', href: '#custom' },
+        ]"
+      />
+
+      <h3 id="init-position">initPosition</h3>
+      <p>
+        Positions a floating element relative to the anchor element and sets up auto-updating so the
+        position stays correct on scroll, resize, etc. To be called when the floating element is
+        shown or added to the DOM. See
+        <DocsInternalLink
+          href="#options"
+          text="Options"
+        />.
+      </p>
+
+      <DocsWarning>
+        For each floating element positioned with <code>initPosition</code>, always make sure to
+        <strong>call <code>destroyPosition</code> when the floating element is hidden or removed from the
+          DOM</strong>
+        to prevent severe performance problems.
+      </DocsWarning>
+
+      <!-- eslint-disable -->
+      <!-- prettier-ignore -->
+      <DocsShowCode language="javascript">
+        import useKFloatingPosition from 'kolibri-design-system/lib/composables/useKFloatingPosition';
+
+        const { initPosition } = useKFloatingPosition();
+
+        initPosition(
+          'my-tooltip',            // Unique ID of the floating element
+          floatingEl,              // Floating DOM element (e.g. tooltip)
+          anchorEl,                // Anchor DOM element (e.g. button)
+          options                  // Floating UI options
+        );
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <h3 id="destroy-position">destroyPosition</h3>
+      <p>
+        Stops auto-updating the position of the floating element positioned with
+        <code>initPosition</code>. Call when the floating element is hidden or removed from the DOM
+        to prevent severe performance problems.
+      </p>
+
+      <!-- eslint-disable -->
+      <!-- prettier-ignore -->
+      <DocsShowCode language="javascript">
+        import useKFloatingPosition from 'kolibri-design-system/lib/composables/useKFloatingPosition';
+
+        const { destroyPosition } = useKFloatingPosition();
+
+        destroyPosition('my-tooltip');
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <h3 id="options">Options</h3>
+      <p>
+        The <code>options</code> object passed to <code>initPosition</code> corresponds to
+        <DocsExternalLink
+          href="https://floating-ui.com/docs/computeposition#options"
+          text="the options parameter"
+        />
+
+        of Floating UI's <code>computePosition</code>. Use <code>options</code> to configure
+        placement, strategy, and middleware. Middleware can be imported from
+        <code>useKFloatingPosition</code>.
+      </p>
+
+      <!-- eslint-disable -->
+      <!-- prettier-ignore -->
+      <DocsShowCode language="javascript">
+        import useKFloatingPosition from 'kolibri-design-system/lib/composables/useKFloatingPosition';
+
+        const { initPosition, offset, flip, shift } = useKFloatingPosition();
+
+        initPosition('my-tooltip', floatingEl, anchorEl, {
+          placement: 'bottom',
+          strategy: 'fixed',
+          middleware: [
+            offset(6),
+            flip(),
+            shift({padding: 5}),
+          ],
+        });
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <h3 id="custom">Custom implementation</h3>
+      <p>
+        <code>initPosition</code> and <code>destroyPosition</code> are designed to work seamlessly
+        with other parts of the design system and cover the majority of use cases. In rare cases, it
+        may be useful to have direct access to Floating UI, for example when you only need the
+        <code>x, y</code> coordinates and want to apply them yourself. You can import Floating UI
+        functions from <code>useKFloatingPosition</code> and use them as described in the
+        <DocsExternalLink
+          href="https://floating-ui.com/docs/computePosition"
+          text="Floating UI documentation"
+        />.
+      </p>
+
+      <!-- eslint-disable -->
+      <!-- prettier-ignore -->
+      <DocsShowCode language="javascript">
+        import useKFloatingPosition from 'kolibri-design-system/lib/composables/useKFloatingPosition';
+
+        const { computePosition, autoUpdate } = useKFloatingPosition();
+      </DocsShowCode>
+      <!-- eslint-enable -->
+
+      <DocsWarning>
+        Follow Floating UI's guidance to
+        <strong><DocsExternalLink
+          href="https://floating-ui.com/docs/autoUpdate#usage"
+          text="clean up auto-updating"
+        />
+          to prevent severe performance problems.</strong>
+      </DocsWarning>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Example"
+      anchor="#example"
+    >
+      <p>Click the button to toggle the tooltip.</p>
+      <DocsExample
+        exampleId="basic"
+        loadExample="useKFloatingPosition/Basic.vue"
+        block
+      />
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Related"
+      anchor="#related"
+    >
+      <ul>
+        <li>
+          <DocsInternalLink
+            href="/floatingelements"
+            text="Floating elements"
+          />
+          has general overview of floating elements
+        </li>
+        <li><DocsLibraryLink component="useKFloatingInteraction" /> TBD</li>
+        <li>
+          <DocsExternalLink
+            href="https://floating-ui.com/docs/getting-started"
+            text="Floating UI"
+          />
+        </li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>
+
+
+<script>
+
+  export default {};
+
+</script>

--- a/docs/plugins/load-common-components.js
+++ b/docs/plugins/load-common-components.js
@@ -17,6 +17,7 @@ import DocsToggleButton from '~/common/DocsToggleButton';
 import DocsFilter from '~/common/DocsFilter';
 import DocsTable from '~/common/DocsTable';
 import DocsSubNav from '~/common/DocsSubNav';
+import DocsWarning from '~/common/DocsWarning';
 import VisualTestExample from '~~/jest.conf/components/VisualTestExample.vue';
 import VisualTestLayout from '~~/jest.conf/components/VisualTestLayout.vue';
 
@@ -36,6 +37,7 @@ Vue.component('DocsToggleContent', DocsToggleContent);
 Vue.component('DocsToggleButton', DocsToggleButton);
 Vue.component('DocsTable', DocsTable);
 Vue.component('DocsSubNav', DocsSubNav);
+Vue.component('DocsWarning', DocsWarning);
 
 Vue.use(VueSimpleMarkdown);
 

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -61,6 +61,17 @@ const layoutRelatedKeywords = ['grid', 'layout', 'container', 'page'];
 const tabsRelatedKeywords = ['tab', 'tabs', 'panel', 'tablist', 'tabpanel'];
 const compositionRelatedKeywords = ['composable', 'composition'];
 const cardRelatedKeywords = ['grid', 'card', 'cardgrid'];
+const floatingRelatedKeywords = [
+  'tooltip',
+  'dropdown',
+  'popover',
+  'floating',
+  'trigger',
+  'anchor',
+  'reference',
+  'activator',
+  'position',
+];
 
 export default [
   new Section({
@@ -72,6 +83,10 @@ export default [
       new Page({
         path: '/installation',
         title: 'Installation',
+      }),
+      new Page({
+        path: '/browsersupport',
+        title: 'Browser support',
       }),
       new Page({
         path: '/principles',
@@ -173,6 +188,11 @@ export default [
         path: '/loaders',
         title: 'Loaders',
       }),
+      new Page({
+        path: '/floatingelements',
+        title: 'Floating elements',
+        keywords: floatingRelatedKeywords,
+      }),
     ],
   }),
   new Section({
@@ -220,6 +240,12 @@ export default [
           'loader',
           'loading',
         ],
+      }),
+      new Page({
+        path: '/usekfloatingposition',
+        title: 'useKFloatingPosition',
+        isCode: true,
+        keywords: [...compositionRelatedKeywords, ...floatingRelatedKeywords],
       }),
     ],
   }),

--- a/examples/useKFloatingPosition/Basic.vue
+++ b/examples/useKFloatingPosition/Basic.vue
@@ -26,10 +26,10 @@
   import { ref, onBeforeUnmount, nextTick } from 'vue';
   import useKFloatingPosition from '../../lib/composables/useKFloatingPosition';
 
-  const FLOATING_ID = 'tooltip-unique-id';
-
   export default {
     setup() {
+      const TOOLTIP_ID = 'tooltip-unique-id';
+
       const { initPosition, destroyPosition, offset, flip } = useKFloatingPosition();
 
       const isVisible = ref(false);
@@ -40,7 +40,7 @@
         isVisible.value = true;
 
         nextTick(() => {
-          initPosition(FLOATING_ID, floatingRef.value, anchorRef.value.$el, {
+          initPosition(TOOLTIP_ID, floatingRef.value, anchorRef.value.$el, {
             placement: 'bottom',
             middleware: [offset(8), flip()],
           });
@@ -49,7 +49,7 @@
 
       function hide() {
         isVisible.value = false;
-        destroyPosition(FLOATING_ID);
+        destroyPosition(TOOLTIP_ID);
       }
 
       function toggle() {
@@ -57,7 +57,7 @@
       }
 
       onBeforeUnmount(() => {
-        destroyPosition(FLOATING_ID);
+        destroyPosition(TOOLTIP_ID);
       });
 
       return { isVisible, anchorRef, floatingRef, toggle };

--- a/examples/useKFloatingPosition/Basic.vue
+++ b/examples/useKFloatingPosition/Basic.vue
@@ -1,0 +1,91 @@
+<template>
+
+  <div>
+    <KButton
+      ref="anchorRef"
+      @click="toggle"
+    >
+      {{ isVisible ? 'Hide tooltip' : 'Show tooltip' }}
+    </KButton>
+
+    <div
+      v-if="isVisible"
+      ref="floatingRef"
+      class="tooltip"
+      :style="{ color: $themeTokens.textInverted, background: $themeTokens.text }"
+    >
+      Kolibri Fly!
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref, onBeforeUnmount, nextTick } from 'vue';
+  import useKFloatingPosition from '../../lib/composables/useKFloatingPosition';
+
+  const FLOATING_ID = 'tooltip-unique-id';
+
+  export default {
+    setup() {
+      const { initPosition, destroyPosition, offset, flip } = useKFloatingPosition();
+
+      const isVisible = ref(false);
+      const anchorRef = ref(null);
+      const floatingRef = ref(null);
+
+      function show() {
+        isVisible.value = true;
+
+        nextTick(() => {
+          initPosition(FLOATING_ID, floatingRef.value, anchorRef.value.$el, {
+            placement: 'bottom',
+            middleware: [offset(8), flip()],
+          });
+        });
+      }
+
+      function hide() {
+        isVisible.value = false;
+        destroyPosition(FLOATING_ID);
+      }
+
+      function toggle() {
+        isVisible.value ? hide() : show();
+      }
+
+      onBeforeUnmount(() => {
+        destroyPosition(FLOATING_ID);
+      });
+
+      return { isVisible, anchorRef, floatingRef, toggle };
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '../../lib/styles/definitions';
+
+  .tooltip {
+    @extend %dropshadow-1dp;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: max-content;
+    min-width: 75px;
+    padding: 8px;
+    font-size: 12px;
+    font-weight: normal;
+    line-height: 1.4;
+    text-align: center;
+    pointer-events: none;
+    border-radius: 8px;
+  }
+
+</style>

--- a/lib/composables/useKFloatingPosition/__tests__/index.spec.js
+++ b/lib/composables/useKFloatingPosition/__tests__/index.spec.js
@@ -1,7 +1,7 @@
 import useKFloatingPosition, { _instances } from '../index.js';
 
 jest.mock('@floating-ui/dom', () => ({
-  computePosition: jest.fn().mockResolvedValue({}),
+  computePosition: jest.fn().mockResolvedValue({ x: 10, y: 20, strategy: 'absolute' }),
   autoUpdate: jest.fn(() => jest.fn()),
 }));
 
@@ -29,7 +29,7 @@ describe('useKFloatingPosition', () => {
   });
 
   describe('initPosition', () => {
-    it('stores the instance & sets up auto-updating', () => {
+    it('stores the instance, sets up auto-updating, and updates the position', async () => {
       initPosition('floating-1', floatingEl, anchorEl, { placement: 'bottom' });
 
       expect(mockAutoUpdate).toHaveBeenCalledWith(anchorEl, floatingEl, expect.any(Function));
@@ -39,11 +39,14 @@ describe('useKFloatingPosition', () => {
       });
 
       const updateFn = mockAutoUpdate.mock.calls[0][2];
-      updateFn();
+      await updateFn();
 
       expect(mockComputePosition).toHaveBeenCalledWith(anchorEl, floatingEl, {
         placement: 'bottom',
       });
+      expect(floatingEl).toHaveStyle({ position: 'absolute' });
+      expect(floatingEl).toHaveStyle({ left: '10px' });
+      expect(floatingEl).toHaveStyle({ top: '20px' });
     });
 
     it('cleans up any existing instance before reinitializing', () => {

--- a/lib/composables/useKFloatingPosition/__tests__/index.spec.js
+++ b/lib/composables/useKFloatingPosition/__tests__/index.spec.js
@@ -1,0 +1,69 @@
+import useKFloatingPosition, { _instances } from '../index.js';
+
+jest.mock('@floating-ui/dom', () => ({
+  computePosition: jest.fn().mockResolvedValue({}),
+  autoUpdate: jest.fn(() => jest.fn()),
+}));
+
+const {
+  initPosition,
+  destroyPosition,
+  autoUpdate: mockAutoUpdate,
+  computePosition: mockComputePosition,
+} = useKFloatingPosition();
+
+describe('useKFloatingPosition', () => {
+  let anchorEl, floatingEl;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    anchorEl = document.createElement('div');
+    floatingEl = document.createElement('div');
+    document.body.appendChild(anchorEl);
+    document.body.appendChild(floatingEl);
+  });
+
+  afterEach(() => {
+    destroyPosition('floating-1');
+    document.body.innerHTML = '';
+  });
+
+  describe('initPosition', () => {
+    it('stores the instance & sets up auto-updating', () => {
+      initPosition('floating-1', floatingEl, anchorEl, { placement: 'bottom' });
+
+      expect(mockAutoUpdate).toHaveBeenCalledWith(anchorEl, floatingEl, expect.any(Function));
+      expect(_instances['floating-1']).toEqual({
+        cleanup: mockAutoUpdate.mock.results[0].value,
+        floatingEl,
+      });
+
+      const updateFn = mockAutoUpdate.mock.calls[0][2];
+      updateFn();
+
+      expect(mockComputePosition).toHaveBeenCalledWith(anchorEl, floatingEl, {
+        placement: 'bottom',
+      });
+    });
+
+    it('cleans up any existing instance before reinitializing', () => {
+      initPosition('floating-1', floatingEl, anchorEl, {});
+      const firstCleanup = _instances['floating-1'].cleanup;
+
+      initPosition('floating-1', floatingEl, anchorEl, {});
+      expect(firstCleanup).toHaveBeenCalledTimes(1);
+      expect(_instances['floating-1']).toBeDefined();
+    });
+  });
+
+  describe('destroyPosition', () => {
+    it('stops auto-updating and removes the instance', () => {
+      initPosition('floating-1', floatingEl, anchorEl, {});
+      const mockCleanup = _instances['floating-1'].cleanup;
+
+      destroyPosition('floating-1');
+      expect(mockCleanup).toHaveBeenCalledTimes(1);
+      expect(_instances['floating-1']).toBeUndefined();
+    });
+  });
+});

--- a/lib/composables/useKFloatingPosition/index.js
+++ b/lib/composables/useKFloatingPosition/index.js
@@ -46,13 +46,21 @@ export default function useKFloatingPosition() {
     destroyPosition(floatingId);
 
     function updatePosition() {
-      computePosition(anchorEl, floatingEl, options).then(({ x, y, strategy }) => {
-        Object.assign(floatingEl.style, {
-          position: strategy,
-          left: `${x}px`,
-          top: `${y}px`,
+      computePosition(anchorEl, floatingEl, options)
+        .then(({ x, y, strategy }) => {
+          Object.assign(floatingEl.style, {
+            position: strategy,
+            left: `${x}px`,
+            top: `${y}px`,
+          });
+        })
+        .catch(err => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[useKFloatingPosition] Failed to compute position for "${floatingId}":`,
+            err,
+          );
         });
-      });
     }
 
     _instances[floatingId] = {

--- a/lib/composables/useKFloatingPosition/index.js
+++ b/lib/composables/useKFloatingPosition/index.js
@@ -1,0 +1,99 @@
+import {
+  computePosition,
+  autoUpdate,
+  offset,
+  shift,
+  limitShift,
+  flip,
+  arrow,
+  size,
+  autoPlacement,
+  hide,
+  inline,
+  detectOverflow,
+} from '@floating-ui/dom';
+
+// Map of floating element IDs to their cleanup functions and elements.
+// { <floating id>: { cleanup: fn, floatingEl: Element } }
+export const _instances = {};
+
+/**
+ * Manages the positioning of floating elements relative
+ * to their anchor elements.
+ *
+ * @returns {Object} { initPosition, destroyPosition, computePosition,
+ * autoUpdate, offset, shift, limitShift, flip, arrow, size, autoPlacement,
+ * hide, inline, detectOverflow }
+ */
+export default function useKFloatingPosition() {
+  /**
+   * Positions a floating element relative to the anchor element
+   * and sets up auto-updating so the position stays correct on
+   * scroll, resize, etc. To be called when the floating element
+   * is shown or added to the DOM.
+   *
+   * Make sure to call `destroyPosition` when the floating element
+   * is hidden or removed from the DOM to prevent severe performance
+   * problems.
+   *
+   * @param {String} floatingId - Unique ID of the floating element
+   * @param {Element} floatingEl - Floating DOM element (e.g. tooltip)
+   * @param {Element} anchorEl - Anchor DOM element
+   * @param {Object} options - Floating UI options
+   *   (https://floating-ui.com/docs/computePosition#options)
+   */
+  function initPosition(floatingId, floatingEl, anchorEl, options = {}) {
+    destroyPosition(floatingId);
+
+    function updatePosition() {
+      computePosition(anchorEl, floatingEl, options).then(({ x, y, strategy }) => {
+        Object.assign(floatingEl.style, {
+          position: strategy,
+          left: `${x}px`,
+          top: `${y}px`,
+        });
+      });
+    }
+
+    _instances[floatingId] = {
+      cleanup: autoUpdate(anchorEl, floatingEl, updatePosition),
+      floatingEl,
+    };
+  }
+
+  /**
+   * Stops auto-updating the position of the floating element
+   * positioned with `initPosition`. Call when the floating
+   * element is hidden or removed from the DOM to prevent severe
+   * performance problems.
+   *
+   * @param {String} floatingId - Unique ID of the floating element
+   */
+  function destroyPosition(floatingId) {
+    const instance = _instances[floatingId];
+    if (instance) {
+      instance.cleanup();
+      delete _instances[floatingId];
+    }
+  }
+
+  return {
+    initPosition,
+    destroyPosition,
+    // Floating UI core
+    computePosition,
+    autoUpdate,
+    // Floating UI middleware
+    offset,
+    shift,
+    limitShift,
+    flip,
+    arrow,
+    size,
+    autoPlacement,
+    hide,
+    inline,
+    // Floating UI utilities
+    detectOverflow,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lib"
   ],
   "dependencies": {
+    "@floating-ui/dom": "1.7.6",
     "aphrodite": "https://github.com/learningequality/aphrodite/",
     "autosize": "3.0.21",
     "color": "4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,6 +1415,26 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
+"@floating-ui/core@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.5.tgz#d4af157a03330af5a60e69da7a4692507ada0622"
+  integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
+  dependencies:
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.6.tgz#f915bba5abbb177e1f227cacee1b4d0634b187bf"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
+  dependencies:
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
+
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.11.tgz#a269e055e40e2f45873bae9d1a2fdccbd314ea3f"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
+
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
## Description

The first PR in the series that aims to prepare selected parts of https://github.com/learningequality/kolibri-design-system/pull/1114 for production environment. Targets `floating-production` feature branch. The next PR will be for `useKFloatingInteraction`.

Adds `useKFloatingPosition` composable with new documentation pages
- [Browser support](https://deploy-preview-1240--kolibri-design-system.netlify.app/browsersupport)
- [Floating elements](https://deploy-preview-1240--kolibri-design-system.netlify.app/floatingelements)
- [useKFloatingPosition](https://deploy-preview-1240--kolibri-design-system.netlify.app/usekfloatingposition)

Note that Floating UI may be replaced by Popper, depending on results of browser testing in Kolibri & dev discussion (the structure of the composable and documentation will be the same for both, except few differences).

#### Issue addressed

Part of https://github.com/learningequality/kolibri-design-system/issues/1158

## Changelog

Skipped. Will prepare the changelog before merging the feature branch to `develop`.

## AI usage

I used Claude for draft and then further assistance when iterating on it. There's not a place that I wouldn't tweak or see ;) Also self-reviewed the final diff fully.