### PR TITLE
Add 'opened' to pull-request-target trigger types

### DIFF
--- a/.github/workflows/call-pull-request-target.yml
+++ b/.github/workflows/call-pull-request-target.yml
@@ -1,7 +1,7 @@
 name: Handle pull request events
 on:
   pull_request_target:
-    types: [review_requested, labeled]
+    types: [opened, review_requested, labeled]
 jobs:
   call-workflow:
     name: Call shared workflow


### PR DESCRIPTION
Extends the existing caller to listen for `opened` events so the new dependabot-reviewer handler fires on dependabot PRs.

Pairs with learningequality/.github#78.

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Listen for `opened` events in the shared pull-request-target caller workflow, so the new dependabot reviewer handler in `learningequality/.github` fires on dependabot PR open.
  - **Products impact:** none
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## AI usage

I used Claude Code to design the workflow changes — extending the existing pull-request-target reusable pattern with a new dependabot-reviewer handler and rolling out the caller across our repos. I reviewed the diff manually before opening each PR.