### PR TITLE
Fix KPageContainer noPadding on mobile devices

### DIFF
--- a/lib/KPageContainer.vue
+++ b/lib/KPageContainer.vue
@@ -66,13 +66,13 @@
     border-radius: 4px;
   }
 
-  .no-padding {
-    padding: 0;
-  }
-
   .page-container.small {
     padding: 8px 16px 16px;
     margin-top: 0;
+  }
+
+  .page-container.no-padding {
+    padding: 0;
   }
 
 </style>


### PR DESCRIPTION

## Description
* Fixes KPageContainer `noPadding` prop not working on mobile devices.
  * Given that `.page-container.small` was being defined after `.page-container.no-padding`, the last class was not taking effect if the window was small, even if the `noPadding` prop was true, which is an incorrect behavior.

**Comment:** In general, we can also achieve this by setting the `style` attribute directly on the component tag, but it's still a bug in the KPageContainer implementation that needs to be fixed until we agree on a better implementation for these layout components.

#### Issue addressed

Found while testing https://github.com/learningequality/studio/pull/5924.

### Before/after screenshots

Before:
<img width="408" height="316" alt="image" src="https://github.com/user-attachments/assets/43785070-3420-4108-8e11-ad402913cb2e" />

After:

<img width="394" height="264" alt="image" src="https://github.com/user-attachments/assets/6a389c3f-5be2-4b41-99e6-869134378ac2" />

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Fixes KPageContainer `noPadding` prop not working on mobile devices.
  - **Products impact:** bugfix.
  - **Addresses:** https://github.com/learningequality/studio/pull/5924.
  - **Components:** KPageContainer.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
