### PR TITLE
Implement the KListboxGroup component and documentation for KMultiSelect

### DIFF
--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -89,6 +89,7 @@
           { text: 'Select all', href: '#select-all' },
           { text: 'Customized', href: '#customized' },
           { text: 'Scrollable', href: '#scrollable' },
+          { text: 'Grouped', href: '#grouped' },
         ]"
       />
 
@@ -193,6 +194,17 @@
           <!-- eslint-enable -->
         </template>
       </DocsExample>
+
+      <h3>
+        Grouped
+        <DocsAnchorTarget anchor="#grouped" />
+      </h3>
+      <p>Group options using <code>KListboxGroup</code>.</p>
+      <DocsExample
+        block
+        exampleId="klistbox-grouped"
+        loadExample="KListbox/Grouped.vue"
+      />
     </DocsPageSection>
 
     <DocsPageSection

--- a/docs/pages/klistboxgroup.vue
+++ b/docs/pages/klistboxgroup.vue
@@ -1,0 +1,24 @@
+<template>
+
+  <DocsPageTemplate apiDocs>
+    <DocsPageSection
+      title="Overview"
+      anchor="#overview"
+    >
+      <p>
+        <code>KListboxGroup</code> groups a set of <code>KListboxOption</code> children under a
+        labelled ARIA group. See <DocsLibraryLink component="KListbox" /> for guidance and examples.
+      </p>
+    </DocsPageSection>
+  </DocsPageTemplate>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KListboxGroupDocs',
+  };
+
+</script>

--- a/docs/tableOfContents.js
+++ b/docs/tableOfContents.js
@@ -476,6 +476,13 @@ export default [
         keywords: listboxRelatedKeywords,
       }),
       new Page({
+        path: '/klistboxgroup',
+        title: 'KListboxGroup',
+        isCode: true,
+        candidate: true,
+        keywords: listboxRelatedKeywords,
+      }),
+      new Page({
         path: '/kmultiselect',
         title: 'KMultiselect',
         isCode: true,

--- a/examples/KListbox/Grouped.vue
+++ b/examples/KListbox/Grouped.vue
@@ -54,8 +54,11 @@
               :label="child.label"
               :indeterminate="isGroupIndeterminate(child)"
               class="option"
-              :style="{ paddingLeft: '36px', paddingRight: '12px',
-                        borderColor: $themeTokens.fineLine }"
+              :style="{
+                paddingLeft: '36px',
+                paddingRight: '12px',
+                borderColor: $themeTokens.fineLine,
+              }"
             />
 
             <KListboxOption
@@ -64,8 +67,11 @@
               :value="subchild.value"
               :label="subchild.label"
               class="option"
-              :style="{ paddingLeft: '60px', paddingRight: '12px',
-                        borderColor: $themeTokens.fineLine }"
+              :style="{
+                paddingLeft: '60px',
+                paddingRight: '12px',
+                borderColor: $themeTokens.fineLine,
+              }"
             />
           </KListboxGroup>
 
@@ -75,8 +81,11 @@
             :value="child.value"
             :label="child.label"
             class="option"
-            :style="{ paddingLeft: '36px', paddingRight: '12px',
-                      borderColor: $themeTokens.fineLine }"
+            :style="{
+              paddingLeft: '36px',
+              paddingRight: '12px',
+              borderColor: $themeTokens.fineLine,
+            }"
           />
         </template>
       </KListboxGroup>
@@ -118,9 +127,7 @@
         {
           label: 'Humanities',
           value: 'humanities',
-          children: [
-            { label: 'Literature', value: 'literature' },
-          ],
+          children: [{ label: 'Literature', value: 'literature' }],
         },
       ]);
 
@@ -157,9 +164,7 @@
           updated = updated.filter(v => v !== 'physics');
         }
 
