### PR TITLE
feat: add color prop to KCheckbox to customize checked and indeterminate icon colors

### DIFF
--- a/docs/pages/kcheckbox.vue
+++ b/docs/pages/kcheckbox.vue
@@ -270,6 +270,17 @@
         loadExample="KCheckbox/CheckedApiSingle.vue"
       />
     </DocsPageSection>
+
+    <DocsPageSection
+      title="Example: Custom Color"
+      anchor="#example-custom-color"
+    >
+      <p>The <code>color</code> prop overrides the default checked/indeterminate icon color.</p>
+      <DocsExample
+        exampleId="custom-color"
+        loadExample="KCheckbox/CustomColor.vue"
+      />
+    </DocsPageSection>
   </DocsPageTemplate>
 
 </template>

--- a/examples/KCheckbox/CustomColor.vue
+++ b/examples/KCheckbox/CustomColor.vue
@@ -1,0 +1,31 @@
+<template>
+
+  <div>
+    <KCheckbox
+      v-model="inputValue"
+      label="Selected with custom color"
+      color="#4caf50"
+    />
+    <KCheckbox
+      v-model="indeterminate"
+      label="Indeterminate with custom color"
+      :indeterminate="true"
+      color="#4caf50"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    data() {
+      return {
+        inputValue: true,
+        indeterminate: false,
+      };
+    },
+  };
+
+</script>

--- a/lib/KCheckbox/__tests__/components/KCheckboxVisualTest.vue
+++ b/lib/KCheckbox/__tests__/components/KCheckboxVisualTest.vue
@@ -54,6 +54,12 @@
       width="400px"
       loadExample="KCheckbox/WithDescription.vue"
     />
+
+    <VisualTestExample
+      title="Custom Color"
+      width="400px"
+      loadExample="KCheckbox/CustomColor.vue"
+    />
   </VisualTestLayout>
 
 </template>

--- a/lib/KCheckbox/index.vue
+++ b/lib/KCheckbox/index.vue
@@ -178,6 +178,13 @@
         type: Boolean,
         default: false,
       },
+      /**
+       * Color for the checked and indeterminate icons
+       */
+      color: {
+        type: String,
+        default: null,
+      },
     },
     data: () => ({
       isActive: false,
@@ -237,7 +244,9 @@
       },
       notBlank() {
         return {
-          fill: this.disabled ? this.$themeTokens.textDisabled : this.$themeTokens.primary,
+          fill: this.disabled
+            ? this.$themeTokens.textDisabled
+            : this.color || this.$themeTokens.primary,
         };
       },
       activeOutline() {

--- a/lib/__tests__/KCheckbox.spec.js
+++ b/lib/__tests__/KCheckbox.spec.js
@@ -85,6 +85,18 @@ describe('KCheckbox component', () => {
       const checkbox = screen.getByLabelText('disabled');
       expect(checkbox).toBeDisabled();
     });
+
+    it(`should render with custom color when color prop is provided for checked state`, () => {
+      renderComponent({ label: 'custom color', inputValue: true, color: 'custom-color' });
+      const icon = screen.getByTestId('icon-checked');
+      expect(icon).toHaveStyle({ fill: 'custom-color' });
+    });
+
+    it(`should render with custom color when color prop is provided for indeterminate state`, () => {
+      renderComponent({ label: 'custom color', indeterminate: true, color: 'custom-color' });
+      const icon = screen.getByTestId('icon-indeterminateCheck');
+      expect(icon).toHaveStyle({ fill: 'custom-color' });
+    });
   });
 
   it(`should render the default's slot content in <label>`, () => {


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
Added colour prop to KCheckbox to customise checked and indeterminate icon colours, and added unit tests.

#### Issue addressed
#1275 

### Before/after screenshots
<!-- Insert images here if applicable -->
<img width="956" height="650" alt="image" src="https://github.com/user-attachments/assets/3c4553d8-c7f1-494e-9e24-de863b35b9e0" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:**  Added colour prop to KCheckbox to customise checked and indeterminate icon colours, and added unit tests.
  - **Products impact:**  KDS 
  - **Addresses:**  #1275 
  - **Components:**  KCheckbox
  - **Breaking:** No
  - **Impacts a11y:** No
  - **Guidance:** 

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test
- Navigate to the KCheckbox component page in the docs.
- Scroll down to the new "Example: Custom Color" section.
- Verify that the checked checkbox renders with the custom green checkmark.
- Verify that the indeterminate checkbox renders with the custom green dash.
- Click the checkboxes to toggle them and ensure that the unchecked (empty) state remains the default annotation  color, and it only turns green when active.
- Check the other examples on the page to ensure standard checkboxes still use the default primary color when checked.


## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
