### PR TITLE
Switch klistwithoverflow flex-wrap style

### DIFF
--- a/lib/KListWithOverflow.vue
+++ b/lib/KListWithOverflow.vue
@@ -268,7 +268,7 @@
   .list {
     position: relative;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
     overflow: visible;
   }


### PR DESCRIPTION
## Description

Switch KListWithOverflow `flex-wrap` from `wrap` to `nowrap`. This will remove a small tick where, for at most 100ms, a second row of KListWithOverflow is visible. The overflow: visible is kept to prevent issues with the focus outline and popup elements rendered as children of the list.

Targeting `develop` as this introduces a subtle breaking change: Now the container needs to ensure a proper min-width value is set so that the list can shrink properly (previously this wasn't needed because `flex-wrap: wrap` already handled this need.

This breaks the `LanguageSwitcherFooter` component on Kolibri, given that there the container cannot provide a proper min-width value, so a proper fix should be opened there before merging this PR.

### Before/after screenshots

Before:

https://github.com/user-attachments/assets/2e39224e-3e27-4244-ab80-9109d12d0366

After:

https://github.com/user-attachments/assets/1869c45d-056a-4b52-b6cd-ff3c2279e8f9

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Fixes a small tick where two rows can be seen for at most 100ms when resizing a KListWithOverflow component.
  - **Products impact:** bugfix.
  - **Addresses:** -.
  - **Components:** KListWithOverflow.
  - **Breaking:** yes
  - **Impacts a11y:** no
  - **Guidance:** Make sure KListWithOverflow's containers can calculate and ensure a proper min-width value so that the list can be shrunk.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
