### PR TITLE
KListbox: Support functions (in addition to strings) for the messages prop

### DIFF
--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -5,7 +5,7 @@
       :id="ariaDescribedById"
       class="visuallyhidden"
     >
-      {{ messages.clickable }}
+      {{ getMessage('clickable') }}
     </p>
 
     <!--
@@ -118,7 +118,7 @@
       function toggleOption(value) {
         if (isSelected(value)) {
           emitInput(props.value.filter(v => v !== value));
-          sendPoliteMessage(props.messages.optionDeselected);
+          sendPoliteMessage(getMessage('optionDeselected'));
         } else {
           emitInput([...props.value, value]);
         }
@@ -134,7 +134,7 @@
         // by merging previously selected values with all visible options
         const allValues = uniq([...props.value, ...options.value.map(o => o.value)]);
         emitInput(allValues);
-        sendPoliteMessage(props.messages.allOptionsSelected);
+        sendPoliteMessage(getMessage('allOptionsSelected'));
       }
 
       function deselectAllOptions() {
@@ -144,7 +144,11 @@
         const optionValues = new Set(options.value.map(o => o.value));
         const remainingValues = props.value.filter(v => !optionValues.has(v));
         emitInput(remainingValues);
-        sendPoliteMessage(props.messages.allOptionsDeselected);
+        sendPoliteMessage(getMessage('allOptionsDeselected'));
+      }
+
+      function getMessage(key) {
+        return typeof props.messages[key] === 'function' ? props.messages[key]() : props.messages[key];
       }
 
       const allSelected = computed(
@@ -315,6 +319,7 @@
         onListFocus,
         onListBlur,
         onListKeydown,
+        getMessage,
       };
     },
     props: {
@@ -347,7 +352,8 @@
         default: null,
       },
       /**
-       * Localized strings
+       * Localized strings for screen reader announcements.
+       * Can be static strings or functions returning strings.
        */
       messages: {
         type: Object,
@@ -360,12 +366,12 @@
             'optionDeselected',
           ];
           const missing = requiredKeys.filter(
-            key => typeof messages[key] !== 'string' || messages[key].length === 0,
+            key => typeof messages[key] !== 'string' && typeof messages[key] !== 'function',
           );
           if (missing.length) {
             // eslint-disable-next-line no-console
             console.warn(
-              `[KListbox] 'messages' prop is missing required string keys: ${missing.join(', ')}`,
+              `[KListbox] 'messages' prop keys must be strings or functions. Invalid keys: ${missing.join(', ')}`,
             );
             return false;
           }

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -148,7 +148,9 @@
       }
 
       function getMessage(key) {
-        return typeof props.messages[key] === 'function' ? props.messages[key]() : props.messages[key];
+        return typeof props.messages[key] === 'function'
+          ? props.messages[key]()
+          : props.messages[key];
       }
 
       const allSelected = computed(


### PR DESCRIPTION

<!-- Please remove any unused sections -->

## Description
Updates KListbox to accept both strings and functions for its messages prop, enabling KMultiSelect to pass its messages as functions without breaking existing consumers that still pass plain strings.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1290 

### Before/after screenshots
<!-- Insert images here if applicable -->

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** KListbox messages prop now accepts both plain strings and functions. A getMessage() helper resolves the value at runtime by calling the function if needed, or returning the string directly.
  - **Products impact:** updated API
  - **Addresses:** #1290 
  - **Components:** Klistbox
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** No changes required for existing consumers passing plain strings

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

check if the desired functionality is achieved.

## (optional) Implementation notes

### At a high level, how did you implement this?
<!-- Briefly describe how this works -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests
- [ ] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
<!-- Any additional notes you'd like to add -->