-        const sciencesAll = ['biology', 'physics'].every(v =>
-          updated.includes(v),
-        );
+        const sciencesAll = ['biology', 'physics'].every(v => updated.includes(v));
         if (sciencesAll && !updated.includes('sciences')) {
           updated.push('sciences');
         } else if (!sciencesAll && updated.includes('sciences')) {
@@ -227,9 +232,9 @@
 <style lang="scss" scoped>
 
   .listbox {
+    overflow: hidden;
     border: 1px solid;
     border-radius: 4px;
-    overflow: hidden;
   }
 
   .select-all,

--- a/examples/KListbox/Grouped.vue
+++ b/examples/KListbox/Grouped.vue
@@ -1,0 +1,201 @@
+<template>
+
+  <div>
+    <h4 :id="labelId">Choose subjects</h4>
+
+    <KListbox
+      :id="listboxId"
+      :value="selected"
+      :ariaLabelledBy="labelId"
+      :messages="messages"
+      @input="handleInput"
+    >
+      <KListboxGroup
+        v-for="group in subjectsData"
+        :key="group.value"
+        :label="group.label"
+        hideLabel
+      >
+        <KListboxOption
+          :value="group.value"
+          :label="group.label"
+          :indeterminate="isGroupIndeterminate(group)"
+          :style="{ paddingLeft: '16px', paddingRight: '16px' }"
+        />
+
+        <template v-for="child in group.children">
+          <KListboxGroup
+            v-if="child.children"
+            :key="'group-' + child.value"
+            :label="child.label"
+            hideLabel
+          >
+            <KListboxOption
+              :value="child.value"
+              :label="child.label"
+              :indeterminate="isGroupIndeterminate(child)"
+              :style="{ paddingLeft: '40px', paddingRight: '16px' }"
+            />
+
+            <KListboxOption
+              v-for="subchild in child.children"
+              :key="subchild.value"
+              :value="subchild.value"
+              :label="subchild.label"
+              :style="{ paddingLeft: '64px', paddingRight: '16px' }"
+            />
+          </KListboxGroup>
+
+          <KListboxOption
+            v-else
+            :key="'option-' + child.value"
+            :value="child.value"
+            :label="child.label"
+            :style="{ paddingLeft: '40px', paddingRight: '16px' }"
+          />
+        </template>
+      </KListboxGroup>
+    </KListbox>
+
+    <p style="margin-top: 16px">
+      Selected: <code>{{ JSON.stringify(selected) }}</code>
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const labelId = 'cascade-label';
+      const listboxId = 'cascade-listbox';
+
+      const subjectsData = ref([
+        {
+          label: 'Sciences',
+          value: 'sciences',
+          children: [
+            { label: 'Biology', value: 'biology' },
+            {
+              label: 'Physics',
+              value: 'physics',
+              children: [
+                { label: 'Mechanics', value: 'mechanics' },
+                { label: 'Electromagnetism', value: 'electromagnetism' },
+              ],
+            },
+            { label: 'Chemistry', value: 'chemistry' },
+          ],
+        },
+        {
+          label: 'Humanities',
+          value: 'humanities',
+          children: [
+            { label: 'Literature', value: 'literature' },
+            { label: 'History', value: 'history' },
+          ],
+        },
+      ]);
+
+      const messages = {
+        clickable: 'Options are clickable',
+        allOptionsSelected: 'All options selected',
+        allOptionsDeselected: 'No options selected',
+        optionDeselected: 'Deselected',
+      };
+
+      // Leaf-only descendants per group — used to derive indeterminate and checked states
+      const groupLeaves = {
+        sciences: ['biology', 'mechanics', 'electromagnetism', 'chemistry'],
+        physics: ['mechanics', 'electromagnetism'],
+        humanities: ['literature', 'history'],
+      };
+
+      // All descendants per group (nodes + leaves) — used for downward cascade
+      const groupDescendants = {
+        sciences: ['biology', 'physics', 'mechanics', 'electromagnetism', 'chemistry'],
+        physics: ['mechanics', 'electromagnetism'],
+        humanities: ['literature', 'history'],
+      };
+
+      // Upward cascade: sync each group's checked state to its leaf descendants,
+      // processing deepest groups first so parent groups see correct child states
+      const resolveSelections = currentSelection => {
+        let updated = [...currentSelection];
+
+        const physicsAll = ['mechanics', 'electromagnetism'].every(v => updated.includes(v));
+        if (physicsAll && !updated.includes('physics')) {
+          updated.push('physics');
+        } else if (!physicsAll && updated.includes('physics')) {
+          updated = updated.filter(v => v !== 'physics');
+        }
+
+        const sciencesAll = ['biology', 'physics', 'chemistry'].every(v =>
+          updated.includes(v),
+        );
+        if (sciencesAll && !updated.includes('sciences')) {
+          updated.push('sciences');
+        } else if (!sciencesAll && updated.includes('sciences')) {
+          updated = updated.filter(v => v !== 'sciences');
+        }
+
+        const humanitiesAll = ['literature', 'history'].every(v => updated.includes(v));
+        if (humanitiesAll && !updated.includes('humanities')) {
+          updated.push('humanities');
+        } else if (!humanitiesAll && updated.includes('humanities')) {
+          updated = updated.filter(v => v !== 'humanities');
+        }
+
+        return updated;
+      };
+
+      const selected = ref(resolveSelections(['mechanics', 'history']));
+
+      const isGroupIndeterminate = group => {
+        const leaves = groupLeaves[group.value];
+        if (!leaves) return false;
+        const some = leaves.some(val => selected.value.includes(val));
+        const all = leaves.every(val => selected.value.includes(val));
+        return some && !all;
+      };
+
+      // Downward cascade: when a group header is toggled, add or remove all of
+      // its descendants, then run the upward cascade to sync parent groups
+      const handleInput = newSelection => {
+        let updated = [...newSelection];
+
+        for (const groupVal of ['sciences', 'physics', 'humanities']) {
+          const wasSelected = selected.value.includes(groupVal);
+          const isNowSelected = newSelection.includes(groupVal);
+
+          if (wasSelected !== isNowSelected) {
+            const items = groupDescendants[groupVal];
+            if (isNowSelected) {
+              updated = [...new Set([...updated, ...items])];
+            } else {
+              const toRemove = new Set(items);
+              updated = updated.filter(val => !toRemove.has(val));
+            }
+          }
+        }
+
+        selected.value = resolveSelections(updated);
+      };
+
+      return {
+        labelId,
+        listboxId,
+        subjectsData,
+        selected,
+        messages,
+        isGroupIndeterminate,
+        handleInput,
+      };
+    },
+  };
+
+</script>

