### PR TITLE
Implement initial file structure and sub components for KMultiselect

### DIFF
--- a/docs/pages/kmultiselect.vue
+++ b/docs/pages/kmultiselect.vue
@@ -1,0 +1,95 @@
+<template>
+
+  <DocsPageTemplate>
+    <DocsPageSection
+      title="Overview"
+      anchor="#overview"
+    >
+      <p>
+        <code>KMultiselect</code> is a candidate component under development. It allows users to
+        select multiple options from a list or dropdown, displaying the selected items as tags or
+        chips.
+      </p>
+      <p>
+        For now, this page demonstrates <code>KChip</code>, which is used to render the individual
+        selected items.
+      </p>
+    </DocsPageSection>
+
+    <DocsPageSection
+      title="KChip"
+      anchor="#kchip"
+    >
+      <p>
+        <code>KChip</code> represents a selected option or tag. It can be standard (non-closeable),
+        closeable, or disabled, and supports custom accessible labels.
+      </p>
+
+      <h3>Standard Chips (Non-closeable)</h3>
+      <DocsShow>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip text="Mathematics" />
+          <KChip text="English Language Arts" />
+        </div>
+      </DocsShow>
+
+      <h3>Closeable Chips</h3>
+      <DocsShow>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip
+            text="Science"
+            close
+          />
+          <KChip
+            text="Social Studies"
+            close
+          />
+        </div>
+      </DocsShow>
+
+      <h3>Disabled Chips</h3>
+      <DocsShow>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip
+            text="History (Disabled)"
+            disabled
+          />
+          <KChip
+            text="Geography (Disabled & Closeable)"
+            close
+            disabled
+          />
+        </div>
+      </DocsShow>
+
+      <h3>Custom Close Accessible Label (removeLabel)</h3>
+      <DocsShow>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip
+            text="Custom Action"
+            close
+            removeLabel="Delete Custom Action tag"
+          />
+        </div>
+      </DocsShow>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>
+
+
+<script>
+
+  import KChip from '../../lib/candidate/multiselect/KChip/index.vue';
+
+  export default {
+    name: 'KMultiselectDocs',
+    components: {
+      KChip,
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/docs/pages/playground/index.vue
+++ b/docs/pages/playground/index.vue
@@ -8,85 +8,21 @@
 
     Please do not commit your local updates of this file.
   -->
-  <div style="padding: 40px; font-family: sans-serif">
-    <h1 style="margin-bottom: 8px">KChip Playground</h1>
-    <p style="margin-bottom: 32px; color: #666666">
-      Testing all states and variations of the candidate <code>KChip</code> component.
-    </p>
+  <div style="padding: 24px">
+    <!-- 
+      Example: Uncomment lines bellow, change something
+      in lib/KBreadcrumbs.vue and see the updates reflected
+      on this page
+    -->
+    <!-- <KBreadcrumbs
+      :items="[
+        { text: 'Global Digital Library', link: { path: '#' } },
+        { text: 'English', link: { path: '#' } },
+        { text: 'Level 2 ', link: { path: '#' } },
+      ]"
+    /> -->
 
-    <!-- Interactive Event Logger -->
-    <div
-      v-if="eventLog.length"
-      style="
-  padding: 12px;
-  margin-bottom: 24px;
-  font-family: monospace;
-  background-color: #f0f0f0;
-  border-left: 4px solid #0077c2;
-  border-radius: 4px;
-      "
-    >
-      <strong>Latest Event:</strong> {{ eventLog }}
-    </div>
-
-    <!-- Playground Grid -->
-    <div style="display: flex; flex-direction: column; gap: 24px">
-      <!-- State 1: Basic Chips -->
-      <section>
-        <h3 style="margin-bottom: 12px">Standard Chips (Non-closeable)</h3>
-        <div style="display: flex; gap: 12px; align-items: center">
-          <KChip text="Mathematics" />
-          <KChip text="English Language Arts" />
-        </div>
-      </section>
-
-      <!-- State 2: Closeable Chips -->
-      <section>
-        <h3 style="margin-bottom: 12px">Closeable Chips</h3>
-        <div style="display: flex; gap: 12px; align-items: center">
-          <KChip
-            text="Science"
-            close
-            @close="logEvent('Science chip closed')"
-          />
-          <KChip
-            text="Social Studies"
-            close
-            @close="logEvent('Social Studies chip closed')"
-          />
-        </div>
-      </section>
-
-      <!-- State 3: Disabled Chips -->
-      <section>
-        <h3 style="margin-bottom: 12px">Disabled Chips</h3>
-        <div style="display: flex; gap: 12px; align-items: center">
-          <KChip
-            text="History (Disabled)"
-            disabled
-          />
-          <KChip
-            text="Geography (Disabled & Closeable)"
-            close
-            disabled
-            @close="logEvent('This should not trigger!')"
-          />
-        </div>
-      </section>
-
-      <!-- State 4: Custom Accessible Label -->
-      <section>
-        <h3 style="margin-bottom: 12px">Custom Close Accessible Label (removeLabel)</h3>
-        <div style="display: flex; gap: 12px; align-items: center">
-          <KChip
-            text="Custom Action"
-            close
-            removeLabel="Delete Custom Action tag"
-            @close="logEvent('Custom Action chip closed')"
-          />
-        </div>
-      </section>
-    </div>
+    <!-- Play around with your component here: -->
   </div>
 
 </template>
@@ -94,23 +30,17 @@
 
 <script>
 
-  import KChip from '../../../lib/candidate/multiselect/KChip/index.vue';
-
+  /*
+    Playground is a Vue component too,
+    so you can also use `data`, `methods`, etc.
+    as usual if helpful
+  */
   export default {
     name: 'Playground',
-    components: {
-      KChip,
-    },
     data() {
-      return {
-        eventLog: '',
-      };
+      return {};
     },
-    methods: {
-      logEvent(msg) {
-        this.eventLog = `${msg} at ${new Date().toLocaleTimeString()}`;
-      },
-    },
+    methods: {},
   };
 
 </script>

--- a/docs/pages/playground/index.vue
+++ b/docs/pages/playground/index.vue
@@ -8,21 +8,85 @@
 
     Please do not commit your local updates of this file.
   -->
-  <div style="padding: 24px">
-    <!-- 
-      Example: Uncomment lines bellow, change something
-      in lib/KBreadcrumbs.vue and see the updates reflected
-      on this page
-    -->
-    <!-- <KBreadcrumbs
-      :items="[
-        { text: 'Global Digital Library', link: { path: '#' } },
-        { text: 'English', link: { path: '#' } },
-        { text: 'Level 2 ', link: { path: '#' } },
-      ]"
-    /> -->
+  <div style="padding: 40px; font-family: sans-serif">
+    <h1 style="margin-bottom: 8px">KChip Playground</h1>
+    <p style="margin-bottom: 32px; color: #666666">
+      Testing all states and variations of the candidate <code>KChip</code> component.
+    </p>
 
