### PR TITLE
Add KListbox and setup KDS for candidate components

### DIFF
--- a/docs/assets/definitions.scss
+++ b/docs/assets/definitions.scss
@@ -6,4 +6,4 @@ $link-hover-color: #26614d;
 $selection-color: #badbd2;
 $basic-transition: color 0.25s ease,
   fill 0.25s ease;
-$nav-width: 260px;
+$nav-width: 280px;

--- a/docs/common/DocsBanner.vue
+++ b/docs/common/DocsBanner.vue
@@ -1,0 +1,77 @@
+<template>
+
+  <div
+    class="banner"
+    :style="{
+      backgroundColor: config.backgroundColor,
+      color: $themeTokens.text,
+    }"
+  >
+    <KIcon
+      :icon="config.icon"
+      class="icon"
+      :color="config.iconColor"
+    />
+    <div class="content">
+      <slot></slot>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'DocsBanner',
+    props: {
+      a11y: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    computed: {
+      config() {
+        if (this.a11y) {
+          return {
+            icon: 'a11y',
+            backgroundColor: this.$themePalette.orange.v_50,
+            iconColor: undefined,
+          };
+        }
+        return {
+          icon: 'info',
+          backgroundColor: this.$themePalette.lightblue.v_50,
+          iconColor: this.$themePalette.lightblue.v_500,
+        };
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .banner {
+    display: flex;
+    gap: 12px;
+    padding: 12px 16px;
+    margin: 16px 0;
+    border-radius: 4px;
+  }
+
+  .icon {
+    position: relative;
+    top: 0;
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+  }
+
+  .content {
+    flex: 1;
+    font-size: 1em;
+  }
+
+</style>

--- a/docs/common/DocsPageSection.vue
+++ b/docs/common/DocsPageSection.vue
@@ -42,7 +42,7 @@
     },
     computed: {
       style() {
-        return this.fullwidth ? {} : { maxWidth: '900px' };
+        return this.fullwidth ? {} : { maxWidth: '1000px' };
       },
     },
     mounted() {

--- a/docs/common/DocsPageTemplate/BadgeCandidate.vue
+++ b/docs/common/DocsPageTemplate/BadgeCandidate.vue
@@ -1,0 +1,48 @@
+<template>
+
+  <span
+    class="badge"
+    :class="{ small }"
+    :style="{
+      backgroundColor: $themePalette.lightblue.v_50,
+      color: $themePalette.lightblue.v_600,
+    }"
+  >
+    Candidate
+  </span>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'BadgeCandidate',
+    props: {
+      small: {
+        type: Boolean,
+        default: false,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    margin-left: 12px;
+    font-size: 14px;
+    border-radius: 6px;
+  }
+
+  .small {
+    padding: 2px 6px;
+    margin-left: 6px;
+    font-size: 12px;
+  }
+
+</style>

--- a/docs/common/DocsPageTemplate/Header.vue
+++ b/docs/common/DocsPageTemplate/Header.vue
@@ -12,6 +12,7 @@
           @click="toggleSideNav"
         />
         <span :class="{ code: codeStyle }">{{ title }}</span>
+        <BadgeCandidate v-if="candidate" />
         <a
           href="#"
           @click="scrollToTop"
@@ -49,11 +50,13 @@
 
 <script>
 
+  import BadgeCandidate from './BadgeCandidate.vue';
   import BranchLink from './BranchLink.vue';
 
   export default {
     name: 'Header',
     components: {
+      BadgeCandidate,
       BranchLink,
     },
     props: {
@@ -68,6 +71,10 @@
       title: {
         type: String,
         required: true,
+      },
+      candidate: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {
@@ -147,20 +154,18 @@
   }
 
   .header-text {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     margin: 0;
     font-weight: 400;
   }
 
-  .header-text > * {
-    vertical-align: middle;
-  }
-
   .icon-link {
+    display: block;
     width: 14px;
     height: 14px;
     margin-right: 8px;
-    margin-left: 8px;
+    margin-left: 16px;
     transition: all 0.15s ease;
   }
 

--- a/docs/common/DocsPageTemplate/SideNav/NavLink.vue
+++ b/docs/common/DocsPageTemplate/SideNav/NavLink.vue
@@ -6,6 +6,10 @@
     :class="{ code: page.isCode }"
   >
     {{ page.title }}
+    <BadgeCandidate
+      v-if="page.candidate"
+      small
+    />
   </div>
   <router-link
     v-else
@@ -15,6 +19,10 @@
     :class="{ 'current-page': currentPage, code: page.isCode }"
   >
     {{ page.title }}
+    <BadgeCandidate
+      v-if="page.candidate"
+      small
+    />
   </router-link>
 
 </template>
@@ -22,8 +30,13 @@
 
 <script>
 
+  import BadgeCandidate from '../BadgeCandidate.vue';
+
   export default {
     name: 'NavLink',
+    components: {
+      BadgeCandidate,
+    },
     props: {
       page: {
         type: Object,
@@ -58,7 +71,8 @@
   @import '~/assets/definitions';
 
   .block {
-    display: block;
+    display: flex;
+    align-items: center;
     padding: 4px 8px;
     margin-right: -8px;
     margin-bottom: 2px;

--- a/docs/common/DocsPageTemplate/index.vue
+++ b/docs/common/DocsPageTemplate/index.vue
@@ -16,6 +16,7 @@
       :sections="pageSections"
       :title="page.title"
       :codeStyle="page.isCode"
+      :candidate="page.candidate"
       class="floating-header"
       @update-side-nav="handleSideNavUpdate"
     />
@@ -26,10 +27,26 @@
         :sections="pageSections"
         :title="page.title"
         :codeStyle="page.isCode"
+        :candidate="page.candidate"
         style="visibility: hidden"
       />
 
       <div class="content">
+        <DocsPageSection>
+          <DocsBanner v-if="page.candidate">
+            <p style="margin: 0">
+              This component is a
+              <DocsInternalLink
+                href="/candidate-components"
+                text="candidate"
+              />.
+            </p>
+            <div v-if="$slots.developerNotes">
+              <h2 class="developer-notes-title">Developer notes</h2>
+              <slot name="developerNotes"></slot>
+            </div>
+          </DocsBanner>
+        </DocsPageSection>
         <slot></slot>
         <DocsPageSection
           v-for="(section, i) in apiSections"
@@ -242,6 +259,13 @@
       padding: 0 16px 200px;
       overflow-x: hidden;
     }
+  }
+
+  .developer-notes-title {
+    margin: 18px 0 4px;
+    font-size: inherit;
+    font-weight: normal;
+    text-decoration: underline;
   }
 
   .overlay {

--- a/docs/pages/candidate-components.vue
+++ b/docs/pages/candidate-components.vue
@@ -62,6 +62,19 @@
         <li>It is highly specific to a single application</li>
       </ul>
     </DocsPageSection>
+
+    <DocsPageSection
+      title="Note"
+      anchor="#note"
+    >
+      <p>
+        See additional details and examples on the candidate process in this
+        <DocsExternalLink
+          href="https://www.figma.com/design/nGLCIW2iZBsY1AZcyjQdDE/KDS-Candidate"
+          text="Figma file"
+        />.
+      </p>
+    </DocsPageSection>
   </DocsPageTemplate>
 
 </template>

--- a/docs/pages/candidate-components.vue
+++ b/docs/pages/candidate-components.vue
@@ -1,0 +1,76 @@
+<template>
+
+  <DocsPageTemplate>
+    <DocsPageSection
+      title="Overview"
+      anchor="#overview"
+    >
+      <p>
+        A <strong>candidate component</strong> is a component whose accessibility, visual design,
+        and interactions are largely established, and which has been identified as useful to include
+        in the design system, but whose user experience or implementation details need more time to
+        mature. This means that the following are expected to be refined:
+      </p>
+      <ul>
+        <li>Visual and interaction details</li>
+        <li>Props, slots, events, sub-components</li>
+        <li>What parts belong in the design system versus consuming applications</li>
+      </ul>
+
+      <p>
+        Candidate components are <strong>in active use</strong> in consuming applications.
+        Therefore, they need to follow the
+        <strong>same release planning as regular components</strong>, particularly regarding
+        breaking changes. Thorough unit and visual test coverage is expected to allow for smooth
+        iteration.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Criteria"
+      anchor="#criteria"
+    >
+      <p>
+        A component
+        <strong>can be considered for candidacy when one or more of the following are true:</strong>
+      </p>
+      <ul>
+        <li>
+          It maps to a well-established accessibility pattern or is a collection of such patterns
+          (e.g.
+          <DocsExternalLink
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/"
+            text="APG patterns"
+          />)
+        </li>
+        <li>The overall user experience is unlikely to change significantly</li>
+      </ul>
+
+      <p>
+        For example, consider a modal side panel component. Its accessibility requirements (focus
+        management, ARIA roles, and keyboard handling) apply uniformly to all use cases, and the
+        main parts of its visual layout are well-defined. Even with some visual or implementation
+        details still unresolved, a single component ensures a more reliable and consistent user
+        experience, avoids duplicated work, and lets real use cases strengthen its robustness across
+        a wide variety of contexts.
+      </p>
+
+      <p>A component <strong>is unlikely to become a candidate when:</strong></p>
+      <ul>
+        <li>The accessibility pattern is still being explored</li>
+        <li>The user experience is expected to change significantly</li>
+        <li>It is highly specific to a single application</li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'CandidateComponents',
+  };
+
+</script>

--- a/docs/pages/candidate-components.vue
+++ b/docs/pages/candidate-components.vue
@@ -18,11 +18,8 @@
       </ul>
 
       <p>
-        Candidate components are <strong>in active use</strong> in consuming applications.
-        Therefore, they need to follow the
-        <strong>same release planning as regular components</strong>, particularly regarding
-        breaking changes. Thorough unit and visual test coverage is expected to allow for smooth
-        iteration.
+        Candidate components are <strong>in active use</strong> in consuming applications. Thorough
+        unit and visual test coverage is expected to allow for smooth iterations.
       </p>
     </DocsPageSection>
 

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -21,6 +21,11 @@
           listbox pattern and use cases vary. If a frequent pattern emerges, it may motivate
           dedicated search/filter components that integrate well with <code>KListbox</code>.
         </li>
+        <li>
+          Currently KListbox doesn't support options reodering, so bear in mind that if the list
+          changes due to a filter, the filtered list should preserve the order of the original list
+          to avoid unexpected keyboard navigation.
+        </li>
       </ul>
     </template>
 

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -1,0 +1,247 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+    <template #developerNotes>
+      <ul :style="{ margin: 0 }">
+        <li>
+          Grouped options aren't supported yet, as we haven't needed them. They could be added by
+          extending our listbox components according to
+          <DocsExternalLink
+            text="grouped options of APG's listbox pattern"
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-grouped/"
+          />
+          (likely adding <code>KListboxGroup</code>)
+        </li>
+        <li>
+          Reflecting our first use-cases, multi selection is the default behavior. Single selection
+          mode could be added by a few adjustments in line with the same APG listbox pattern.
+        </li>
+        <li>
+          Listboxes are often combined with searching or filtering, but that's not part of the
+          listbox pattern and use cases vary. If a frequent pattern emerges, it may motivate
+          dedicated search/filter components that integrate well with <code>KListbox</code>.
+        </li>
+      </ul>
+    </template>
+
+    <DocsPageSection
+      title="Overview"
+      anchor="#overview"
+    >
+      <p>
+        <code>KListbox</code> is a representation of the
+        <DocsExternalLink
+          text="APG listbox pattern"
+          href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/"
+        />
+        with several additional enhancements. It can be used as a standalone listbox or within a
+        composite widget such as a dropdown or combobox.
+      </p>
+
+      <p>Its options are provided via <DocsLibraryLink component="KListboxOption" />.</p>
+
+      <p>
+        It currently defaults to multi selection and does not yet support single selection or
+        grouped options (see developer notes above).
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Messages"
+      anchor="#messages"
+    >
+      <p>
+        <code>KListbox</code> requires a <code>messages</code> object. Each entry must be a
+        translated string that is short and focused.
+      </p>
+      <KTable
+        :headers="messageHeaders"
+        :rows="tableRows"
+        caption="KListbox messages"
+        :stickyColumns="['first']"
+      >
+        <template #cell="{ content, colIndex }">
+          <code v-if="colIndex === 0">{{ content }}</code>
+          <i v-else-if="colIndex === 3">{{ content }}</i>
+          <template v-else>{{ content }}</template>
+        </template>
+      </KTable>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Usage"
+      anchor="#usage"
+    >
+      <DocsSubNav
+        :items="[
+          { text: 'Default', href: '#default' },
+          { text: 'Select all', href: '#select-all' },
+          { text: 'Customized', href: '#customized' },
+          { text: 'Scrollable', href: '#scrollable' },
+        ]"
+      />
+
+      <h3>
+        Default
+        <DocsAnchorTarget anchor="#default" />
+      </h3>
+
+      <p><code>KListboxOption</code> is a direct child of <code>KListbox</code>.</p>
+
+      <DocsBanner a11y>
+        If <code>KListbox</code> is not part of another widget, such as a combobox, add either a
+        visible label referenced by <code>aria-labelledby</code> or a value specified for
+        <code>aria-label</code>. Use concise and descriptive value.
+      </DocsBanner>
+
+      <DocsExample
+        block
+        exampleId="klistbox-default"
+        loadExample="KListbox/Default.vue"
+      />
+
+      <h3>
+        Select all
+        <DocsAnchorTarget anchor="#select-all" />
+      </h3>
+
+      <p>
+        Use the <code>#selectAll</code> scoped slot together with a select control, typically
+        <code>KCheckbox</code>, to implement the select all functionality.
+      </p>
+
+      <DocsBanner a11y>
+        Set <code>aria-controls</code> on the control to the listbox <code>id</code> to associate
+        the two.
+      </DocsBanner>
+
+      <DocsExample
+        block
+        exampleId="klistbox-select-all"
+        loadExample="KListbox/SelectAll.vue"
+      />
+
+      <h3>
+        Customized
+        <DocsAnchorTarget anchor="#customized" />
+      </h3>
+      <p>
+        Apply style on the listbox and its rows to add more space, borders, or other appearance
+        customizations. Use slots to show rich content.
+      </p>
+
+      <DocsBanner a11y>
+        Ensure custom content is accessible and the final implementation works as a whole. For
+        example here, setting both the row and checkbox width to 100% is needed to make the entire
+        <i>All users</i> row clickable.
+      </DocsBanner>
+
+      <DocsExample
+        block
+        exampleId="klistbox-customized"
+        loadExample="KListbox/Customized.vue"
+      />
+
+      <h3>
+        Scrollable
+        <DocsAnchorTarget anchor="#scrollable" />
+      </h3>
+      <p>
+        To limit the space a long list takes up, apply a maximum height, and the list will become
+        scrollable.
+      </p>
+      <DocsExample
+        block
+        exampleId="klistbox-scrollable"
+        loadExample="KListbox/Scrollable.vue"
+        hideStyle
+        hideScript
+      >
+        <template #html>
+          <!-- eslint-disable -->
+          <DocsShowCode language="html">
+            <KListbox
+              :style="{ maxHeight: '200px' }"
+              ...
+            >
+              ...
+            </KListbox>
+          </DocsShowCode>
+          <!-- eslint-enable -->
+        </template>
+      </DocsExample>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="Related"
+      anchor="#related"
+    >
+      <ul>
+        <li>
+          <DocsLibraryLink component="KListboxOption" /> is a single option inside
+          <code>KListbox</code>
+        </li>
+        <li>
+          <DocsExternalLink
+            text="APG listbox"
+            href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/"
+          />
+          specifies the related accessibility pattern
+        </li>
+      </ul>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        messageHeaders: [
+          { label: 'Name', dataType: 'string', columnId: 'name', minWidth: '220px' },
+          { label: 'Required', dataType: 'string', columnId: 'required', minWidth: '140px' },
+          { label: 'Description', dataType: 'string', columnId: 'description' },
+          { label: 'Examples', dataType: 'string', columnId: 'example', minWidth: '200px' },
+        ],
+        messageRows: [
+          {
+            name: 'clickable',
+            required: 'Yes',
+            description:
+              'Accessible description of the listbox to indicate that its options are clickable.',
+            example: 'Options are clickable',
+          },
+          {
+            name: 'allOptionsSelected',
+            required: 'Yes',
+            description:
+              'Announced via live region when all options are selected with Ctrl + A or when the select all checkbox is used.',
+            example: 'All options selected',
+          },
+          {
+            name: 'allOptionsDeselected',
+            required: 'Yes',
+            description:
+              'Announced via live region when all options are deselected with Ctrl + A or when the select all checkbox is used.',
+            example: 'No options selected',
+          },
+          {
+            name: 'optionDeselected',
+            required: 'Yes',
+            description: 'Announced via live region when an option is deselected.',
+            example: 'Deselected',
+          },
+        ],
+      };
+    },
+    computed: {
+      tableRows() {
+        return this.messageRows.map(m => [m.name, m.required, m.description, m.example]);
+      },
+    },
+  };
+
+</script>

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -44,6 +44,12 @@
         It currently defaults to multi selection and does not yet support single selection or
         grouped options (see developer notes above).
       </p>
+
+      <p>
+        <code>KListbox</code> supports dynamic option sets (useful for integration with filtering,
+        pagination, etc.). Currently rendered options are referred to as <i>visible options</i>.
+        Selection state of hidden options is preserved.
+      </p>
     </DocsPageSection>
 
     <DocsPageSection
@@ -107,8 +113,20 @@
 
       <p>
         Use the <code>#selectAll</code> scoped slot together with a select control, typically
-        <code>KCheckbox</code>, to implement the select all functionality.
+        <code>KCheckbox</code>, to implement the select all functionality. The slot provides:
       </p>
+
+      <ul>
+        <li><code>allSelected</code>: <code>true</code> when every visible option is selected.</li>
+        <li>
+          <code>someSelected</code>: <code>true</code> when at least one (but not all) visible
+          options are selected. Useful for indicating indeterminate state.
+        </li>
+        <li>
+          <code>setAllSelected(checked)</code>: Controls selection of all visible options. Call with
+          <code>true</code> to select all visible options or <code>false</code> to deselect them.
+        </li>
+      </ul>
 
       <DocsBanner a11y>
         Set <code>aria-controls</code> on the select all control to the listbox <code>id</code> to

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -90,8 +90,8 @@
 
       <DocsBanner a11y>
         If <code>KListbox</code> is not part of another widget, such as a combobox, add either a
-        visible label referenced by <code>aria-labelledby</code> or a value specified for
-        <code>aria-label</code>. Use concise and descriptive value.
+        visible label referenced by <code>ariaLabelledBy</code> or a value specified for
+        <code>ariaLabel</code>. Use concise and descriptive value.
       </DocsBanner>
 
       <DocsExample
@@ -111,8 +111,8 @@
       </p>
 
       <DocsBanner a11y>
-        Set <code>aria-controls</code> on the control to the listbox <code>id</code> to associate
-        the two.
+        Set <code>aria-controls</code> on the select all control to the listbox <code>id</code> to
+        associate the two.
       </DocsBanner>
 
       <DocsExample

--- a/docs/pages/klistboxoption.vue
+++ b/docs/pages/klistboxoption.vue
@@ -1,0 +1,15 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+    <DocsPageSection
+      title="Overview"
+      anchor="#overview"
+    >
+      <p>
+        <code>KListboxOption</code> is a single option inside <code>KListbox</code>. See
+        <DocsLibraryLink component="KListbox" /> for guidance and examples.
+      </p>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>

--- a/docs/plugins/load-common-components.js
+++ b/docs/plugins/load-common-components.js
@@ -17,6 +17,7 @@ import DocsToggleButton from '~/common/DocsToggleButton';
 import DocsFilter from '~/common/DocsFilter';
 import DocsTable from '~/common/DocsTable';
 import DocsSubNav from '~/common/DocsSubNav';
+import DocsBanner from '~/common/DocsBanner';
 import VisualTestExample from '~~/jest.conf/components/VisualTestExample.vue';
 import VisualTestLayout from '~~/jest.conf/components/VisualTestLayout.vue';
 
@@ -36,6 +37,7 @@ Vue.component('DocsToggleContent', DocsToggleContent);
 Vue.component('DocsToggleButton', DocsToggleButton);
 Vue.component('DocsTable', DocsTable);
 Vue.component('DocsSubNav', DocsSubNav);
+Vue.component('DocsBanner', DocsBanner);
 
 Vue.use(VueSimpleMarkdown);
 

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -41,12 +41,14 @@ class Page {
     title, // used in side nav, page header, and document title
     isCode = false, // if true, format using <code> tag
     disabled = false, // placeholder - don't link
+    candidate = false, // if true, show a 'Candidate' badge in the side nav and page header
     keywords = [], // additional terms to match
   } = {}) {
     this.path = path;
     this.title = title;
     this.isCode = isCode;
     this.disabled = disabled;
+    this.candidate = candidate;
     this.keywords = keywords;
   }
 }
@@ -61,6 +63,7 @@ const layoutRelatedKeywords = ['grid', 'layout', 'container', 'page'];
 const tabsRelatedKeywords = ['tab', 'tabs', 'panel', 'tablist', 'tabpanel'];
 const compositionRelatedKeywords = ['composable', 'composition'];
 const cardRelatedKeywords = ['grid', 'card', 'cardgrid'];
+const listboxRelatedKeywords = ['listbox', 'option', 'select', 'multi'];
 
 export default [
   new Section({
@@ -76,6 +79,10 @@ export default [
       new Page({
         path: '/principles',
         title: 'Design principles',
+      }),
+      new Page({
+        path: '/candidate-components',
+        title: 'Candidate components',
       }),
       new Page({
         path: '/release-process',
@@ -452,6 +459,20 @@ export default [
         path: '/ktoolbar',
         title: 'KToolbar',
         isCode: true,
+      }),
+      new Page({
+        path: '/klistbox',
+        title: 'KListbox',
+        isCode: true,
+        candidate: true,
+        keywords: listboxRelatedKeywords,
+      }),
+      new Page({
+        path: '/klistboxoption',
+        title: 'KListboxOption',
+        isCode: true,
+        candidate: true,
+        keywords: listboxRelatedKeywords,
       }),
     ],
   }),

--- a/examples/KListbox/Customized.vue
+++ b/examples/KListbox/Customized.vue
@@ -10,14 +10,14 @@
       :messages="messages"
       :style="{ borderColor: $themeTokens.fineLine }"
     >
-      <template #selectAll="{ allSelected, someSelected, toggle }">
+      <template #selectAll="{ allSelected, someSelected, setAllSelected }">
         <div
           class="select-all"
           :style="{ borderColor: $themeTokens.fineLine }"
         >
           <!--
             margin reset prevents KCheckbox from taking more space
-            than necessary and aligns its correctly within the row 
+            than necessary and aligns its correctly within the row
           -->
           <KCheckbox
             label="All users"
@@ -27,7 +27,7 @@
             :checked="allSelected"
             :indeterminate="someSelected"
             :style="{ marginTop: '6px', marginBottom: '0' }"
-            @change="toggle"
+            @change="setAllSelected"
           >
             <KLabeledIcon label="All users">
               <template #icon>

--- a/examples/KListbox/Customized.vue
+++ b/examples/KListbox/Customized.vue
@@ -1,0 +1,125 @@
+<template>
+
+  <div>
+    <h4 :id="classLabel">Users</h4>
+    <KListbox
+      :id="listboxId"
+      v-model="selected"
+      class="listbox"
+      :aria-labelledby="classLabel"
+      :messages="messages"
+      :style="{ borderColor: $themeTokens.fineLine }"
+    >
+      <template #selectAll="{ allSelected, someSelected, toggle }">
+        <div
+          class="select-all"
+          :style="{ borderColor: $themeTokens.fineLine }"
+        >
+          <!--
+            margin reset prevents KCheckbox from taking more space
+            than necessary and aligns its correctly within the row 
+          -->
+          <KCheckbox
+            label="All users"
+            class="select-all-checkbox"
+            :aria-controls="listboxId"
+            :disabled="isDisabled"
+            :checked="allSelected"
+            :indeterminate="someSelected"
+            :style="{ marginTop: '6px', marginBottom: '0' }"
+            @change="toggle"
+          >
+            <KLabeledIcon label="All users">
+              <template #icon>
+                <KIcon
+                  icon="allUsers"
+                  class="option-icon"
+                  :color="isDisabled ? $themeTokens.textDisabled : $themeTokens.text"
+                />
+              </template>
+            </KLabeledIcon>
+          </KCheckbox>
+        </div>
+      </template>
+
+      <KListboxOption
+        v-for="option in options"
+        :key="option.id"
+        :value="option.id"
+        :label="option.label"
+        class="option"
+        :style="{ borderColor: $themeTokens.fineLine }"
+      >
+        <KLabeledIcon :label="option.label">
+          <template #icon>
+            <KIcon
+              :icon="option.icon"
+              class="option-icon"
+            />
+          </template>
+        </KLabeledIcon>
+      </KListboxOption>
+    </KListbox>
+    <p>
+      Selected: <code>{{ JSON.stringify(selected) }}</code>
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref, computed } from 'vue';
+
+  export default {
+    setup() {
+      const classLabel = 'customized-users';
+      const listboxId = 'customized-listbox';
+      const selected = ref(['coaches']);
+      const options = [
+        { id: 'learners', label: 'Learners', icon: 'learners' },
+        { id: 'coaches', label: 'Coaches', icon: 'coaches' },
+        { id: 'admins', label: 'Admins', icon: 'admins' },
+      ];
+      const isDisabled = computed(() => !options.length);
+      const messages = {
+        clickable: 'Options are clickable',
+        allOptionsSelected: 'All options selected',
+        allOptionsDeselected: 'No options selected',
+        optionDeselected: 'Deselected',
+      };
+      return { classLabel, listboxId, selected, options, isDisabled, messages };
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .listbox {
+    border: 1px solid;
+    border-radius: 4px;
+  }
+
+  .select-all,
+  .select-all-checkbox {
+    width: 100%;
+  }
+
+  .option,
+  .select-all {
+    padding: 8px 12px;
+    border-bottom: 1px solid;
+  }
+
+  .option:last-child {
+    border-bottom: 0;
+  }
+
+  .option-icon {
+    font-size: 1.2em;
+  }
+
+</style>

--- a/examples/KListbox/Customized.vue
+++ b/examples/KListbox/Customized.vue
@@ -6,7 +6,7 @@
       :id="listboxId"
       v-model="selected"
       class="listbox"
-      :aria-labelledby="classLabel"
+      :ariaLabelledBy="classLabel"
       :messages="messages"
       :style="{ borderColor: $themeTokens.fineLine }"
     >

--- a/examples/KListbox/Default.vue
+++ b/examples/KListbox/Default.vue
@@ -1,0 +1,50 @@
+<template>
+
+  <div>
+    <h4 :id="classLabel">Class</h4>
+    <KListbox
+      :id="listboxId"
+      v-model="selected"
+      :aria-labelledby="classLabel"
+      :messages="messages"
+    >
+      <KListboxOption
+        v-for="option in options"
+        :key="option.id"
+        :value="option.id"
+        :label="option.label"
+      />
+    </KListbox>
+    <p>
+      Selected: <code>{{ JSON.stringify(selected) }}</code>
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const classLabel = 'default-class';
+      const listboxId = 'default-listbox';
+      const selected = ref(['literature']);
+      const options = [
+        { id: 'biology', label: 'Biology' },
+        { id: 'literature', label: 'Literature' },
+        { id: 'physics', label: 'Physics' },
+      ];
+      const messages = {
+        clickable: 'Options are clickable',
+        allOptionsSelected: 'All options selected',
+        allOptionsDeselected: 'No options selected',
+        optionDeselected: 'Deselected',
+      };
+      return { classLabel, listboxId, selected, options, messages };
+    },
+  };
+
+</script>

--- a/examples/KListbox/Default.vue
+++ b/examples/KListbox/Default.vue
@@ -5,7 +5,7 @@
     <KListbox
       :id="listboxId"
       v-model="selected"
-      :aria-labelledby="classLabel"
+      :ariaLabelledBy="classLabel"
       :messages="messages"
     >
       <KListboxOption

--- a/examples/KListbox/Scrollable.vue
+++ b/examples/KListbox/Scrollable.vue
@@ -6,7 +6,7 @@
       :id="listboxId"
       v-model="selected"
       class="listbox"
-      :aria-labelledby="classLabel"
+      :ariaLabelledBy="classLabel"
       :style="{ maxHeight: '200px', borderColor: $themeTokens.fineLine }"
       :messages="messages"
     >

--- a/examples/KListbox/Scrollable.vue
+++ b/examples/KListbox/Scrollable.vue
@@ -10,7 +10,7 @@
       :style="{ maxHeight: '200px', borderColor: $themeTokens.fineLine }"
       :messages="messages"
     >
-      <template #selectAll="{ allSelected, someSelected, toggle }">
+      <template #selectAll="{ allSelected, someSelected, setAllSelected }">
         <div
           class="select-all"
           :style="{ borderColor: $themeTokens.fineLine }"
@@ -23,7 +23,7 @@
             :checked="allSelected"
             :indeterminate="someSelected"
             :style="{ marginTop: '6px', marginBottom: '0' }"
-            @change="toggle"
+            @change="setAllSelected"
           />
         </div>
       </template>

--- a/examples/KListbox/Scrollable.vue
+++ b/examples/KListbox/Scrollable.vue
@@ -1,0 +1,100 @@
+<template>
+
+  <div>
+    <h4 :id="classLabel">Class</h4>
+    <KListbox
+      :id="listboxId"
+      v-model="selected"
+      class="listbox"
+      :aria-labelledby="classLabel"
+      :style="{ maxHeight: '200px', borderColor: $themeTokens.fineLine }"
+      :messages="messages"
+    >
+      <template #selectAll="{ allSelected, someSelected, toggle }">
+        <div
+          class="select-all"
+          :style="{ borderColor: $themeTokens.fineLine }"
+        >
+          <KCheckbox
+            label="All classes"
+            class="select-all-checkbox"
+            :aria-controls="listboxId"
+            :disabled="!options.length"
+            :checked="allSelected"
+            :indeterminate="someSelected"
+            :style="{ marginTop: '6px', marginBottom: '0' }"
+            @change="toggle"
+          />
+        </div>
+      </template>
+      <KListboxOption
+        v-for="option in options"
+        :key="option.id"
+        :value="option.id"
+        :label="option.label"
+        class="option"
+        :style="{ borderColor: $themeTokens.fineLine }"
+      />
+    </KListbox>
+    <p>
+      Selected: <code>{{ JSON.stringify(selected) }}</code>
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const classLabel = 'scrollable-class';
+      const listboxId = 'scrollable-listbox';
+      const selected = ref(['literature', 'art', 'chemistry']);
+      const options = [
+        { id: 'biology', label: 'Biology' },
+        { id: 'literature', label: 'Literature' },
+        { id: 'physics', label: 'Physics' },
+        { id: 'art', label: 'Art' },
+        { id: 'chemistry', label: 'Chemistry' },
+        { id: 'geography', label: 'Geography' },
+        { id: 'history', label: 'History' },
+      ];
+      const messages = {
+        clickable: 'Options are clickable',
+        allOptionsSelected: 'All options selected',
+        allOptionsDeselected: 'No options selected',
+        optionDeselected: 'Deselected',
+      };
+      return { classLabel, listboxId, selected, options, messages };
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .listbox {
+    border: 1px solid;
+    border-radius: 4px;
+  }
+
+  .select-all,
+  .select-all-checkbox {
+    width: 100%;
+  }
+
+  .option,
+  .select-all {
+    padding: 4px 6px;
+    border-bottom: 1px solid;
+  }
+
+  .option:last-child {
+    border-bottom: 0;
+  }
+
+</style>

--- a/examples/KListbox/SelectAll.vue
+++ b/examples/KListbox/SelectAll.vue
@@ -8,7 +8,7 @@
       :ariaLabelledBy="classLabel"
       :messages="messages"
     >
-      <template #selectAll="{ allSelected, someSelected, toggle }">
+      <template #selectAll="{ allSelected, someSelected, setAllSelected }">
         <!--
           margin reset prevents KCheckbox from taking more space
           than necessary and aligns its correctly within the row
@@ -20,7 +20,7 @@
           :checked="allSelected"
           :indeterminate="someSelected"
           :style="{ marginTop: '6px', marginBottom: '0' }"
-          @change="toggle"
+          @change="setAllSelected"
         />
       </template>
       <KListboxOption

--- a/examples/KListbox/SelectAll.vue
+++ b/examples/KListbox/SelectAll.vue
@@ -1,0 +1,65 @@
+<template>
+
+  <div>
+    <h4 :id="classLabel">Class</h4>
+    <KListbox
+      :id="listboxId"
+      v-model="selected"
+      :aria-labelledby="classLabel"
+      :messages="messages"
+    >
+      <template #selectAll="{ allSelected, someSelected, toggle }">
+        <!--
+          margin reset prevents KCheckbox from taking more space
+          than necessary and aligns its correctly within the row
+        -->
+        <KCheckbox
+          label="All classes"
+          :aria-controls="listboxId"
+          :disabled="!options.length"
+          :checked="allSelected"
+          :indeterminate="someSelected"
+          :style="{ marginTop: '6px', marginBottom: '0' }"
+          @change="toggle"
+        />
+      </template>
+      <KListboxOption
+        v-for="option in options"
+        :key="option.id"
+        :value="option.id"
+        :label="option.label"
+      />
+    </KListbox>
+    <p>
+      Selected: <code>{{ JSON.stringify(selected) }}</code>
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const classLabel = 'selectall-class';
+      const listboxId = 'selectall-listbox';
+      const selected = ref(['literature']);
+      const options = [
+        { id: 'biology', label: 'Biology' },
+        { id: 'literature', label: 'Literature' },
+        { id: 'physics', label: 'Physics' },
+      ];
+      const messages = {
+        clickable: 'Options are clickable',
+        allOptionsSelected: 'All options selected',
+        allOptionsDeselected: 'No options selected',
+        optionDeselected: 'Deselected',
+      };
+      return { classLabel, listboxId, selected, options, messages };
+    },
+  };
+
+</script>

