### PR TITLE
[KListbox] Add comprehensive Single-Select mode support

### DIFF
--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -4,22 +4,12 @@
     <template #developerNotes>
       <ul :style="{ margin: 0 }">
         <li>
-          Grouped options aren't supported yet, as we haven't needed them. They could be added by
-          extending our listbox components according to
-          <DocsExternalLink
-            text="grouped options of APG's listbox pattern"
-            href="https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-grouped/"
-          />
-          (likely adding <code>KListboxGroup</code>)
-        </li>
-
-        <li>
           Listboxes are often combined with searching or filtering, but that's not part of the
           listbox pattern and use cases vary. If a frequent pattern emerges, it may motivate
           dedicated search/filter components that integrate well with <code>KListbox</code>.
         </li>
         <li>
-          Currently KListbox doesn't support options reodering, so bear in mind that if the list
+          Currently KListbox doesn't support options reordering, so bear in mind that if the list
           changes due to a filter, the filtered list should preserve the order of the original list
           to avoid unexpected keyboard navigation.
         </li>
@@ -43,8 +33,8 @@
       <p>Its options are provided via <DocsLibraryLink component="KListboxOption" />.</p>
 
       <p>
-        It currently defaults to multi selection and does not yet support grouped options (see
-        developer notes above).
+        It supports both multi selection (default, <code>multiple: true</code>) and single selection
+        (<code>multiple: false</code>).
       </p>
 
       <p>
@@ -228,6 +218,10 @@
       <ul>
         <li>
           <DocsLibraryLink component="KListboxOption" /> is a single option inside
+          <code>KListbox</code>
+        </li>
+        <li>
+          <DocsLibraryLink component="KListboxGroup" /> groups options inside
           <code>KListbox</code>
         </li>
         <li>

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -123,10 +123,10 @@
       </ul>
 
       <DocsBanner a11y>
-        Link the control to the listbox <code>id</code> using <code>aria-controls</code>. Build the
-        label for the checkbox in a way that makes it clear it affects the list below (e.g.,
-        <code>'Select all users'</code> instead of <code>'All users'</code>) because
-        <code>aria-controls</code> does not change what the screen reader says.
+        Set <code>aria-controls</code> on the select all control to the listbox <code>id</code> to
+        associate the two. Build the label for the checkbox in a way that makes it clear it affects
+        the list below (e.g., <code>'Select all users'</code> instead of <code>'All users'</code>)
+        because <code>aria-controls</code> does not change what the screen reader says.
       </DocsBanner>
 
       <DocsExample

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -123,10 +123,10 @@
       </ul>
 
       <DocsBanner a11y>
-        Link the control to the listbox <code>id</code> using <code>aria-controls</code>. Provide an
-        explicit label like <code>'Select all users'</code> instead of
-        <code>'All users'</code> because <code>aria-controls</code> does not change what the screen
-        reader says.
+        Link the control to the listbox <code>id</code> using <code>aria-controls</code>. Build the
+        label for the checkbox in a way that makes it clear it affects the list below (e.g.,
+        <code>'Select all users'</code> instead of <code>'All users'</code>) because
+        <code>aria-controls</code> does not change what the screen reader says.
       </DocsBanner>
 
       <DocsExample

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -123,7 +123,10 @@
       </ul>
 
       <DocsBanner a11y>
-        Link the control to the listbox <code>id</code> using <code>aria-controls</code>. Provide an explicit label like <code>'Select all users'</code> instead of <code>'All users'</code> because <code>aria-controls</code> does not change what the screen reader says.
+        Link the control to the listbox <code>id</code> using <code>aria-controls</code>. Provide an
+        explicit label like <code>'Select all users'</code> instead of
+        <code>'All users'</code> because <code>aria-controls</code> does not change what the screen
+        reader says.
       </DocsBanner>
 
       <DocsExample

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -12,10 +12,7 @@
           />
           (likely adding <code>KListboxGroup</code>)
         </li>