-    <!-- Play around with your component here: -->
+    <!-- Interactive Event Logger -->
+    <div
+      v-if="eventLog.length"
+      style="
+  padding: 12px;
+  margin-bottom: 24px;
+  font-family: monospace;
+  background-color: #f0f0f0;
+  border-left: 4px solid #0077c2;
+  border-radius: 4px;
+      "
+    >
+      <strong>Latest Event:</strong> {{ eventLog }}
+    </div>
+
+    <!-- Playground Grid -->
+    <div style="display: flex; flex-direction: column; gap: 24px">
+      <!-- State 1: Basic Chips -->
+      <section>
+        <h3 style="margin-bottom: 12px">Standard Chips (Non-closeable)</h3>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip text="Mathematics" />
+          <KChip text="English Language Arts" />
+        </div>
+      </section>
+
+      <!-- State 2: Closeable Chips -->
+      <section>
+        <h3 style="margin-bottom: 12px">Closeable Chips</h3>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip
+            text="Science"
+            close
+            @close="logEvent('Science chip closed')"
+          />
+          <KChip
+            text="Social Studies"
+            close
+            @close="logEvent('Social Studies chip closed')"
+          />
+        </div>
+      </section>
+
+      <!-- State 3: Disabled Chips -->
+      <section>
+        <h3 style="margin-bottom: 12px">Disabled Chips</h3>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip
+            text="History (Disabled)"
+            disabled
+          />
+          <KChip
+            text="Geography (Disabled & Closeable)"
+            close
+            disabled
+            @close="logEvent('This should not trigger!')"
+          />
+        </div>
+      </section>
+
+      <!-- State 4: Custom Accessible Label -->
+      <section>
+        <h3 style="margin-bottom: 12px">Custom Close Accessible Label (removeLabel)</h3>
+        <div style="display: flex; gap: 12px; align-items: center">
+          <KChip
+            text="Custom Action"
+            close
+            removeLabel="Delete Custom Action tag"
+            @close="logEvent('Custom Action chip closed')"
+          />
+        </div>
+      </section>
+    </div>
   </div>
 
 </template>
@@ -30,17 +94,23 @@
 
 <script>
 