--- a/examples/KListbox/SelectAll.vue
+++ b/examples/KListbox/SelectAll.vue
@@ -5,7 +5,7 @@
     <KListbox
       :id="listboxId"
       v-model="selected"
-      :aria-labelledby="classLabel"
+      :ariaLabelledBy="classLabel"
       :messages="messages"
     >
       <template #selectAll="{ allSelected, someSelected, toggle }">

--- a/jest.conf/setup.js
+++ b/jest.conf/setup.js
@@ -7,7 +7,6 @@ import * as AphroditeNoImportant from 'aphrodite/no-important';
 import 'mock-match-media/jest-setup';
 
 import Vue from 'vue';
-import VueRouter from 'vue-router';
 import VueIntl from 'vue-intl';
 import KThemePlugin from '../lib/KThemePlugin';
 
@@ -37,7 +36,6 @@ global.it.visual = (name, fn) => {
 };
 
 // Register Vue plugins and components
-Vue.use(VueRouter);
 Vue.use(KThemePlugin);
 Vue.use(VueIntl);
 

--- a/jest.conf/visual.load-test-components.js
+++ b/jest.conf/visual.load-test-components.js
@@ -22,6 +22,7 @@ import KTableVisualTest from '~~/lib/KTable/__tests__/components/KTableVisualTes
 import CardsVisualTest from '~~/lib/cards/__tests__/components/CardsVisualTest.vue';
 import KLogoVisualTest from '~~/lib/KLogo/__tests__/components/KLogoVisualTest.vue';
 import KBreadcrumbsVisualTest from '~~/lib/KBreadcrumbs/__tests__/components/KBreadcrumbsVisualTest.vue';
