### PR TITLE
Backport KRadioButton color prop to release-v5

### DIFF
--- a/docs/pages/kradiobutton.vue
+++ b/docs/pages/kradiobutton.vue
@@ -44,6 +44,12 @@
             buttonValue="val-d"
             truncateLabel
           />
+          <KRadioButton
+            v-model="exampleValue"
+            label="Option E (Custom Color)"
+            buttonValue="val-e"
+            :color="$themePalette.green.v_600"
+          />
         </KRadioButtonGroup>
         <p>Current value: {{ exampleValue }}</p>
       </DocsShow>
@@ -71,6 +77,12 @@
             label="Truncated label. Adjusting your browser window size to see this in action."
             buttonValue="val-d"
             truncateLabel
+          />
+          <KRadioButton
+            v-model="exampleValue"
+            label="Option E (Custom Color)"
+            buttonValue="val-e"
+            :color="$themePalette.green.v_600"
           />
         </KRadioButtonGroup>
       </DocsShowCode>

--- a/lib/KRadioButton.vue
+++ b/lib/KRadioButton.vue
@@ -29,7 +29,7 @@
           icon="radioSelected"
           class="radio-button-icon"
           name="radio_button_checked"
-          :style="[{ fill: $themeTokens.primary }, disabledStyle, activeStyle]"
+          :style="[{ fill: color || $themeTokens.primary }, disabledStyle, activeStyle]"
         />
         <KIcon
           v-else
@@ -163,6 +163,13 @@
       truncateLabel: {
         type: Boolean,
         default: false,
+      },
+      /**
+       * Color for the selected radio button icon
+       */
+      color: {
+        type: String,
+        default: null,
       },
     },
     data: () => ({

--- a/lib/__tests__/KRadioButton.spec.js
+++ b/lib/__tests__/KRadioButton.spec.js
@@ -1,0 +1,69 @@
+import { mount } from '@vue/test-utils';
+import KRadioButton from '../KRadioButton.vue';
+
+describe('KRadioButton component', () => {
+  it('should render with default color when color prop is not provided', () => {
+    const wrapper = mount(KRadioButton, {
+      propsData: {
+        currentValue: 'val-a',
+        buttonValue: 'val-a',
+      },
+      mocks: {
+        $themeTokens: {
+          primary: 'default-primary-color',
+          textDisabled: 'disabled-color',
+          annotation: 'annotation-color',
+        },
+        $coreOutline: {},
+      },
+    });
+
+    const selectedIcon = wrapper.findComponent({ name: 'KIcon' });
+    expect(selectedIcon.exists()).toBe(true);
+    expect(selectedIcon.props('icon')).toBe('radioSelected');
+    expect(selectedIcon.attributes('style')).toContain('fill: default-primary-color');
+  });
+
+  it('should render with custom color when color prop is provided', () => {
+    const wrapper = mount(KRadioButton, {
+      propsData: {
+        currentValue: 'val-a',
+        buttonValue: 'val-a',
+        color: 'custom-color',
+      },
+      mocks: {
+        $themeTokens: {
+          primary: 'default-primary-color',
+          textDisabled: 'disabled-color',
+          annotation: 'annotation-color',
+        },
+        $coreOutline: {},
+      },
+    });
+
+    const selectedIcon = wrapper.findComponent({ name: 'KIcon' });
+    expect(selectedIcon.attributes('style')).toContain('fill: custom-color');
+  });
+
+  it('should render with disabled color when disabled is true, overriding custom color', () => {
+    const wrapper = mount(KRadioButton, {
+      propsData: {
+        currentValue: 'val-a',
+        buttonValue: 'val-a',
+        color: 'custom-color',
+        disabled: true,
+      },
+      mocks: {
+        $themeTokens: {
+          primary: 'default-primary-color',
+          textDisabled: 'disabled-color',
+          annotation: 'annotation-color',
+        },
+        $coreOutline: {},
+      },
+    });
+
+    const selectedIcon = wrapper.findComponent({ name: 'KIcon' });
+    expect(selectedIcon.attributes('style')).toContain('fill: disabled-color');
+  });
+});


### PR DESCRIPTION
## Description
Backport https://github.com/learningequality/kolibri-design-system/pull/1280 to `release-v5`.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #*PR# HERE*

### Before/after screenshots
<!-- Insert images here if applicable -->

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Adds an optional color prop to KRadioButton and included component tests
  - **Products impact:** new API.
  - **Addresses:** .
  - **Components:** KRadioButton.
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** .

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->