-        <li>
-          Reflecting our first use-cases, multi selection is the default behavior. Single selection
-          mode could be added by a few adjustments in line with the same APG listbox pattern.
-        </li>
+
         <li>
           Listboxes are often combined with searching or filtering, but that's not part of the
           listbox pattern and use cases vary. If a frequent pattern emerges, it may motivate
@@ -46,8 +43,8 @@
       <p>Its options are provided via <DocsLibraryLink component="KListboxOption" />.</p>
 
       <p>
-        It currently defaults to multi selection and does not yet support single selection or
-        grouped options (see developer notes above).
+        It currently defaults to multi selection and does not yet support grouped options (see
+        developer notes above).
       </p>
 
       <p>
@@ -87,6 +84,7 @@
         :items="[
           { text: 'Default', href: '#default' },
           { text: 'Select all', href: '#select-all' },
+          { text: 'Single Select', href: '#single-select' },
           { text: 'Customized', href: '#customized' },
           { text: 'Scrollable', href: '#scrollable' },
           { text: 'Grouped', href: '#grouped' },
@@ -143,6 +141,22 @@
         block
         exampleId="klistbox-select-all"
         loadExample="KListbox/SelectAll.vue"
+      />
+
+      <h3>
+        Single Select
+        <DocsAnchorTarget anchor="#single-select" />
+      </h3>
+
+      <p>
+        Set <code>multiple="false"</code> on the listbox and <code>showCheckbox="false"</code> on
+        the options to render plain text options for single selection.
+      </p>
+
+      <DocsExample
+        block
+        exampleId="klistbox-single-select"
+        loadExample="KListbox/SingleSelect.vue"
       />
 
       <h3>

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -74,7 +74,7 @@
         :items="[
           { text: 'Default', href: '#default' },
           { text: 'Select all', href: '#select-all' },
-          { text: 'Single Select', href: '#single-select' },
+          { text: 'Single select', href: '#single-select' },
           { text: 'Customized', href: '#customized' },
           { text: 'Scrollable', href: '#scrollable' },
           { text: 'Grouped', href: '#grouped' },
@@ -91,7 +91,7 @@
       <DocsBanner a11y>
         If <code>KListbox</code> is not part of another widget, such as a combobox, add either a
         visible label referenced by <code>ariaLabelledBy</code> or a value specified for
-        <code>ariaLabel</code>. Use concise and descriptive value.
+        <code>ariaLabel</code>. Use a concise, descriptive value.
       </DocsBanner>
 
       <DocsExample
@@ -123,8 +123,7 @@
       </ul>
 
       <DocsBanner a11y>
-        Set <code>aria-controls</code> on the select all control to the listbox <code>id</code> to
-        associate the two.
+        Link the control to the listbox <code>id</code> using <code>aria-controls</code>. Provide an explicit label like <code>'Select all users'</code> instead of <code>'All users'</code> because <code>aria-controls</code> does not change what the screen reader says.
       </DocsBanner>
 
       <DocsExample
@@ -134,13 +133,14 @@
       />
 
       <h3>
-        Single Select
+        Single select
         <DocsAnchorTarget anchor="#single-select" />
       </h3>
 
       <p>
-        Set <code>multiple="false"</code> on the listbox and <code>showCheckbox="false"</code> on
-        the options to render plain text options for single selection.
+        Set <code>multiple="false"</code> on the listbox. Options automatically hide the checkbox
+        selector in single-select mode. Use the <code>showSelector</code> prop on
+        <DocsLibraryLink component="KListboxOption" /> to override this behaviour explicitly.
       </p>
 
       <DocsExample
@@ -276,6 +276,13 @@
             required: 'Yes',
             description: 'Announced via live region when an option is deselected.',
             example: 'Deselected',
+          },
+          {
+            name: 'partiallySelected',
+            required: 'No',
+            description:
+              'Renders a visually-hidden text inside indeterminate options so screen readers announce the partial selection state. Use with grouped listboxes that have parent checkboxes.',
+            example: 'Partially selected',
           },
         ],
       };