--- a/examples/KListbox/Grouped.vue
+++ b/examples/KListbox/Grouped.vue
@@ -1,15 +1,33 @@
 <template>
 
   <div>
-    <h4 :id="labelId">Choose subjects</h4>
+    <h4 :id="labelId">Class</h4>
 
     <KListbox
       :id="listboxId"
       :value="selected"
+      class="listbox"
       :ariaLabelledBy="labelId"
       :messages="messages"
+      :style="{ borderColor: $themeTokens.fineLine }"
       @input="handleInput"
     >
+      <template #selectAll="{ allSelected, someSelected, setAllSelected }">
+        <div
+          class="select-all"
+          :style="{ borderColor: $themeTokens.fineLine }"
+        >
+          <KCheckbox
+            label="All classes"
+            class="select-all-checkbox"
+            :aria-controls="listboxId"
+            :checked="allSelected"
+            :indeterminate="someSelected"
+            :style="{ marginTop: '6px', marginBottom: '0' }"
+            @change="setAllSelected"
+          />
+        </div>
+      </template>
       <KListboxGroup
         v-for="group in subjectsData"
         :key="group.value"
@@ -20,7 +38,8 @@
           :value="group.value"
           :label="group.label"
           :indeterminate="isGroupIndeterminate(group)"
-          :style="{ paddingLeft: '16px', paddingRight: '16px' }"
+          class="option"
+          :style="{ paddingLeft: '12px', paddingRight: '12px', borderColor: $themeTokens.fineLine }"
         />
 
         <template v-for="child in group.children">
@@ -34,7 +53,9 @@
               :value="child.value"
               :label="child.label"
               :indeterminate="isGroupIndeterminate(child)"
-              :style="{ paddingLeft: '40px', paddingRight: '16px' }"
+              class="option"
+              :style="{ paddingLeft: '36px', paddingRight: '12px',
+                        borderColor: $themeTokens.fineLine }"
             />
 
             <KListboxOption
@@ -42,7 +63,9 @@
               :key="subchild.value"
               :value="subchild.value"
               :label="subchild.label"
-              :style="{ paddingLeft: '64px', paddingRight: '16px' }"
+              class="option"
+              :style="{ paddingLeft: '60px', paddingRight: '12px',
+                        borderColor: $themeTokens.fineLine }"
             />
           </KListboxGroup>
 
@@ -51,7 +74,9 @@
             :key="'option-' + child.value"
             :value="child.value"
             :label="child.label"
-            :style="{ paddingLeft: '40px', paddingRight: '16px' }"
+            class="option"
+            :style="{ paddingLeft: '36px', paddingRight: '12px',
+                      borderColor: $themeTokens.fineLine }"
           />
         </template>
       </KListboxGroup>
@@ -88,7 +113,6 @@
                 { label: 'Electromagnetism', value: 'electromagnetism' },
               ],
             },
