### PR TITLE
feat: add optional color prop to KRadioButton and include component tests

### DIFF
--- a/docs/pages/kradiobutton.vue
+++ b/docs/pages/kradiobutton.vue
@@ -44,6 +44,12 @@
             buttonValue="val-d"
             truncateLabel
           />
+          <KRadioButton
+            v-model="exampleValue"
+            label="Option E (Custom Color)"
+            buttonValue="val-e"
+            :color="$themePalette.green.v_600"
+          />
         </KRadioButtonGroup>
         <p>Current value: {{ exampleValue }}</p>
       </DocsShow>
@@ -71,6 +77,12 @@
             label="Truncated label. Adjusting your browser window size to see this in action."
             buttonValue="val-d"
             truncateLabel
+          />
+          <KRadioButton
+            v-model="exampleValue"
+            label="Option E (Custom Color)"
+            buttonValue="val-e"
+            :color="$themePalette.green.v_600"
           />
         </KRadioButtonGroup>
       </DocsShowCode>

--- a/lib/KRadioButton.vue
+++ b/lib/KRadioButton.vue
@@ -29,7 +29,7 @@
           icon="radioSelected"
           class="radio-button-icon"
           name="radio_button_checked"
-          :style="[{ fill: $themeTokens.primary }, disabledStyle, activeStyle]"
+          :style="[{ fill: color || $themeTokens.primary }, disabledStyle, activeStyle]"
         />
         <KIcon
           v-else
@@ -163,6 +163,13 @@
       truncateLabel: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * Color for the selected radio button icon
+       */
+      color: {
+        type: String,
+        default: null,
       },
     },
     data: () => ({

--- a/lib/__tests__/KRadioButton.spec.js
+++ b/lib/__tests__/KRadioButton.spec.js
@@ -1,0 +1,69 @@
+import { mount } from '@vue/test-utils';
+import KRadioButton from '../KRadioButton.vue';
+
+describe('KRadioButton component', () => {
+  it('should render with default color when color prop is not provided', () => {
+    const wrapper = mount(KRadioButton, {
+      propsData: {
+        currentValue: 'val-a',
+        buttonValue: 'val-a',
+      },
+      mocks: {
+        $themeTokens: {
+          primary: 'default-primary-color',
+          textDisabled: 'disabled-color',
+          annotation: 'annotation-color',
+        },
+        $coreOutline: {},
+      },
+    });
+
+    const selectedIcon = wrapper.findComponent({ name: 'KIcon' });
+    expect(selectedIcon.exists()).toBe(true);
+    expect(selectedIcon.props('icon')).toBe('radioSelected');
+    expect(selectedIcon.attributes('style')).toContain('fill: default-primary-color');
+  });
+
+  it('should render with custom color when color prop is provided', () => {
+    const wrapper = mount(KRadioButton, {
+      propsData: {
+        currentValue: 'val-a',
+        buttonValue: 'val-a',
+        color: 'custom-color',
+      },
+      mocks: {
+        $themeTokens: {
+          primary: 'default-primary-color',
+          textDisabled: 'disabled-color',
+          annotation: 'annotation-color',
+        },
+        $coreOutline: {},
+      },
+    });
+
+    const selectedIcon = wrapper.findComponent({ name: 'KIcon' });
+    expect(selectedIcon.attributes('style')).toContain('fill: custom-color');
+  });
+
+  it('should render with disabled color when disabled is true, overriding custom color', () => {
+    const wrapper = mount(KRadioButton, {
+      propsData: {
+        currentValue: 'val-a',
+        buttonValue: 'val-a',
+        color: 'custom-color',
+        disabled: true,
+      },
+      mocks: {
+        $themeTokens: {
+          primary: 'default-primary-color',
+          textDisabled: 'disabled-color',
+          annotation: 'annotation-color',
+        },
+        $coreOutline: {},
+      },
+    });
+
+    const selectedIcon = wrapper.findComponent({ name: 'KIcon' });
+    expect(selectedIcon.attributes('style')).toContain('fill: disabled-color');
+  });
+});


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
<!-- What does this PR do? Briefly describe in 1-2 sentences* -->
Added an optional color prop to KRadioButton and included component tests
#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1276 

### Before/after screenshots
<!-- Insert images here if applicable -->
<img width="932" height="314" alt="image" src="https://github.com/user-attachments/assets/24dcbacd-9098-4a42-806d-870e77f9f1fa" />


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Added an optional color prop to KRadioButton and included component tests
  - **Products impact:** KDS
  - **Addresses:**  #1276 
  - **Components:** KRadioButton
  - **Breaking:** no
  - **Impacts a11y:**  no
  - **Guidance:**  -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

- Navigate to the KRadioButton component page in the docs.
- Scroll down to the Usage code examples.
- Locate the new radio button option labeled "Option E (Custom Color)".
- Click on it and verify that the selected inner circle renders in the custom green color ($themePalette.green.v_600).
- Verify that all other existing radio buttons in the examples still correctly use the default primary color when selected.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