--- a/docs/pages/klistbox.vue
+++ b/docs/pages/klistbox.vue
@@ -32,10 +32,7 @@
 
       <p>Its options are provided via <DocsLibraryLink component="KListboxOption" />.</p>
 
-      <p>
-        It supports both multi selection (default, <code>multiple: true</code>) and single selection
-        (<code>multiple: false</code>).
-      </p>
+      <p>It supports both multi selection and single selection.</p>
 
       <p>
         <code>KListbox</code> supports dynamic option sets (useful for integration with filtering,

--- a/examples/KListbox/Customized.vue
+++ b/examples/KListbox/Customized.vue
@@ -20,7 +20,7 @@
             than necessary and aligns its correctly within the row
           -->
           <KCheckbox
-            label="All users"
+            label="Select all users"
             class="select-all-checkbox"
             :aria-controls="listboxId"
             :disabled="isDisabled"
@@ -29,7 +29,7 @@
             :style="{ marginTop: '6px', marginBottom: '0' }"
             @change="setAllSelected"
           >
-            <KLabeledIcon label="All users">
+            <KLabeledIcon label="Select all users">
               <template #icon>
                 <KIcon
                   icon="allUsers"

--- a/examples/KListbox/Customized.vue
+++ b/examples/KListbox/Customized.vue
@@ -114,6 +114,10 @@
     border-bottom: 1px solid;
   }
 
+  .option {
+    padding-inline-start: 16px;
+  }
+
   .option:last-child {
     border-bottom: 0;
   }

--- a/examples/KListbox/Customized.vue
+++ b/examples/KListbox/Customized.vue
@@ -115,7 +115,7 @@
   }
 
   .option {
-    padding-inline-start: 16px;
+    padding-left: 16px;
   }
 
   .option:last-child {

--- a/examples/KListbox/Grouped.vue
+++ b/examples/KListbox/Grouped.vue
@@ -18,7 +18,7 @@
           :style="{ borderColor: $themeTokens.fineLine }"
         >
           <KCheckbox
-            label="All classes"
+            label="Select all classes"
             class="select-all-checkbox"
             :aria-controls="listboxId"
             :checked="allSelected"
@@ -136,6 +136,7 @@
         allOptionsSelected: 'All options selected',
         allOptionsDeselected: 'No options selected',
         optionDeselected: 'Deselected',
+        partiallySelected: 'Partially selected',
       };
 
       // Leaf-only descendants per group: used to derive indeterminate and checked states

--- a/examples/KListbox/Grouped.vue
+++ b/examples/KListbox/Grouped.vue
@@ -39,7 +39,7 @@
           :label="group.label"
           :indeterminate="isGroupIndeterminate(group)"
           class="option"
-          :style="{ paddingLeft: '12px', paddingRight: '12px', borderColor: $themeTokens.fineLine }"
+          :style="{ paddingLeft: '16px', paddingRight: '12px', borderColor: $themeTokens.fineLine }"
         />
 
         <template v-for="child in group.children">
@@ -55,7 +55,7 @@
               :indeterminate="isGroupIndeterminate(child)"
               class="option"
               :style="{
-                paddingLeft: '36px',
+                paddingLeft: '40px',
                 paddingRight: '12px',
                 borderColor: $themeTokens.fineLine,
               }"
@@ -68,7 +68,7 @@
               :label="subchild.label"
               class="option"
               :style="{
-                paddingLeft: '60px',
+                paddingLeft: '64px',
                 paddingRight: '12px',
                 borderColor: $themeTokens.fineLine,
               }"
@@ -82,7 +82,7 @@
             :label="child.label"
             class="option"
             :style="{
-              paddingLeft: '36px',
+              paddingLeft: '40px',
               paddingRight: '12px',
               borderColor: $themeTokens.fineLine,
             }"

--- a/examples/KListbox/Scrollable.vue
+++ b/examples/KListbox/Scrollable.vue
@@ -93,6 +93,10 @@
     border-bottom: 1px solid;
   }
 