-            { label: 'Chemistry', value: 'chemistry' },
           ],
         },
         {
@@ -96,7 +120,6 @@
           value: 'humanities',
           children: [
             { label: 'Literature', value: 'literature' },
-            { label: 'History', value: 'history' },
           ],
         },
       ]);
@@ -110,16 +133,16 @@
 
       // Leaf-only descendants per group — used to derive indeterminate and checked states
       const groupLeaves = {
-        sciences: ['biology', 'mechanics', 'electromagnetism', 'chemistry'],
+        sciences: ['biology', 'mechanics', 'electromagnetism'],
         physics: ['mechanics', 'electromagnetism'],
-        humanities: ['literature', 'history'],
+        humanities: ['literature'],
       };
 
       // All descendants per group (nodes + leaves) — used for downward cascade
       const groupDescendants = {
-        sciences: ['biology', 'physics', 'mechanics', 'electromagnetism', 'chemistry'],
+        sciences: ['biology', 'physics', 'mechanics', 'electromagnetism'],
         physics: ['mechanics', 'electromagnetism'],
-        humanities: ['literature', 'history'],
+        humanities: ['literature'],
       };
 
       // Upward cascade: sync each group's checked state to its leaf descendants,
@@ -134,7 +157,7 @@
           updated = updated.filter(v => v !== 'physics');
         }
 
-        const sciencesAll = ['biology', 'physics', 'chemistry'].every(v =>
+        const sciencesAll = ['biology', 'physics'].every(v =>
           updated.includes(v),
         );
         if (sciencesAll && !updated.includes('sciences')) {
@@ -143,7 +166,7 @@
           updated = updated.filter(v => v !== 'sciences');
         }
 
-        const humanitiesAll = ['literature', 'history'].every(v => updated.includes(v));
+        const humanitiesAll = ['literature'].every(v => updated.includes(v));
         if (humanitiesAll && !updated.includes('humanities')) {
           updated.push('humanities');
         } else if (!humanitiesAll && updated.includes('humanities')) {
@@ -153,7 +176,7 @@
         return updated;
       };
 
-      const selected = ref(resolveSelections(['mechanics', 'history']));
+      const selected = ref(resolveSelections(['mechanics']));
 
       const isGroupIndeterminate = group => {
         const leaves = groupLeaves[group.value];
@@ -199,3 +222,29 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .listbox {
+    border: 1px solid;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .select-all,
+  .select-all-checkbox {
+    width: 100%;
+  }
+
+  .select-all {
+    padding: 8px 12px;
+    border-bottom: 1px solid;
+  }
+
+  .option {
+    padding: 8px 0;
+    border-bottom: 1px solid;
+  }
+
+</style>

--- a/examples/KListbox/Grouped.vue
+++ b/examples/KListbox/Grouped.vue
@@ -138,14 +138,14 @@
         optionDeselected: 'Deselected',
       };
 
-      // Leaf-only descendants per group — used to derive indeterminate and checked states
+      // Leaf-only descendants per group: used to derive indeterminate and checked states
       const groupLeaves = {
         sciences: ['biology', 'mechanics', 'electromagnetism'],
         physics: ['mechanics', 'electromagnetism'],
         humanities: ['literature'],
       };
 
-      // All descendants per group (nodes + leaves) — used for downward cascade
+      // All descendants per group (nodes + leaves): used for downward cascade
       const groupDescendants = {
         sciences: ['biology', 'physics', 'mechanics', 'electromagnetism'],
         physics: ['mechanics', 'electromagnetism'],

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -45,6 +45,7 @@ import KFocusTrap from './KFocusTrap.vue';
 import KToolbar from './KToolbar';
 import KListbox from './candidate/listbox/KListbox';
 import KListboxOption from './candidate/listbox/KListboxOption';
+import KListboxGroup from './candidate/listbox/KListboxGroup';
 
 import { themeTokens, themeBrand, themePalette, themeOutlineStyle } from './styles/theme';
 import globalThemeState from './styles/globalThemeState';
@@ -147,6 +148,7 @@ export default function KThemePlugin(Vue) {
   Vue.component('KLabeledIcon', KLabeledIcon);
   Vue.component('KListbox', KListbox);
   Vue.component('KListboxOption', KListboxOption);
+  Vue.component('KListboxGroup', KListboxGroup);
   Vue.component('KLinearLoader', KLinearLoader);
   Vue.component('KLogo', KLogo);
   Vue.component('KModal', KModal);

--- a/lib/candidate/listbox/KListbox/__tests__/components/KListboxVisualTest.vue
+++ b/lib/candidate/listbox/KListbox/__tests__/components/KListboxVisualTest.vue
@@ -21,6 +21,11 @@
       width="400px"
       loadExample="KListbox/Scrollable.vue"
     />
+    <VisualTestExample
+      title="Grouped"
+      width="400px"
+      loadExample="KListbox/Grouped.vue"
+    />
   </VisualTestLayout>
 
 </template>

--- a/lib/candidate/listbox/KListbox/__tests__/index.spec.js
+++ b/lib/candidate/listbox/KListbox/__tests__/index.spec.js
@@ -54,7 +54,7 @@ describe('KListbox', () => {
       },
     });
     expect(warn).toHaveBeenCalledWith(
-      '[KListbox] KListboxOption must be a direct child of KListbox.',
+      '[KListbox] KListboxOption must be a direct child of KListbox or nested inside KListboxGroup.',
     );
     warn.mockRestore();
   });

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -276,14 +276,29 @@
       });
 
       onMounted(() => {
-        // Warn if any KListboxOption is not a direct child of the listbox element
+        // Warn if any KListboxOption is not a direct child of the listbox
+        // element or properly nested under KListboxGroup elements
         if (process.env.NODE_ENV !== 'production') {
           const hasIndirectOptions = Array.from(
             listEl.value.querySelectorAll('[role="option"]'),
-          ).some(el => el.parentElement !== listEl.value);
+          ).some(el => {
+            let parent = el.parentElement;
+            while (parent && parent !== listEl.value) {
+              const tag = parent.tagName.toLowerCase();
+              const role = parent.getAttribute('role');
+              if ((tag === 'ul' && role === 'group') || (tag === 'li' && role === 'presentation')) {
+                parent = parent.parentElement;
+              } else {
+                return true;
+              }
+            }
+            return false;
+          });
           if (hasIndirectOptions) {
             // eslint-disable-next-line no-console
-            console.warn('[KListbox] KListboxOption must be a direct child of KListbox.');
+            console.warn(
+              '[KListbox] KListboxOption must be a direct child of KListbox or nested inside KListboxGroup.',
+            );
           }
         }
       });