-  /*
-    Playground is a Vue component too,
-    so you can also use `data`, `methods`, etc.
-    as usual if helpful
-  */
+  import KChip from '../../../lib/candidate/multiselect/KChip/index.vue';
+
   export default {
     name: 'Playground',
-    data() {
-      return {};
+    components: {
+      KChip,
     },
-    methods: {},
+    data() {
+      return {
+        eventLog: '',
+      };
+    },
+    methods: {
+      logEvent(msg) {
+        this.eventLog = `${msg} at ${new Date().toLocaleTimeString()}`;
+      },
+    },
   };
 
 </script>

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -64,6 +64,7 @@ const tabsRelatedKeywords = ['tab', 'tabs', 'panel', 'tablist', 'tabpanel'];
 const compositionRelatedKeywords = ['composable', 'composition'];
 const cardRelatedKeywords = ['grid', 'card', 'cardgrid'];
 const listboxRelatedKeywords = ['listbox', 'option', 'select', 'multi'];
+const multiselectRelatedKeywords = ['multiselect', 'chip', 'tag', 'option', 'select', 'multi'];
 
 export default [
   new Section({
@@ -473,6 +474,13 @@ export default [
         isCode: true,
         candidate: true,
         keywords: listboxRelatedKeywords,
+      }),
+      new Page({
+        path: '/kmultiselect',
+        title: 'KMultiselect',
+        isCode: true,
+        candidate: true,
+        keywords: multiselectRelatedKeywords,
       }),
     ],
   }),

--- a/lib/candidate/multiselect/KChip/__tests__/index.spec.js
+++ b/lib/candidate/multiselect/KChip/__tests__/index.spec.js
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import KChip from '../index.vue';
+
+function renderComponent(props = {}) {
+  return render(KChip, {
+    props: { text: 'Test Chip', close: false, ...props },
+  });
+}
+
+describe('KChip', () => {
+  it('renders with text prop', () => {
+    renderComponent({ text: 'Mathematics' });
+    expect(screen.getByText('Mathematics')).toBeInTheDocument();
+  });
+
+  it('renders slot content when provided', () => {
+    render(KChip, { slots: { default: '<strong>Custom label</strong>' } });
+    expect(screen.getByText('Custom label')).toBeInTheDocument();
+  });
+
+  it('renders close button when close prop is true', () => {
+    renderComponent({ close: true });
+    expect(screen.getByRole('button', { name: 'Remove Test Chip' })).toBeInTheDocument();
+  });
+
+  it('does not render close button when close prop is false', () => {
+    renderComponent({ close: false });
+    expect(screen.queryByRole('button', { name: 'Remove Test Chip' })).not.toBeInTheDocument();
+  });
+
+  it('emits close event when close button is clicked', async () => {
+    const { emitted } = renderComponent({ close: true });
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Test Chip' }));
+    expect(emitted().close).toHaveLength(1);
+  });
+
+  it('close button is disabled when disabled prop is true', () => {
+    renderComponent({ close: true, disabled: true });
+    expect(screen.getByRole('button', { name: 'Remove Test Chip' })).toBeDisabled();
+  });
+
+  it('does not emit close when disabled', () => {
+    const { emitted } = renderComponent({ close: true, disabled: true });
+    screen.getByRole('button', { name: 'Remove Test Chip' }).click();
+    expect(emitted().close).toBeUndefined();
+  });
+
+  it('uses removeLabel prop as the close button accessible label', () => {
+    renderComponent({ close: true, removeLabel: 'Delete Test Chip' });
+    expect(screen.getByRole('button', { name: 'Delete Test Chip' })).toBeInTheDocument();
+  });
+});