+  .option {
+    padding-inline-start: 10px;
+  }
+
   .option:last-child {
     border-bottom: 0;
   }

--- a/examples/KListbox/Scrollable.vue
+++ b/examples/KListbox/Scrollable.vue
@@ -94,7 +94,7 @@
   }
 
   .option {
-    padding-inline-start: 10px;
+    padding-left: 10px;
   }
 
   .option:last-child {

--- a/examples/KListbox/Scrollable.vue
+++ b/examples/KListbox/Scrollable.vue
@@ -16,7 +16,7 @@
           :style="{ borderColor: $themeTokens.fineLine }"
         >
           <KCheckbox
-            label="All classes"
+            label="Select all classes"
             class="select-all-checkbox"
             :aria-controls="listboxId"
             :disabled="!options.length"

--- a/examples/KListbox/SelectAll.vue
+++ b/examples/KListbox/SelectAll.vue
@@ -14,7 +14,7 @@
           than necessary and aligns its correctly within the row
         -->
         <KCheckbox
-          label="All classes"
+          label="Select all classes"
           :aria-controls="listboxId"
           :disabled="!options.length"
           :checked="allSelected"

--- a/examples/KListbox/SingleSelect.vue
+++ b/examples/KListbox/SingleSelect.vue
@@ -1,0 +1,75 @@
+<template>
+
+  <div>
+    <h4 :id="classLabel">Class (Single Select)</h4>
+    <KListbox
+      :id="listboxId"
+      v-model="selected"
+      class="listbox"
+      :ariaLabelledBy="classLabel"
+      :messages="messages"
+      :multiple="false"
+      :style="{ borderColor: $themeTokens.fineLine }"
+    >
+      <KListboxOption
+        v-for="option in options"
+        :key="option.id"
+        :value="option.id"
+        :label="option.label"
+        :showCheckbox="false"
+        class="option"
+        :style="{ borderColor: $themeTokens.fineLine }"
+      />
+    </KListbox>
+    <p>
+      Selected: <code>{{ JSON.stringify(selected) }}</code>
+    </p>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { ref } from 'vue';
+
+  export default {
+    setup() {
+      const classLabel = 'single-select-class';
+      const listboxId = 'single-select-listbox';
+      const selected = ref(['literature']);
+      const options = [
+        { id: 'biology', label: 'Biology' },
+        { id: 'literature', label: 'Literature' },
+        { id: 'physics', label: 'Physics' },
+      ];
+      const messages = {
+        clickable: 'Options are clickable',
+        allOptionsSelected: 'All options selected',
+        allOptionsDeselected: 'No options selected',
+        optionDeselected: 'Deselected',
+      };
+      return { classLabel, listboxId, selected, options, messages };
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .listbox {
+    border: 1px solid;
+    border-radius: 4px;
+  }
+
+  .option {
+    padding: 8px 12px;
+    border-bottom: 1px solid;
+  }
+
+  .option:last-child {
+    border-bottom: 0;
+  }
+
+</style>

--- a/examples/KListbox/SingleSelect.vue
+++ b/examples/KListbox/SingleSelect.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h4 :id="classLabel">Class (Single Select)</h4>
+    <h4 :id="classLabel">Class</h4>
     <KListbox
       :id="listboxId"
       v-model="selected"
@@ -16,7 +16,6 @@
         :key="option.id"
         :value="option.id"
         :label="option.label"
-        :showCheckbox="false"
         class="option"
         :style="{ borderColor: $themeTokens.fineLine }"
       />
@@ -64,7 +63,7 @@
   }
 
   .option {
-    padding: 8px 12px;
+    padding: 8px 6px;
     border-bottom: 1px solid;
   }
 

--- a/lib/candidate/listbox/KListbox/__tests__/components/KListboxVisualTest.vue
+++ b/lib/candidate/listbox/KListbox/__tests__/components/KListboxVisualTest.vue
@@ -12,6 +12,11 @@
       loadExample="KListbox/SelectAll.vue"
     />
     <VisualTestExample
+      title="Single select"
+      width="400px"
+      loadExample="KListbox/SingleSelect.vue"
+    />
+    <VisualTestExample
       title="Customized"
       width="400px"
       loadExample="KListbox/Customized.vue"

--- a/lib/candidate/listbox/KListbox/__tests__/index.spec.js
+++ b/lib/candidate/listbox/KListbox/__tests__/index.spec.js
@@ -112,6 +112,37 @@ describe('KListbox', () => {
     });
   });
 