--- a/lib/candidate/listbox/KListboxGroup/__tests__/index.spec.js
+++ b/lib/candidate/listbox/KListboxGroup/__tests__/index.spec.js
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/vue';
+import KListboxGroup from '../index.vue';
+
+function renderComponent({ props = {}, slots = {} } = {}) {
+  return render(KListboxGroup, {
+    props: { label: 'Test Group', ...props },
+    slots: { default: '<li role="option">Option A</li>', ...slots },
+  });
+}
+
+describe('KListboxGroup', () => {
+  it('renders outer li with role="presentation"', () => {
+    const { container } = renderComponent();
+    const outerLi = container.firstChild;
+    expect(outerLi.tagName.toLowerCase()).toBe('li');
+    expect(outerLi).toHaveAttribute('role', 'presentation');
+    expect(outerLi).toHaveClass('k-listbox-group');
+  });
+
+  it('renders inner ul with role="group" and aria-label', () => {
+    const { container } = renderComponent({ props: { label: 'Animals' } });
+    const innerUl = container.querySelector('ul');
+    expect(innerUl).toBeInTheDocument();
+    expect(innerUl).toHaveAttribute('role', 'group');
+    expect(innerUl).toHaveAttribute('aria-label', 'Animals');
+    expect(innerUl).toHaveClass('k-listbox-group-list');
+  });
+
+  it('renders visible label div with aria-hidden="true" by default', () => {
+    const { container } = renderComponent({ props: { label: 'Land Animals' } });
+    const headerDiv = container.querySelector('.k-listbox-group-label');
+    expect(headerDiv.tagName.toLowerCase()).toBe('div');
+    expect(headerDiv).toHaveAttribute('aria-hidden', 'true');
+    expect(headerDiv).toHaveTextContent('Land Animals');
+  });
+
+  it('hides visible label when hideLabel is true', () => {
+    const { container } = renderComponent({
+      props: { label: 'Water Animals', hideLabel: true },
+    });
+    expect(container.querySelector('.k-listbox-group-label')).toBeNull();
+  });
+
+  it('preserves aria-label on the group when hideLabel is true', () => {
+    const { container } = renderComponent({
+      props: { label: 'Water Animals', hideLabel: true },
+    });
+    const innerUl = container.querySelector('ul');
+    expect(innerUl).toHaveAttribute('role', 'group');
+    expect(innerUl).toHaveAttribute('aria-label', 'Water Animals');
+  });
+
+  it('renders slotted options inside the group', () => {
+    renderComponent({
+      slots: { default: '<li role="option">Dog</li><li role="option">Cat</li>' },
+    });
+    expect(screen.getByRole('option', { name: 'Dog' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Cat' })).toBeInTheDocument();
+  });
+
+  it('supports nested groups', () => {
+    const { container } = renderComponent({
+      props: { label: 'Parent Group' },
+      slots: {
+        default: `
+          <li role="presentation" class="k-listbox-group child-group">
+            <ul role="group" aria-label="Child Group">
+              <li role="option">Nested Option</li>
+            </ul>
+          </li>
+        `,
+      },
+    });
+
+    const parentTrack = screen.getByRole('group', { name: 'Parent Group' });
+    const childTrack = screen.getByRole('group', { name: 'Child Group' });
+
+    expect(parentTrack).toContainElement(childTrack);
+    expect(screen.getByRole('option', { name: 'Nested Option' })).toBeInTheDocument();
+
+    const childGroupWrapper = container.querySelector('.child-group');
+    expect(childGroupWrapper.tagName.toLowerCase()).toBe('li');
+    expect(childGroupWrapper.parentElement).toBe(parentTrack);
+  });
+});

--- a/lib/candidate/listbox/KListboxGroup/index.vue
+++ b/lib/candidate/listbox/KListboxGroup/index.vue
@@ -1,0 +1,76 @@
+<template>
+
+  <li
+    class="k-listbox-group"
+    role="presentation"
+  >
+    <div
+      v-if="label && !hideLabel"
+      class="k-listbox-group-label"
+      :style="{ color: $themeTokens.annotation }"
+      aria-hidden="true"
+    >
+      {{ label }}
+    </div>
+
+    <ul
+      role="group"
+      :aria-label="label"
+      class="k-listbox-group-list"
+    >
+      <!-- @slot KListboxOption(s) or nested KListboxGroup(s) -->
+      <slot></slot>
+    </ul>
+  </li>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'KListboxGroup',
+
+    props: {
+      /**
+       * Human-readable label for this group.
+       * Used as the accessible name (aria-label) for the group.
+       */
+      label: {
+        type: String,
+        required: true,
+      },
+      /** Visually hides the text label (e.g. when the parent renders its own checkbox heading) */
+      hideLabel: {
+        type: Boolean,
+        default: false,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .k-listbox-group {
+    list-style: none;
+  }
+
+  .k-listbox-group-label {
+    padding: 6px 12px 2px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .k-listbox-group-list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+</style>

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -17,6 +17,7 @@
       presentational
       :style="{ marginTop: '6px', marginBottom: '0' }"
       :checked="isSelected"
+      :indeterminate="indeterminate"
       :label="label"
     >
       <!-- @slot For customizing option label -->
@@ -86,6 +87,13 @@
       label: {
         type: String,
         required: true,
+      },
+      /**
+       * Indeterminate visual state for group checkboxes.
+       */
+      indeterminate: {
+        type: Boolean,
+        default: false,
       },
     },
   };


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Adds KListboxGroup, a new candidate component that wraps KListboxOptions into a labelled ARIA group inside KListbox. Also extends KListboxOption with an indeterminate prop to support group-header checkbox states. This is step 2 of the KMultiselect primitives roadmap.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1263 

### Before/after screenshots
<!-- Insert images here if applicable -->
[Screencast From 2026-05-26 20-47-47.webm](https://github.com/user-attachments/assets/a189f4d9-3b5f-4549-9566-1f6a69915cce)

IMG:
<img width="1325" height="692" alt="image" src="https://github.com/user-attachments/assets/1e70ea13-18c7-4704-b7c3-d534c1a37a90" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Adds KListboxGroup
  - **Products impact:**new API
  - **Addresses:** #1263 
  - **Components:** KListboxGroup, KListboxOption, KListbox
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** KListboxGroup is a candidate component intended for use inside KListbox. Pass a label prop (required) for the accessible group name. Use hideLabel to suppress the visual category label when a KListboxOption serves as the interactive group header.
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

- Verify the grouped example renders correctly with cascading selection (select/deselect a group header selects/deselects all its children; partial selection shows the header as indeterminate)
- Tab into the listbox and use arrow keys ,confirm options within groups are navigable
- Test with a screen reader ,confirm the group name is announced when focus enters each group
- Confirm the test file for the component is well written.

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [x] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