--- a/lib/candidate/multiselect/KChip/index.vue
+++ b/lib/candidate/multiselect/KChip/index.vue
@@ -1,0 +1,230 @@
+<template>
+
+  <div
+    class="k-chip"
+    :class="{
+      'k-chip-closeable': close,
+      'k-chip-disabled': disabled,
+    }"
+    :style="chipStyles"
+  >
+    <div class="k-chip-content">
+      <div class="k-chip-text">
+        <slot>
+          {{ text }}
+        </slot>
+      </div>
+
+      <button
+        v-if="close"
+        class="k-chip-close-button"
+        :class="closeButtonClass"
+        :aria-label="computedRemoveLabel"
+        type="button"
+        data-testid="k-chip-close"
+        :disabled="disabled || undefined"
+        @click.stop="handleClose"
+      >
+        <span
+          class="k-chip-icon-wrap"
+          aria-hidden="true"
+        >
+          <KIcon
+            icon="delete"
+            :color="iconOutlineColor"
+            class="k-chip-icon k-chip-icon-outline"
+          />
+          <KIcon
+            icon="delete"
+            :color="iconFilledColor"
+            class="k-chip-icon k-chip-icon-filled"
+          />
+        </span>
+      </button>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KChip',
+
+    props: {
+      /**
+       * Text label displayed inside the chip.
+       * Ignored when the default slot is used.
+       */
+      text: {
+        type: String,
+        default: '',
+      },
+
+      /**
+       * When true, renders a remove/close button on the trailing end of the chip.
+       */
+      close: {
+        type: Boolean,
+        default: false,
+      },
+
+      /**
+       * Disables the chip and makes the close button non-interactive.
+       */
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
+
+      /**
+       * Accessible label for the close button.
+       * Defaults to "Remove <text>" when not provided.
+       * Pass a translated string when deploying in non-English contexts.
+       */
+      removeLabel: {
+        type: String,
+        default: null,
+      },
+    },
+
+    emits: ['close'],
+
+    computed: {
+      chipStyles() {
+        if (this.disabled) {
+          return {
+            backgroundColor: this.$themePalette.grey.v_100,
+            color: this.$themeTokens.textDisabled,
+          };
+        }
+        return {
+          backgroundColor: this.$themePalette.grey.v_200,
+        };
+      },
+
+      computedRemoveLabel() {
+        if (this.removeLabel) return this.removeLabel;
+        return this.text ? `Remove ${this.text}` : 'Remove';
+      },
+
+      iconOutlineColor() {
+        return this.disabled ? this.$themeTokens.textDisabled : this.$themePalette.grey.v_400;
+      },
+
+      iconFilledColor() {
+        return this.disabled ? this.$themeTokens.textDisabled : this.$themePalette.grey.v_900;
+      },
+
+      closeButtonClass() {
+        return this.$computedClass({
+          ':focus': {
+            ...this.$coreOutline,
+            outlineOffset: 0,
+          },
+        });
+      },
+    },
+
+    methods: {
+      handleClose() {
+        if (this.disabled) return;
+        /**
+         * Emitted when the close/remove button is activated.
+         * @event close
+         */
+        this.$emit('close');
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  /* https://www.w3.org/TR/WCAG21/#target-size */
+  $toucharea-min-size: 44px;
+
+  .k-chip {
+    display: inline-flex;
+    align-items: center;
+    height: 26px;
+    min-height: 26px;
+    padding: 2px 12px;
+    margin: 5px;
+    font-size: 13px;
+    white-space: nowrap;
+    user-select: none;
+    border-radius: 12px;
+    transition: all 0.2s ease;
+  }
+
+  .k-chip-content {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+  }
+
+  .k-chip-text {
+    display: flex;
+    align-items: center;
+  }
+
+  .k-chip-close-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    cursor: pointer;
+    background: transparent;
+    border: 0;
+    border-radius: 50%;
+  }
+
+  .k-chip.k-chip-closeable {
+    padding: 3px 6px 2px 12px;
+  }
+
+  .k-chip-disabled {
+    pointer-events: none;
+  }
+
+  .k-chip-icon-wrap {
+    position: relative;
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    font-size: 18px;
+    cursor: pointer;
+  }
+
+  .k-chip-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 24px;
+    height: 24px;
+    transition: opacity 0.4s ease;
+    transform: translate(-50%, -50%);
+  }
+
+  .k-chip-icon-filled {
+    z-index: 1;
+    opacity: 0;
+  }
+
+  .k-chip-close-button:not(:disabled):hover {
+    .k-chip-icon-filled {
+      opacity: 1;
+    }
+
+    .k-chip-icon-outline {
+      opacity: 0;
+    }
+  }
+
+</style>


### PR DESCRIPTION


<!-- Please remove any unused sections -->

## Description
Migrates and hardens `StudioChip` from the studio repository to the Kolibri Design System as component `KChip` under `lib/candidate/multiselect/KChip/index.vue`. This is the first sub-component for the upcoming `KMultiSelect` component.
Also created the test file for KChip component.
#### Issue addressed
<!-- Only necessary if applicable -->
Fixes #1260 


### Before/after screenshots
<!-- Insert images here if applicable -->
KChip component:
<img width="481" height="178" alt="Screenshot From 2026-05-23 11-29-24" src="https://github.com/user-attachments/assets/2064e958-875d-4ab4-9238-d8ddd3c3fc5a" />
<img width="481" height="178" alt="Screenshot From 2026-05-23 11-29-29" src="https://github.com/user-attachments/assets/06fa7251-4204-454d-bdef-6773bb3e9d35" />
<img width="481" height="178" alt="Screenshot From 2026-05-23 11-29-34" src="https://github.com/user-attachments/assets/18996cac-478e-46cc-b710-2a8cd7c2de65" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:**  Migrate and harden StudioChip to KDS as KChip candidate component  
  -  **Products impact:**  new API 
  - **Addresses:** [Link(s) to GH issue(s) addressed. Include KDS links as well as links to related issues in a consumer product repository too.](https://github.com/learningequality/kolibri-design-system/issues/1260)
  - **Components:** KChip
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** Introduces `KChip`, a pill-shaped tag representing a selected value or filter token. Supports keyboard accessibility, standard design system styling, custom translation label via `removeLabel`, and a `disabled` state.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test
All 8 test cases passes.
## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [x] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
I have currnelty added the playground file too for testing and will removed this when reviewed