+  describe('single-select mode (multiple: false)', () => {
+    it('emits input event with only the newly selected value (replacing existing)', async () => {
+      const component = renderComponent({ props: { multiple: false, value: [OPTIONS[0].id] } });
+      const option2 = await screen.findByRole('option', { name: OPTIONS[1].label });
+
+      await userEvent.click(option2);
+      const emittedValue = component.emitted().input[0][0];
+
+      expect(emittedValue).toEqual([OPTIONS[1].id]);
+    });
+
+    it('does not deselect an option if it is already selected', async () => {
+      const component = renderComponent({ props: { multiple: false, value: [OPTIONS[0].id] } });
+      const option1 = await screen.findByRole('option', { name: OPTIONS[0].label });
+
+      await userEvent.click(option1);
+
+      expect(component.emitted().input).toBeUndefined();
+    });
+
+    it('ignores Ctrl+A (does not select all)', async () => {
+      const component = renderComponent({ props: { multiple: false } });
+      const listbox = await screen.findByRole('listbox');
+      listbox.focus();
+
+      await userEvent.keyboard('{Control>}a{/Control}');
+
+      expect(component.emitted().input).toBeUndefined();
+    });
+  });
+
   describe('listbox focus', () => {
     describe('if none of the options are selected before the listbox receives focus ', () => {
       it('focus is set on the first option and there is no automatic change in the selection state', async () => {

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -438,6 +438,7 @@
   .k-listbox-select-all {
     display: flex;
     align-items: center;
+    padding-inline-start: 4px;
   }
 
   .k-listbox-list {

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -438,7 +438,7 @@
   .k-listbox-select-all {
     display: flex;
     align-items: center;
-    padding-inline-start: 4px;
+    padding-left: 4px;
   }
 
   .k-listbox-list {

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -297,7 +297,9 @@
         isSelected,
         isFocused,
         toggleOption,
-        multiple: props.multiple,
+        get multiple() {
+          return props.multiple;
+        },
       });
 
       onMounted(() => {

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -13,7 +13,7 @@
       checkbox is clicked (otherwise click would cause double-toggle, resulting in no change))
     -->
     <div
-      v-if="$scopedSlots.selectAll"
+      v-if="multiple && $scopedSlots.selectAll"
       class="k-listbox-select-all"
       :class="$computedClass(selectAllStyles)"
       :style="{ backgroundColor: $themeTokens.surface }"
@@ -173,6 +173,7 @@
 
       function changeSelectAll(checked) {
         if (!hasOptions.value) return;
+        if (!props.multiple) return; // Prevent "select all" in single-select mode
         if (checked) {
           selectAllOptions();
         } else {
@@ -271,6 +272,9 @@
           case 'A':
             if (!event.ctrlKey && !event.metaKey) {
               return;
+            }
+            if (!props.multiple) {
+              return; // Do not allow select-all in single-select mode
             }
             if (allSelected.value) {
               deselectAllOptions();
@@ -396,7 +400,10 @@
       },
       /**
        * Whether the listbox allows multiple selections.
-       * Controls the aria-multiselectable attribute.
+       * Controls both the aria-multiselectable ARIA attribute and the
+       * actual selection behavior: when false, re-clicking an already
+       * selected option does nothing, and selecting a new option replaces
+       * the current selection instead of adding to it.
        */
       multiple: {
         type: Boolean,

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -297,6 +297,7 @@
         isSelected,
         isFocused,
         toggleOption,
+        getMessage,
         get multiple() {
           return props.multiple;
         },

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -354,7 +354,8 @@
         required: true,
       },
       /**
-       * Array of currently selected option values
+       * Array of selected option values. Always an Array in both single and
+       * multi-select modes for a consistent v-model API.
        */
       value: {
         type: Array,

--- a/lib/candidate/listbox/KListbox/index.vue
+++ b/lib/candidate/listbox/KListbox/index.vue
@@ -297,6 +297,7 @@
         isSelected,
         isFocused,
         toggleOption,
+        multiple: props.multiple,
       });
 
       onMounted(() => {

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -41,10 +41,11 @@
       }"
     >
       <KIcon
-        v-if="isSelected"
         icon="done"
         aria-hidden="true"
         class="k-option-check-icon"
+        :color="$themeTokens.primary"
+        :style="{ visibility: isSelected ? 'visible' : 'hidden' }"
       />
       <slot>{{ label }}</slot>
     </span>
@@ -167,7 +168,7 @@
 
   .k-option-check-icon {
     flex-shrink: 0;
-    font-size: 18px;
+    font-size: 16px;
   }
 
 </style>

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -42,10 +42,9 @@
     >
       <KIcon
         icon="done"
-        aria-hidden="true"
         class="k-option-check-icon"
         :color="$themeTokens.primary"
-        :style="{ visibility: isSelected ? 'visible' : 'hidden' }"
+        :style="{ visibility: isSelected ? 'visible' : 'hidden', top: '0' }"
       />
       <slot>{{ label }}</slot>
     </span>
@@ -156,7 +155,7 @@
     display: flex;
     align-items: center;
     min-height: 36px;
-    padding-inline-start: 4px;
+    padding-left: 4px;
     cursor: pointer;
   }
 

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -61,7 +61,15 @@
       const uid = optionCount++;
       const optionId = `klistbox-option-${uid}`;
 
-      onMounted(() => listbox.registerOption({ id: optionId, value: props.value }));
+      onMounted(() => {
+        listbox.registerOption({ id: optionId, value: props.value });
+        if (process.env.NODE_ENV !== 'production' && props.showCheckbox && !listbox.multiple) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "[KListboxOption] 'showCheckbox' is true but the parent KListbox is in single-select mode ('multiple: false'). Set 'showCheckbox: false' to hide the checkbox.",
+          );
+        }
+      });
 
       onBeforeUnmount(() => listbox.unregisterOption({ id: optionId, value: props.value }));
 

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -14,7 +14,7 @@
       than necessary and aligns it correctly within the row
     -->
     <KCheckbox
-      v-if="showCheckbox"
+      v-if="effectiveShowSelector"
       presentational
       :style="{ marginTop: '6px', marginBottom: '0' }"
       :checked="isSelected"
@@ -22,20 +22,30 @@
       :label="label"
     >
       <!-- @slot For customizing option label -->
-      <slot></slot>
+      <slot>{{ label }}</slot>
+      <span
+        v-if="indeterminate && partiallySelectedText"
+        class="visuallyhidden"
+        aria-hidden="false"
+      >
+        {{ partiallySelectedText }}
+      </span>
     </KCheckbox>
-    <!--
-      When showCheckbox is false (e.g. single-select or hideSelected mode),
-      render the label as plain text. aria-selected on the <li> still conveys
-      the selected state to screen readers.
-    -->
+
     <span
       v-else
+      class="k-option-plain-label"
       :style="{
         color: isSelected ? $themeTokens.primary : 'inherit',
         fontWeight: isSelected ? '500' : 'normal',
       }"
     >
+      <KIcon
+        v-if="isSelected"
+        icon="done"
+        aria-hidden="true"
+        class="k-option-check-icon"
+      />
       <slot>{{ label }}</slot>
     </span>
   </li>
@@ -63,12 +73,6 @@
 
       onMounted(() => {
         listbox.registerOption({ id: optionId, value: props.value });
-        if (process.env.NODE_ENV !== 'production' && props.showCheckbox && !listbox.multiple) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            "[KListboxOption] 'showCheckbox' is true but the parent KListbox is in single-select mode ('multiple: false'). Set 'showCheckbox: false' to hide the checkbox.",
-          );
-        }
       });
 
       onBeforeUnmount(() => listbox.unregisterOption({ id: optionId, value: props.value }));
@@ -88,12 +92,24 @@
         listbox.toggleOption(props.value);
       }
 
+      const partiallySelectedText = computed(() => {
+        if (!listbox.getMessage) return null;
+        return listbox.getMessage('partiallySelected') || null;
+      });
+
+      const effectiveShowSelector = computed(() => {
+        if (props.showSelector !== null) return props.showSelector;
+        return listbox.multiple;
+      });
+
       return {
         optionId,
         isSelected,
         isFocused,
         rowStyles,
         onClick,
+        partiallySelectedText,
+        effectiveShowSelector,
       };
     },
     props: {
@@ -112,19 +128,20 @@
         required: true,
       },
       /**
-       * Indeterminate visual state for group checkboxes.
+       * Sets the selection indicator to an indeterminate state.
+       * Use when some but not all options within a group are selected.
        */
       indeterminate: {
         type: Boolean,
         default: false,
       },
       /**
-       * When true, wraps the option label in a KCheckbox for multi-select use cases.
-       * When false, renders a plain label for single-select use cases.
+       * Controls whether the selector is shown. By default it is `null`, which hides
+       * it in single-select and shows it in multi-select. Set to `true` or `false` to override.
        */
-      showCheckbox: {
+      showSelector: {
         type: Boolean,
-        default: true,
+        default: null,
       },
     },
   };