+import KListboxVisualTest from '~~/lib/candidate/listbox/KListbox/__tests__/components/KListboxVisualTest.vue';
 
 // Visual tests helper components
 Vue.component('VisualTestExample', VisualTestExample);
@@ -48,3 +49,4 @@ Vue.component('KLogoVisualTest', KLogoVisualTest);
 Vue.component('KDropdownMenuVisualTest', KDropdownMenuVisualTest);
 Vue.component('KBreadcrumbsVisualTest', KBreadcrumbsVisualTest);
 Vue.component('KButtonVisualTest', KButtonVisualTest);
+Vue.component('KListboxVisualTest', KListboxVisualTest);

--- a/lib/KTable/__tests__/tab.spec.js
+++ b/lib/KTable/__tests__/tab.spec.js
@@ -1,5 +1,4 @@
 import userEvent from '@testing-library/user-event';
-import VueRouter from 'vue-router';
 import { render } from '@testing-library/vue';
 import {
   getAllRenderedCells,
@@ -69,7 +68,6 @@ describe('KTable.vue Tab Navigation', () => {
           rows,
           ...props,
         },
-        routes: new VueRouter(),
       });
 
     it('tab navigation', async () => {

--- a/lib/KTable/test-utils.js
+++ b/lib/KTable/test-utils.js
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { expect } from '@jest/globals';
-import VueRouter from 'vue-router';
 import { themePalette } from '../styles/theme';
 import KTable from './index.vue';
 
@@ -31,7 +30,6 @@ export const renderComponent = props =>
       caption: 'Test Table',
       ...props,
     },
-    routes: new VueRouter(),
   });
 
 // ---- Table content utils ----

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -43,6 +43,8 @@ import KLogo from './KLogo';
 import KRadioButtonGroup from './KRadioButtonGroup.vue';
 import KFocusTrap from './KFocusTrap.vue';
 import KToolbar from './KToolbar';