@@ -138,7 +155,19 @@
     display: flex;
     align-items: center;
     min-height: 36px;
+    padding-inline-start: 4px;
     cursor: pointer;
+  }
+
+  .k-option-plain-label {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .k-option-check-icon {
+    flex-shrink: 0;
+    font-size: 18px;
   }
 
 </style>

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -70,8 +70,7 @@
       const isFocused = computed(() => listbox.isFocused(props.value));
 
       const rowStyles = computed(() => ({
-        backgroundColor:
-          !props.showCheckbox && isSelected.value ? 'rgba(0, 0, 0, 0.05)' : themeTokens().surface,
+        backgroundColor: themeTokens().surface,
         ':hover': {
           backgroundColor: themePalette().grey.v_100,
         },

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -31,8 +31,10 @@
     -->
     <span
       v-else
-      class="k-listbox-option-label"
-      :style="{ lineHeight: '24px' }"
+      :style="{
+        color: isSelected ? $themeTokens.primary : 'inherit',
+        fontWeight: isSelected ? '500' : 'normal',
+      }"
     >
       <slot>{{ label }}</slot>
     </span>
@@ -68,7 +70,8 @@
       const isFocused = computed(() => listbox.isFocused(props.value));
 
       const rowStyles = computed(() => ({
-        backgroundColor: themeTokens().surface,
+        backgroundColor:
+          !props.showCheckbox && isSelected.value ? 'rgba(0, 0, 0, 0.05)' : themeTokens().surface,
         ':hover': {
           backgroundColor: themePalette().grey.v_100,
         },
@@ -109,10 +112,8 @@
         default: false,
       },
       /**
-       * When true (default), wraps the option label in a KCheckbox for
-       * multi-select use cases. When false, renders a plain label — used
-       * when checkboxes are not meaningful (e.g. single-select, or
-       * hideSelected mode where selected items are already removed from the list).
+       * When true, wraps the option label in a KCheckbox for multi-select use cases.
+       * When false, renders a plain label for single-select use cases.
        */
       showCheckbox: {
         type: Boolean,

--- a/lib/candidate/listbox/KListboxOption/index.vue
+++ b/lib/candidate/listbox/KListboxOption/index.vue
@@ -6,7 +6,7 @@
     class="k-listbox-option"
     :class="$computedClass(rowStyles)"
     :style="isFocused ? { ...$coreOutline, outlineOffset: '-3px' } : {}"
-    :aria-selected="String(isSelected)"
+    :aria-selected="indeterminate ? undefined : String(isSelected)"
     @click="onClick"
   >
     <!--

--- a/lib/candidate/multiselect/KMultiSelect/components/KMultiSelectNode.vue
+++ b/lib/candidate/multiselect/KMultiSelect/components/KMultiSelectNode.vue
@@ -9,7 +9,7 @@
       :value="node.value"
       :label="node.label"
       :indeterminate="isIndeterminate"
-      :showCheckbox="showCheckbox"
+      :showSelector="showSelector"
       :style="indentStyle"
     >
       <template v-if="$scopedSlots.option">
@@ -26,7 +26,7 @@
       :key="child.value"
       :node="child"
       :depth="depth + 1"
-      :showCheckbox="showCheckbox"
+      :showSelector="showSelector"
       :indeterminateValues="indeterminateValues"
     >
       <template
@@ -45,7 +45,7 @@
     v-else
     :value="node.value"
     :label="node.label"
-    :showCheckbox="showCheckbox"
+    :showSelector="showSelector"
     :style="indentStyle"
   >
     <template v-if="$scopedSlots.option">
@@ -114,7 +114,7 @@
        * When false, options are rendered without a checkbox visual.
        * Derived automatically by KMultiSelectDropdown as `multiple && !hideSelected`.
        */
-      showCheckbox: {
+      showSelector: {
         type: Boolean,
         default: true,
       },


### PR DESCRIPTION
<!-- Please remove any unused sections -->

## Description
This PR updates `KListbox` to natively support strict single-selection. This is a foundational requirement for the upcoming `KMultiSelect` component, which needs to be able to operate in a single-select mode without checkboxes. It introduces a functional `multiple="false"` guard to the listbox and a `showCheckbox="false"` visual fallback to the options.


https://github.com/user-attachments/assets/7c8c268c-1b7e-4548-8346-54c6768817c3




#### Issue addressed
Addresses #1292 

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

  - **Description:** Added native single-select support to `KListbox` and `KListboxOption`.
  - **Products impact:** none
  - **Addresses:** #1292 
  - **Components:** KListbox, KListboxOption
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** Set `multiple="false"` on `KListbox` and `showCheckbox="false"` on `KListboxOption` to enforce single selection rules (disables Ctrl+A, replaces value instead of appending) while dropping the visual checkbox for plain text rendering with selection highlighting.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Navigate to the `KListbox` component page in the local documentation.
2. Scroll down to the new **Single Select** example.
3. Verify that clicking options correctly replaces the active selection (rather than selecting multiple).
4. Verify that the `Ctrl+A` "select all" keyboard shortcut is blocked.
5. Verify that selected options highlight with the primary blue text and a subtle gray background.

## (optional) Implementation notes

### At a high level, how did you implement this?
- Added `multiple` prop to `KListbox`. When false, clicking an option replaces the array and ignores `Ctrl+A`.
- Added `showCheckbox` prop to `KListboxOption`. When false, the `KCheckbox` wrapper is removed and replaced with a plain `<span class="k-listbox-option-label">`.
- Migrated inline styles to the `<style>` block and strictly maintained the `36px` minimum row height and `24px` line height to ensure absolute visual parity with the checkbox rows.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests
- [x] The change is described in the changelog section above

## Reviewer guidance

- [x] Is the code clean and well-commented?
- [x] Are there tests for this change?
- [x] Are all UI components LTR and RTL compliant (if applicable)?

## Comments
**Note to reviewers:** This branch (`feature/klistbox-single-select`) was branched off of my previous PR for `feature/kmultiselect-components-input-node`. Therefore, the git diff currently shows the `KMultiSelectInput` and `KMultiSelectNode` files as well. 

If my previous PR (#1289) gets merged first, I can rebase this branch to clean up the diff. Otherwise, you can focus your review on the `KListbox` and `KListboxOption` directories!