+import KListbox from './candidate/listbox/KListbox';
+import KListboxOption from './candidate/listbox/KListboxOption';
 
 import { themeTokens, themeBrand, themePalette, themeOutlineStyle } from './styles/theme';
 import globalThemeState from './styles/globalThemeState';
@@ -143,6 +145,8 @@ export default function KThemePlugin(Vue) {
   Vue.component('KIconButton', KIconButton);
   Vue.component('KImg', KImg);
   Vue.component('KLabeledIcon', KLabeledIcon);
+  Vue.component('KListbox', KListbox);
+  Vue.component('KListboxOption', KListboxOption);
   Vue.component('KLinearLoader', KLinearLoader);
   Vue.component('KLogo', KLogo);
   Vue.component('KModal', KModal);

--- a/lib/__tests__/KCheckbox.spec.js
+++ b/lib/__tests__/KCheckbox.spec.js
@@ -1,12 +1,10 @@
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import VueRouter from 'vue-router';
 import KCheckbox from '../KCheckbox';
 
 const renderComponent = (props = {}, slots = {}) =>
   render(KCheckbox, {
     props,
-    routes: new VueRouter(),
     slots,
   });
 

--- a/lib/buttons-and-links/__tests__/KButton.spec.js
+++ b/lib/buttons-and-links/__tests__/KButton.spec.js
@@ -1,12 +1,10 @@
 import { render, screen } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import VueRouter from 'vue-router';
 import KButton from '../KButton.vue';
 
 const renderComponent = (props = {}, slots = {}) =>
   render(KButton, {
     props,
-    routes: new VueRouter(),
     slots,
   });
 

--- a/lib/candidate/listbox/KListbox/__tests__/components/KListboxVisualTest.vue
+++ b/lib/candidate/listbox/KListbox/__tests__/components/KListboxVisualTest.vue
@@ -1,0 +1,26 @@
+<template>
+
+  <VisualTestLayout>
+    <VisualTestExample
+      title="Default"
+      width="400px"
+      loadExample="KListbox/Default.vue"
+    />
+    <VisualTestExample
+      title="Select all"
+      width="400px"
+      loadExample="KListbox/SelectAll.vue"
+    />
+    <VisualTestExample
+      title="Customized"
+      width="400px"
+      loadExample="KListbox/Customized.vue"
+    />
+    <VisualTestExample
+      title="Scrollable"
+      width="400px"
+      loadExample="KListbox/Scrollable.vue"
+    />
+  </VisualTestLayout>
+
+</template>

--- a/lib/candidate/listbox/KListbox/__tests__/index.spec.js
+++ b/lib/candidate/listbox/KListbox/__tests__/index.spec.js
@@ -1,0 +1,285 @@
+import { render, screen, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import KListbox from '../index.vue';
+
+const OPTIONS = [
+  { id: 'id-first', label: 'First option' },
+  { id: 'id-second', label: 'Second option' },
+  { id: 'id-third', label: 'Third option' },
+];
+
+const MESSAGES = {
+  clickable: 'Options are clickable',
+  allOptionsSelected: 'All options selected',
+  allOptionsDeselected: 'No options selected',
+  optionDeselected: 'Deselected',
+};
+
+const LISTBOX_ID = 'test-listbox';
+
+function makeListboxOptions(options = OPTIONS) {
+  return options.map(o => `<KListboxOption value="${o.id}" label="${o.label}" />`).join('');
+}
+
+const getOptionByLabel = label => screen.getByRole('option', { name: label });
+const getOptionDomId = label => getOptionByLabel(label).id;
+const getPoliteRegion = () => document.querySelector('#k-live-region [aria-live="polite"]');
+
+function renderComponent({ props = {}, slots = {}, ...rest } = {}) {
+  return render(KListbox, {
+    props: { id: LISTBOX_ID, value: [], messages: MESSAGES, ...props },
+    slots: { default: makeListboxOptions(), ...slots },
+    ...rest,
+  });
+}
+
+describe('KListbox', () => {
+  it('smoke test', async () => {
+    renderComponent();
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('warns when options are not direct children', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    renderComponent({
+      slots: {
+        default: `<span><KListboxOption value="${OPTIONS[0].id}" label="${OPTIONS[0].label}" /></span>`,
+      },
+    });
+    expect(warn).toHaveBeenCalledWith('[KListboxOption] must be a direct child of KListbox.');
+    warn.mockRestore();
+  });
+
+  it('listbox has correct role and attributes', async () => {
+    renderComponent();
+    const listbox = await screen.findByRole('listbox');
+    expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
+    expect(listbox).toHaveAttribute('tabindex', '0');
+    expect(listbox).toHaveAttribute('data-focus', 'true');
+  });
+
+  it('id, aria-label, and aria-labelledby are forwarded to the listbox element', async () => {
+    renderComponent({
+      props: { id: 'listbox-id' },
+      attrs: { 'aria-label': 'Label', 'aria-labelledby': 'label-id' },
+    });
+    const listbox = await screen.findByRole('listbox');
+    expect(listbox).toHaveAttribute('id', 'listbox-id');
+    expect(listbox).toHaveAttribute('aria-label', 'Label');
+    expect(listbox).toHaveAttribute('aria-labelledby', 'label-id');
+  });
+
+  it('listbox aria-describedby points to a visually hidden element with the correct description', async () => {
+    renderComponent();
+    const listbox = await screen.findByRole('listbox');
+    expect(listbox).toHaveAttribute('aria-describedby', `${LISTBOX_ID}-description`);
+    const description = document.getElementById(`${LISTBOX_ID}-description`);
+    expect(description).toHaveClass('visuallyhidden');
+    expect(description).toHaveTextContent(MESSAGES.clickable);
+  });
+
+  it('options have correct role and attributes', async () => {
+    renderComponent();
+    const options = await screen.findAllByRole('option');
+    expect(options.length).toBe(3);
+    options.forEach(opt => {
+      expect(opt).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('when an option is selected', () => {
+    it('emits input event with the updated value and aria-selected is updated', async () => {
+      const component = renderComponent();
+      const option = await screen.findByRole('option', { name: OPTIONS[0].label });
+      expect(option).toHaveAttribute('aria-selected', 'false');
+
+      await userEvent.click(option);
+      const emittedValue = component.emitted().input[0][0];
+
+      expect(emittedValue).toEqual([OPTIONS[0].id]);
+
+      // need to update prop to simulate v-model
+      await component.updateProps({ value: emittedValue });
+      expect(option).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('listbox focus', () => {
+    describe('if none of the options are selected before the listbox receives focus ', () => {
+      it('focus is set on the first option and there is no automatic change in the selection state', async () => {
+        renderComponent();
+        const listbox = await screen.findByRole('listbox');
+        listbox.focus();
+        await waitFor(() =>
+          expect(listbox).toHaveAttribute(
+            'aria-activedescendant',
+            getOptionDomId(OPTIONS[0].label),
+          ),
+        );
+        OPTIONS.forEach(o =>
+          expect(getOptionByLabel(o.label)).toHaveAttribute('aria-selected', 'false'),
+        );
+      });
+    });
+
+    describe('if one or more options are selected before the listbox receives focus ', () => {
+      it('focus is set on the first option in the list that is selected', async () => {
+        renderComponent({ props: { value: [OPTIONS[1].id, OPTIONS[2].id] } });
+        const listbox = await screen.findByRole('listbox');
+        listbox.focus();
+        await waitFor(() =>
+          expect(listbox).toHaveAttribute(
+            'aria-activedescendant',
+            getOptionDomId(OPTIONS[1].label),
+          ),
+        );
+      });
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    let component;
+
+    beforeEach(() => {
+      component = renderComponent();
+    });
+
+    const focusListbox = async () => {
+      const listbox = await screen.findByRole('listbox');
+      listbox.focus();
+      await waitFor(() => expect(listbox).toHaveAttribute('aria-activedescendant'));
+      return listbox;
+    };
+
+    it('Down Arrow moves focus through options in order and wraps to the first after the last', async () => {
+      const listbox = await focusListbox();
+
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[0].label));
+
+      await userEvent.keyboard('{ArrowDown}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[1].label));
+      await userEvent.keyboard('{ArrowDown}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[2].label));
+
+      // wrap
+      await userEvent.keyboard('{ArrowDown}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[0].label));
+    });
+
+    it('Up Arrow moves focus through options in reverse order and wraps to the last from the first', async () => {
+      const listbox = await focusListbox();
+
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[0].label));
+
+      // wrap
+      await userEvent.keyboard('{ArrowUp}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[2].label));
+
+      await userEvent.keyboard('{ArrowUp}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[1].label));
+      await userEvent.keyboard('{ArrowUp}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[0].label));
+    });
+
+    it('Home moves focus to the first option', async () => {
+      const listbox = await focusListbox();
+
+      // first move focus away from the first option
+      // to ensure Home is doing something
+      await userEvent.keyboard('{ArrowDown}{ArrowDown}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[2].label));
+
+      await userEvent.keyboard('{Home}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[0].label));
+    });
+
+    it('End moves focus to the last option', async () => {
+      const listbox = await focusListbox();
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[0].label));
+
+      await userEvent.keyboard('{End}');
+      expect(listbox).toHaveAttribute('aria-activedescendant', getOptionDomId(OPTIONS[2].label));
+    });
+
+    it('Space selects the focused option', async () => {
+      await focusListbox();
+      await userEvent.keyboard(' ');
+      const emittedValue = component.emitted().input[0][0];
+      expect(emittedValue).toEqual([OPTIONS[0].id]);
+      // need to update prop to simulate v-model
+      await component.updateProps({ value: emittedValue });
+      expect(getOptionByLabel(OPTIONS[0].label)).toHaveAttribute('aria-selected', 'true');
+    });
+
+    describe('Ctrl + A', () => {
+      it('selects all options', async () => {
+        await focusListbox();
+        await userEvent.keyboard('{Control>}a{/Control}');
+        const emittedValue = component.emitted().input[0][0];
+        expect(emittedValue).toEqual(OPTIONS.map(o => o.id));
+        // need to update prop to simulate v-model
+        await component.updateProps({ value: emittedValue });
+        OPTIONS.forEach(o =>
+          expect(getOptionByLabel(o.label)).toHaveAttribute('aria-selected', 'true'),
+        );
+      });
+
+      it('deselects all options if every option is already selected', async () => {
+        await component.updateProps({ value: OPTIONS.map(o => o.id) });
+        await focusListbox();
+        await userEvent.keyboard('{Control>}a{/Control}');
+        const emittedValue = component.emitted().input[0][0];
+        expect(emittedValue).toEqual([]);
+        // need to update prop to simulate v-model
+        await component.updateProps({ value: emittedValue });
+        OPTIONS.forEach(o =>
+          expect(getOptionByLabel(o.label)).toHaveAttribute('aria-selected', 'false'),
+        );
+      });
+
+      // Options may be dynamic, e.g. when KListbox used with a filter or pagination
+      describe('when there are selections outside the visible options', () => {
+        it('selects all visible options without dropping selections for hidden (e.g. filtered out) options', async () => {
+          await component.updateProps({ value: ['id-hidden'] });
+          await focusListbox();
+          await userEvent.keyboard('{Control>}a{/Control}');
+          expect(component.emitted().input[0][0]).toEqual(['id-hidden', ...OPTIONS.map(o => o.id)]);
+        });
+
+        it('deselects all visible options without dropping selections for hidden (e.g. filtered out) options', async () => {
+          await component.updateProps({
+            value: ['id-hidden', ...OPTIONS.map(o => o.id)],
+          });
+          await focusListbox();
+          await userEvent.keyboard('{Control>}a{/Control}');
+          expect(component.emitted().input[0][0]).toEqual(['id-hidden']);
+        });
+      });
+    });
+  });
+
+  describe('live region', () => {
+    it('announces deselection when an option is deselected', async () => {
+      renderComponent({ props: { value: [OPTIONS[0].id] } });
+      await screen.findAllByRole('option');
+      await userEvent.click(getOptionByLabel(OPTIONS[0].label));
+      expect(getPoliteRegion()).toHaveTextContent(MESSAGES.optionDeselected);
+    });
+
+    it('announces all options selected when Ctrl+A selects everything', async () => {
+      renderComponent();
+      const listbox = await screen.findByRole('listbox');
+      listbox.focus();
+      await userEvent.keyboard('{Control>}a{/Control}');
+      expect(getPoliteRegion()).toHaveTextContent(MESSAGES.allOptionsSelected);
+    });
+
+    it('announces no options selected when Ctrl+A deselects everything', async () => {
+      renderComponent({ props: { value: OPTIONS.map(o => o.id) } });
+      const listbox = await screen.findByRole('listbox');
+      listbox.focus();
+      await userEvent.keyboard('{Control>}a{/Control}');
+      expect(getPoliteRegion()).toHaveTextContent(MESSAGES.allOptionsDeselected);
+    });
+  });
+});

--- a/lib/candidate/listbox/KListbox/__tests__/index.spec.js
+++ b/lib/candidate/listbox/KListbox/__tests__/index.spec.js
@@ -27,7 +27,7 @@ const getPoliteRegion = () => document.querySelector('#k-live-region [aria-live=
 
 function renderComponent({ props = {}, slots = {}, ...rest } = {}) {
   return render(KListbox, {
-    props: { id: LISTBOX_ID, value: [], messages: MESSAGES, ...props },
+    props: { id: LISTBOX_ID, value: [], messages: MESSAGES, ariaLabel: 'Listbox label', ...props },
     slots: { default: makeListboxOptions(), ...slots },
     ...rest,
   });
@@ -39,6 +39,13 @@ describe('KListbox', () => {
     expect(await screen.findByRole('listbox')).toBeInTheDocument();
   });
 
+  it('warns when neither ariaLabel nor ariaLabelledBy is provided', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    renderComponent({ props: { ariaLabel: null, ariaLabelledBy: null } });
+    expect(warn).toHaveBeenCalledWith(`[KListbox] Missing 'ariaLabel' or 'ariaLabelledBy'.`);
+    warn.mockRestore();
+  });
+
   it('warns when options are not direct children', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     renderComponent({
@@ -46,7 +53,9 @@ describe('KListbox', () => {
         default: `<span><KListboxOption value="${OPTIONS[0].id}" label="${OPTIONS[0].label}" /></span>`,
       },
     });
-    expect(warn).toHaveBeenCalledWith('[KListboxOption] must be a direct child of KListbox.');
+    expect(warn).toHaveBeenCalledWith(
+      '[KListbox] KListboxOption must be a direct child of KListbox.',
+    );
     warn.mockRestore();
   });
 
@@ -58,10 +67,9 @@ describe('KListbox', () => {
     expect(listbox).toHaveAttribute('data-focus', 'true');
   });
 
-  it('id, aria-label, and aria-labelledby are forwarded to the listbox element', async () => {
+  it('id, ariaLabel, and ariaLabelledBy are applied to the listbox element', async () => {
     renderComponent({
-      props: { id: 'listbox-id' },
-      attrs: { 'aria-label': 'Label', 'aria-labelledby': 'label-id' },
+      props: { id: 'listbox-id', ariaLabel: 'Label', ariaLabelledBy: 'label-id' },
     });
     const listbox = await screen.findByRole('listbox');
     expect(listbox).toHaveAttribute('id', 'listbox-id');

--- a/lib/candidate/listbox/KListbox/__tests__/visual.spec.js
+++ b/lib/candidate/listbox/KListbox/__tests__/visual.spec.js
@@ -1,0 +1,12 @@
+import {
+  renderComponentForVisualTest,
+  takeSnapshot,
+} from '../../../../../jest.conf/visual.testUtils';
+
+describe.visual('KListbox visual tests', () => {
+  const snapshotOptions = { widths: [600] };
+  it('renders', async () => {
+    await renderComponentForVisualTest('KListboxVisualTest');
+    await takeSnapshot('KListbox visual tests', snapshotOptions);
+  });
+});

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -30,9 +30,10 @@
 
     <ul
       v-show="hasOptions"
-      v-bind="$attrs"
       :id="id"
       ref="listEl"
+      :aria-label="ariaLabel"
+      :aria-labelledby="ariaLabelledBy"
       class="k-listbox-list"
       tabindex="0"
       role="listbox"
@@ -67,8 +68,12 @@
    */
   export default {
     name: 'KListbox',
-    inheritAttrs: false,
     setup(props, { emit }) {
+      if (!props.ariaLabel && !props.ariaLabelledBy) {
+        // eslint-disable-next-line no-console
+        console.warn(`[KListbox] Missing 'ariaLabel' or 'ariaLabelledBy'.`);
+      }
+
       const { sendPoliteMessage } = useKLiveRegion();
       const instance = getCurrentInstance();
       const ariaDescribedById = `${props.id}-description`;
@@ -287,7 +292,7 @@
           ).some(el => el.parentElement !== listEl.value);
           if (hasIndirectOptions) {
             // eslint-disable-next-line no-console
-            console.warn('[KListboxOption] must be a direct child of KListbox.');
+            console.warn('[KListbox] KListboxOption must be a direct child of KListbox.');
           }
         }
       });
@@ -321,6 +326,20 @@
       value: {
         type: Array,
         required: true,
+      },
+      /**
+       * Accessible label for the listbox. Provide either this or `ariaLabelledBy`.
+       */
+      ariaLabel: {
+        type: String,
+        default: null,
+      },
+      /**
+       * ID of an element that labels the listbox. Provide either this or `ariaLabel`.
+       */
+      ariaLabelledBy: {
+        type: String,
+        default: null,
       },
       /**
        * Localized strings

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -60,6 +60,7 @@
   import { ref, computed, provide, getCurrentInstance, onMounted, nextTick } from 'vue';
   import uniq from 'lodash/uniq';
   import useKLiveRegion from '../../../composables/useKLiveRegion';
+  import useNextTickOnce from '../../../composables/useNextTickOnce';
   import { themePalette } from '../../../styles/theme';
 
   /**
@@ -85,11 +86,15 @@
       const hasOptions = computed(() => options.value.length > 0);
 
       // Registration API (consumed by KListboxOption via inject)
+      const { once: onceSort } = useNextTickOnce();
+
       function registerOption(option) {
         options.value.push(option);
         // After an option mounts, reorder options state to match DOM order
         // so that keyboard navigation and focus behave as expected
-        nextTick(() => {
+        onceSort(() => {
+          // just in case the tick runs after the listbox unmounted
+          if (!listEl.value) return;
           const orderedIds = Array.from(listEl.value.querySelectorAll('[role="option"]')).map(
             el => el.id,
           );

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -1,0 +1,384 @@
+<template>
+
+  <div class="k-listbox">
+    <p
+      :id="ariaDescribedById"
+      class="visuallyhidden"
+    >
+      {{ messages.clickable }}
+    </p>
+
+    <!--
+      .self prevents the div click from firing when the slotted
+      checkbox is clicked (otherwise click would cause double-toggle, resulting in no change))
+    -->
+    <div
+      v-if="$scopedSlots.selectAll"
+      class="k-listbox-select-all"
+      :class="$computedClass(selectAllStyles)"
+      :style="{ backgroundColor: $themeTokens.surface }"
+      @click.self="changeSelectAll(!allSelected)"
+    >
+      <!-- @slot Scoped slot for implementing select all functionality -->
+      <slot
+        name="selectAll"
+        :allSelected="allSelected"
+        :someSelected="someSelected"
+        :toggle="changeSelectAll"
+      ></slot>
+    </div>
+
+    <ul
+      v-show="hasOptions"
+      v-bind="$attrs"
+      :id="id"
+      ref="listEl"
+      class="k-listbox-list"
+      tabindex="0"
+      role="listbox"
+      data-focus="true"
+      aria-multiselectable="true"
+      :style="{ outline: 'none' }"
+      :aria-describedby="ariaDescribedById"
+      :aria-activedescendant="focusedOptionId || undefined"
+      @focus="onListFocus"
+      @blur="onListBlur"
+      @mousedown="onListMousedown"
+      @keydown="onListKeydown"
+    >
+      <!-- @slot For `KListboxOption`(s) -->
+      <slot></slot>
+    </ul>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref, computed, provide, getCurrentInstance, onMounted, nextTick } from 'vue';
+  import uniq from 'lodash/uniq';
+  import useKLiveRegion from '../../../composables/useKLiveRegion';
+  import { themePalette } from '../../../styles/theme';
+
+  /**
+   * Representation of the APG listbox pattern
+   * with several additional enhancements
+   */
+  export default {
+    name: 'KListbox',
+    inheritAttrs: false,
+    setup(props, { emit }) {
+      const { sendPoliteMessage } = useKLiveRegion();
+      const instance = getCurrentInstance();
+      const ariaDescribedById = `${props.id}-description`;
+      const options = ref([]);
+      const focusedValue = ref(null);
+      const isKeyboardFocus = ref(false);
+      const listEl = ref(null);
+
+      const hasOptions = computed(() => options.value.length > 0);
+
+      // Registration API (consumed by KListboxOption via inject)
+      function registerOption(option) {
+        options.value.push(option);
+        // After an option mounts, reorder options state to match DOM order
+        // so that keyboard navigation and focus behave as expected
+        nextTick(() => {
+          const orderedIds = Array.from(listEl.value.querySelectorAll('[role="option"]')).map(
+            el => el.id,
+          );
+          options.value.sort((a, b) => orderedIds.indexOf(a.id) - orderedIds.indexOf(b.id));
+        });
+      }
+
+      function unregisterOption(option) {
+        options.value = options.value.filter(o => o.id !== option.id);
+        if (focusedValue.value === option.value) {
+          focusedValue.value = null;
+        }
+      }
+
+      function isSelected(value) {
+        return props.value.includes(value);
+      }
+
+      function emitInput(newValue) {
+        emit('input', newValue);
+      }
+
+      function toggleOption(value) {
+        if (isSelected(value)) {
+          emitInput(props.value.filter(v => v !== value));
+          sendPoliteMessage(props.messages.optionDeselected);
+        } else {
+          emitInput([...props.value, value]);
+        }
+
+        if (focusedValue.value !== value) {
+          setFocus(value);
+        }
+      }
+
+      function selectAllOptions() {
+        // Options may be dynamic, e.g. when KListbox used with a filter
+        // or pagination => preserve selections outside the visible options
+        // by merging previously selected values with all visible options
+        const allValues = uniq([...props.value, ...options.value.map(o => o.value)]);
+        emitInput(allValues);
+        sendPoliteMessage(props.messages.allOptionsSelected);
+      }
+
+      function deselectAllOptions() {
+        // Options may be dynamic, e.g. when KListbox used with a filter
+        // or pagination => preserve selections outside the visible
+        // options by removing only values for currently visible options
+        const optionValues = new Set(options.value.map(o => o.value));
+        const remainingValues = props.value.filter(v => !optionValues.has(v));
+        emitInput(remainingValues);
+        sendPoliteMessage(props.messages.allOptionsDeselected);
+      }
+
+      const allSelected = computed(
+        () => hasOptions.value && options.value.every(o => isSelected(o.value)),
+      );
+
+      const someSelected = computed(
+        () => !allSelected.value && options.value.some(o => isSelected(o.value)),
+      );
+
+      function changeSelectAll(checked) {
+        if (!hasOptions.value) return;
+        if (checked) {
+          selectAllOptions();
+        } else {
+          deselectAllOptions();
+        }
+      }
+
+      const selectAllStyles = computed(() => ({
+        ':hover': {
+          backgroundColor: hasOptions.value ? themePalette().grey.v_100 : 'transparent',
+        },
+        cursor: hasOptions.value ? 'pointer' : 'default',
+      }));
+
+      const focusedOptionId = computed(() => {
+        const focused = options.value.find(o => o.value === focusedValue.value);
+        return focused ? focused.id : null;
+      });
+
+      function isFocused(value) {
+        return focusedValue.value === value;
+      }
+
+      function isFocusVisible(value) {
+        return focusedValue.value === value && isKeyboardFocus.value;
+      }
+
+      function optionValueAt(index) {
+        return options.value[index].value;
+      }
+
+      function setFocus(value) {
+        focusedValue.value = value;
+        nextTick(() => {
+          const option = options.value.find(o => o.value === value);
+          if (!option) return;
+          if (instance.proxy.$inputModality === 'keyboard') {
+            const optionElement = document.getElementById(option.id);
+            if (optionElement) {
+              optionElement.scrollIntoView({
+                block: 'nearest',
+                inline: 'nearest',
+              });
+            }
+          }
+        });
+      }
+
+      function moveFocusBy(delta) {
+        const optionsCount = options.value.length;
+        const currentIndex = options.value.findIndex(o => o.value === focusedValue.value);
+        // Modulo to wrap for circular navigation
+        const newIndex = (currentIndex + delta + optionsCount) % optionsCount;
+        setFocus(optionValueAt(newIndex));
+      }
+
+      function onListFocus() {
+        if (!hasOptions.value) return;
+        // Don't override focus when an option was clicked directly with mouse
+        if (focusedValue.value !== null) return;
+        isKeyboardFocus.value = instance.proxy.$inputModality === 'keyboard';
+        // Focus the first selected option if any, otherwise the first available one
+        const firstSelected = options.value.find(o => isSelected(o.value));
+        if (firstSelected) {
+          setFocus(firstSelected.value);
+        } else {
+          setFocus(optionValueAt(0));
+        }
+      }
+
+      function onListBlur() {
+        focusedValue.value = null;
+        isKeyboardFocus.value = false;
+      }
+
+      function onListMousedown() {
+        isKeyboardFocus.value = false;
+      }
+
+      function onListKeydown(event) {
+        isKeyboardFocus.value = true;
+        if (!hasOptions.value) return;
+        const { key } = event;
+
+        switch (key) {
+          case 'ArrowDown':
+            moveFocusBy(1);
+            break;
+          case 'ArrowUp':
+            moveFocusBy(-1);
+            break;
+          case 'Home':
+            setFocus(optionValueAt(0));
+            break;
+          case 'End':
+            setFocus(optionValueAt(options.value.length - 1));
+            break;
+          case ' ':
+            toggleOption(focusedValue.value);
+            break;
+          // Ctrl + A for select all
+          case 'a':
+          case 'A':
+            if (!event.ctrlKey && !event.metaKey) {
+              return;
+            }
+            if (allSelected.value) {
+              deselectAllOptions();
+            } else {
+              selectAllOptions();
+            }
+            break;
+          default:
+            // Early return for unsupported keys so that
+            // we don't prevent default behavior
+            return;
+        }
+
+        event.preventDefault();
+      }
+
+      provide('klistbox', {
+        registerOption,
+        unregisterOption,
+        isSelected,
+        isFocused,
+        isFocusVisible,
+        toggleOption,
+      });
+
+      onMounted(() => {
+        // Warn if any KListboxOption is not a direct child of the listbox element
+        if (process.env.NODE_ENV !== 'production') {
+          const hasIndirectOptions = Array.from(
+            listEl.value.querySelectorAll('[role="option"]'),
+          ).some(el => el.parentElement !== listEl.value);
+          if (hasIndirectOptions) {
+            // eslint-disable-next-line no-console
+            console.warn('[KListboxOption] must be a direct child of KListbox.');
+          }
+        }
+      });
+
+      return {
+        listEl,
+        hasOptions,
+        ariaDescribedById,
+        focusedOptionId,
+        allSelected,
+        someSelected,
+        selectAllStyles,
+        changeSelectAll,
+        onListFocus,
+        onListBlur,
+        onListMousedown,
+        onListKeydown,
+      };
+    },
+    props: {
+      /**
+       * Unique listbox ID
+       */
+      id: {
+        type: String,
+        required: true,
+      },
+      /**
+       * Array of currently selected option values
+       */
+      value: {
+        type: Array,
+        required: true,
+      },
+      /**
+       * Localized strings
+       */
+      messages: {
+        type: Object,
+        required: true,
+        validator(messages) {
+          const requiredKeys = [
+            'clickable',
+            'allOptionsSelected',
+            'allOptionsDeselected',
+            'optionDeselected',
+          ];
+          const missing = requiredKeys.filter(
+            key => typeof messages[key] !== 'string' || messages[key].length === 0,
+          );
+          if (missing.length) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[KListbox] 'messages' prop is missing required string keys: ${missing.join(', ')}`,
+            );
+            return false;
+          }
+          return true;
+        },
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .k-listbox {
+    // Flex column makes .k-listbox-list its own independent scroll
+    // container, keeping the select-all row outside the scrollable area.
+    // The alternative approach with sticky positioning results in worse
+    // experience: (1) when the first selected option is already in view,
+    // tabbing into the listbox unnecessarily scrolls the selected option to the
+    // top and pushes the preceding options behind the header; (2) the vertical
+    // scrollbar spans over the select all row, which doesn't correspond to
+    // the actual scroll behavior where only the list options scroll
+    display: flex;
+    flex-direction: column;
+  }
+
+  .k-listbox-select-all {
+    display: flex;
+    align-items: center;
+  }
+
+  .k-listbox-list {
+    padding: 0;
+    margin: 0;
+    overflow: auto;
+    list-style: none;
+  }
+
+</style>

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -24,7 +24,7 @@
         name="selectAll"
         :allSelected="allSelected"
         :someSelected="someSelected"
-        :toggle="changeSelectAll"
+        :setAllSelected="changeSelectAll"
       ></slot>
     </div>
 

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -44,7 +44,6 @@
       :aria-activedescendant="focusedOptionId || undefined"
       @focus="onListFocus"
       @blur="onListBlur"
-      @mousedown="onListMousedown"
       @keydown="onListKeydown"
     >
       <!-- @slot For `KListboxOption`(s) -->
@@ -80,7 +79,6 @@
       const ariaDescribedById = `${props.id}-description`;
       const options = ref([]);
       const focusedValue = ref(null);
-      const isKeyboardFocus = ref(false);
       const listEl = ref(null);
 
       const hasOptions = computed(() => options.value.length > 0);
@@ -182,10 +180,6 @@
         return focusedValue.value === value;
       }
 
-      function isFocusVisible(value) {
-        return focusedValue.value === value && isKeyboardFocus.value;
-      }
-
       function optionValueAt(index) {
         return options.value[index].value;
       }
@@ -219,7 +213,6 @@
         if (!hasOptions.value) return;
         // Don't override focus when an option was clicked directly with mouse
         if (focusedValue.value !== null) return;
-        isKeyboardFocus.value = instance.proxy.$inputModality === 'keyboard';
         // Focus the first selected option if any, otherwise the first available one
         const firstSelected = options.value.find(o => isSelected(o.value));
         if (firstSelected) {
@@ -231,15 +224,9 @@
 
       function onListBlur() {
         focusedValue.value = null;
-        isKeyboardFocus.value = false;
-      }
-
-      function onListMousedown() {
-        isKeyboardFocus.value = false;
       }
 
       function onListKeydown(event) {
-        isKeyboardFocus.value = true;
         if (!hasOptions.value) return;
         const { key } = event;
 
@@ -285,7 +272,6 @@
         unregisterOption,
         isSelected,
         isFocused,
-        isFocusVisible,
         toggleOption,
       });
 
@@ -313,7 +299,6 @@
         changeSelectAll,
         onListFocus,
         onListBlur,
-        onListMousedown,
         onListKeydown,
       };
     },

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -1,0 +1,103 @@
+<template>
+
+  <li
+    :id="optionId"
+    role="option"
+    class="k-listbox-option"
+    :class="$computedClass(rowStyles)"
+    :aria-selected="String(isSelected)"
+    @click="onClick"
+  >
+    <!--
+      margin reset prevents KCheckbox from taking more space
+      than necessary and aligns its correctly within the row
+    -->
+    <KCheckbox
+      presentational
+      :style="{ marginTop: '6px', marginBottom: '0' }"
+      :checked="isSelected"
+      :label="label"
+    >
+      <!-- @slot For customizing option label -->
+      <slot></slot>
+    </KCheckbox>
+  </li>
+
+</template>
+
+
+<script>
+
+  import { computed, inject, onMounted, onBeforeUnmount } from 'vue';
+  import { themePalette, themeOutlineStyle, themeTokens } from '../../../styles/theme';
+
+  let optionCount = 0;
+
+  /**
+   * Single option inside KListbox
+   */
+  export default {
+    name: 'KListboxOption',
+    setup(props) {
+      const listbox = inject('klistbox');
+
+      const uid = optionCount++;
+      const optionId = `klistbox-option-${uid}`;
+
+      onMounted(() => listbox.registerOption({ id: optionId, value: props.value }));
+
+      onBeforeUnmount(() => listbox.unregisterOption({ id: optionId, value: props.value }));
+
+      const isSelected = computed(() => listbox.isSelected(props.value));
+
+      const isFocusVisible = computed(() => listbox.isFocusVisible(props.value));
+
+      const rowStyles = computed(() => ({
+        backgroundColor: themeTokens().surface,
+        ':hover': {
+          backgroundColor: themePalette().grey.v_100,
+        },
+        ...(isFocusVisible.value ? { ...themeOutlineStyle(), outlineOffset: '-3px' } : {}),
+      }));
+
+      function onClick() {
+        listbox.toggleOption(props.value);
+      }
+
+      return {
+        optionId,
+        isSelected,
+        rowStyles,
+        onClick,
+      };
+    },
+    props: {
+      /**
+       * A unique value identifying the option within a listbox
+       */
+      value: {
+        type: [String, Number],
+        required: true,
+      },
+      /**
+       * Option label also used as the accessible name
+       */
+      label: {
+        type: String,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .k-listbox-option {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+  }
+
+</style>

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -5,6 +5,7 @@
     role="option"
     class="k-listbox-option"
     :class="$computedClass(rowStyles)"
+    :style="isFocused ? { ...$coreOutline, outlineOffset: '-3px' } : {}"
     :aria-selected="String(isSelected)"
     @click="onClick"
   >
@@ -29,7 +30,7 @@
 <script>
 
   import { computed, inject, onMounted, onBeforeUnmount } from 'vue';
-  import { themePalette, themeOutlineStyle, themeTokens } from '../../../styles/theme';
+  import { themePalette, themeTokens } from '../../../styles/theme';
 
   let optionCount = 0;
 
@@ -50,14 +51,13 @@
 
       const isSelected = computed(() => listbox.isSelected(props.value));
 
-      const isFocusVisible = computed(() => listbox.isFocusVisible(props.value));
+      const isFocused = computed(() => listbox.isFocused(props.value));
 
       const rowStyles = computed(() => ({
         backgroundColor: themeTokens().surface,
         ':hover': {
           backgroundColor: themePalette().grey.v_100,
         },
-        ...(isFocusVisible.value ? { ...themeOutlineStyle(), outlineOffset: '-3px' } : {}),
       }));
 
       function onClick() {
@@ -67,6 +67,7 @@
       return {
         optionId,
         isSelected,
+        isFocused,
         rowStyles,
         onClick,
       };

--- a/lib/composables/useNextTickOnce.js
+++ b/lib/composables/useNextTickOnce.js
@@ -1,0 +1,25 @@
+import { nextTick } from 'vue';
+
+/**
+ * Returns an `once(fn)` function that defers `fn`
+ * to the next Vue tick. If called again before
+ * the tick fires, the call is ignored. After the
+ * tick, the lock resets so future calls can schedule
+ * again. Useful for preventing from multiple calls
+ * of the same function in the same tick.
+ */
+export default function useNextTickOnce() {
+  let isPending = false;
+
+  function once(fn) {
+    if (isPending) return;
+
+    isPending = true;
+    nextTick(() => {
+      fn();
+      isPending = false;
+    });
+  }
+
+  return { once };
+}


### PR DESCRIPTION
## Description

Moves our implementation of APG listbox pattern from Kolibri's [SelectableList.vue](https://github.com/learningequality/kolibri/blob/develop/kolibri/plugins/facility/frontend/views/common/SelectableList.vue#L27-L90) to `candidate/KListbox` and `candidate/KListboxOption`. Part of this work is refactoring `SelectableList` to use `KListbox` (https://github.com/learningequality/kolibri/pull/14695) 

Additionally
- New documentation pages & componnets (banners, badges) to set up KDS for candidate components
- Cleans up unnecessary global Jest router setup and router imports in tests (it seems that the global setup caused having to import router in components that didn't even use routing)

### Issue addressed

- Encapsulates APG `listbox` pattern
- Prepares KDS for multi-select dropdown implementation - multi-select dropdown is a combination of `combobox` and `listbox` pattern. Abstracting `listbox` pattern into a standalone component prevents from having to develop/QA/maintain the very same (and rather nuanced) a11y pattern multiple times. `KListbox` + `KListboxOption` will be used as a standalone `listbox` (as in the original Kolibri use-case) as well as under the hood of the new multi-select dropdown.

## Steps to test

**Visual tests**

Should look same as docs examples. Please preview & confirm, I can't access the build.

**Preview new documentation pages & examples**
- https://deploy-preview-1247--kolibri-design-system.netlify.app/klistbox
- https://deploy-preview-1247--kolibri-design-system.netlify.app/klistboxoption
- https://deploy-preview-1247--kolibri-design-system.netlify.app/candidate-components

**Do QA in Kolibri**

https://github.com/learningequality/kolibri/pull/14695

## AI usage

I had Claude to generate a draft according to a detailed specification I wrote and the original Kolibri's `SelectableList.vue` implementation. Then went through all places and refined in collaboration with Claude. Did final self-review of the whole diff.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Add KListbox and KListboxOption
  - **Products impact:** New component
  - **Addresses:**-
  - **Components:** KListbox, KListboxOption
  - **Breaking:** No
  - **Impacts a11y:** yes
  - **Guidance:** -

  - **Description:**  Cleans up unnecessary global Jest router setup and router imports in tests
  - **Products impact:** None
  - **Addresses:**-
  - **Components:** -
  - **Breaking:** No
  - **Impacts a11y:** -
  - **Guidance:** -
  
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
