### PR TITLE
Expose theme values as CSS variables 

### DIFF
--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -1,4 +1,5 @@
 <template>
+
   <DocsPageTemplate>
     <DocsPageSection
       title="1. Install the plugin"
@@ -94,4 +95,5 @@
       </p>
     </DocsPageSection>
   </DocsPageTemplate>
+
 </template>

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -42,10 +42,10 @@
         </li>
         <li>Globally registers all KDS Vue components.</li>
         <li>
-          Emits theme values as CSS variables (<code>--theme-*</code>, <code>--brand-*</code>, and
+          Emits theme values as CSS variables (<code>--tokens-*</code>, <code>--brand-*</code>, and
           <code>--palette-*</code>) to a <code>&lt;style&gt;</code> tag
           <code>#k-theme-css-variables</code> in an application's document head so that styles can
-          reference them directly, for example <code>var(--theme-primary)</code>. The variables are
+          reference them directly, for example <code>var(--tokens-primary)</code>. The variables are
           updated whenever the theme changes via <code>setBrandColors()</code> or
           <code>setTokenMapping()</code>.
         </li>

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -1,5 +1,4 @@
 <template>
-
   <DocsPageTemplate>
     <DocsPageSection
       title="1. Install the plugin"
@@ -41,6 +40,14 @@
           Vue instances.
         </li>
         <li>Globally registers all KDS Vue components.</li>
+        <li>
+          Emits theme values as CSS variables (<code>--theme-*</code>, <code>--brand-*</code>, and
+          <code>--palette-*</code>) to a <code>&lt;style&gt;</code> tag
+          <code>#k-theme-css-variables</code> in an application's document head so that styles can
+          reference them directly, for example <code>var(--theme-primary)</code>. The variables are
+          updated whenever the theme changes via <code>setBrandColors()</code> or
+          <code>setTokenMapping()</code>.
+        </li>
         <li>
           Inserts assertive and polite ARIA live regions <code>#k-live-region</code> to an
           application's document body (see
@@ -87,5 +94,4 @@
       </p>
     </DocsPageSection>
   </DocsPageTemplate>
-
 </template>

--- a/docs/plugins/load-lib-components.js
+++ b/docs/plugins/load-lib-components.js
@@ -2,6 +2,10 @@ import Vue from 'vue';
 import VueIntl from 'vue-intl';
 import KThemePlugin from '~~/lib/KThemePlugin';
 import trackInputModality from '~~/lib/styles/trackInputModality';
+import {
+  themeCssVariablesText,
+  THEME_CSS_VARIABLES_STYLE_ID,
+} from '~~/lib/styles/themeCssVariables';
 
 // `KThemePlugin` dependency needed for outline style when
 // navigating between KDS components with keyboard
@@ -10,3 +14,21 @@ trackInputModality({ disableFocusRingByDefault: false });
 
 Vue.use(KThemePlugin);
 Vue.use(VueIntl);
+
+export default function ({ app }) {
+  // SSR only: emit theme CSS variables into a head `<style>` tag so the first
+  // paint is themed. On the client, the `KThemePlugin` watcher takes over the
+  // tag and strips vue-meta's marker attributes so vue-meta never overwrites
+  // it with stale CSS.
+  if (process.server) {
+    app.head.style = app.head.style || [];
+    if (!app.head.style.some(style => style.id === THEME_CSS_VARIABLES_STYLE_ID)) {
+      app.head.style.push({
+        hid: THEME_CSS_VARIABLES_STYLE_ID,
+        id: THEME_CSS_VARIABLES_STYLE_ID,
+        type: 'text/css',
+        cssText: themeCssVariablesText(),
+      });
+    }
+  }
+}

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -65,8 +65,6 @@ require('./grids/globalStyles.js'); // global grid styles
  * Also, set up global state, listeners, and styles.
  */
 export default function KThemePlugin(Vue) {
-  initThemeCssVariables();
-
   if (!isNuxtServerSideRendering() && process.env.VISUAL_TESTING !== 'true') {
     const onDomReady = () => {
       _mountLiveRegion();
@@ -80,6 +78,8 @@ export default function KThemePlugin(Vue) {
       onDomReady();
     }
   }
+
+  initThemeCssVariables();
 
   Vue.mixin({
     computed: {

--- a/lib/KThemePlugin.js
+++ b/lib/KThemePlugin.js
@@ -50,6 +50,7 @@ import KSnackbar from './KSnackbar/KSnackbar.vue';
 
 import { themeTokens, themeBrand, themePalette, themeOutlineStyle } from './styles/theme';
 import globalThemeState from './styles/globalThemeState';
+import initThemeCssVariables from './styles/themeCssVariables';
 
 import useKLiveRegion from './composables/useKLiveRegion';
 import _useOverlay from './composables/_useOverlay';
@@ -64,6 +65,8 @@ require('./grids/globalStyles.js'); // global grid styles
  * Also, set up global state, listeners, and styles.
  */
 export default function KThemePlugin(Vue) {
+  initThemeCssVariables();
+
   if (!isNuxtServerSideRendering() && process.env.VISUAL_TESTING !== 'true') {
     const onDomReady = () => {
       _mountLiveRegion();

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -1,0 +1,195 @@
+const TEST_BRAND_COLORS = {
+  primary: {
+    v_100: '#CCE7E7',
+    v_200: '#99CFCF',
+    v_300: '#66B7B7',
+    v_400: '#339F9F',
+    v_500: '#008787',
+    v_600: '#006C6C',
+  },
+  secondary: {
+    v_100: '#F3D5CC',
+    v_200: '#E7AB99',
+    v_300: '#DB8166',
+    v_400: '#CF5733',
+    v_500: '#C32D00',
+    v_600: '#9C2400',
+  },
+};
+
+// The tests assert against the serialized CSS text of the emitted `<style>`
+// tag rather than `getComputedStyle(document.documentElement)` because jsdom's
+// support for the custom property cascade is unreliable.
+describe('themeCssVariables', () => {
+  let Vue;
+  let themeCssVariables;
+  let theme;
+  let palette;
+  let brand;
+
+  beforeEach(() => {
+    // fresh modules so that the `initialized` flag and
+    // `globalThemeState` are reset between tests
+    jest.resetModules();
+    document.head.innerHTML = '';
+    Vue = require('vue');
+    themeCssVariables = require('../themeCssVariables');
+    theme = require('../theme');
+    palette = require('../colorsMaterial').default;
+    brand = require('../colorsDefault').defaultBrandColors;
+  });
+
+  afterEach(() => {
+    delete process.server;
+  });
+
+  function getStyleTag() {
+    return document.getElementById(themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID);
+  }
+
+  it('smoke test: initializes without throwing', () => {
+    expect(() => themeCssVariables.default()).not.toThrow();
+  });
+
+  describe('generateThemeCssVariables', () => {
+    it('emits palette colors with version keys formatted as vN', () => {
+      const variables = themeCssVariables.generateThemeCssVariables();
+      expect(variables['--palette-grey-v400']).toBe(palette.grey.v_400);
+      expect(variables['--palette-black']).toBe(palette.black);
+      expect(variables['--palette-white']).toBe(palette.white);
+      // the `v_N` form should not be emitted
+      expect(variables['--palette-grey-v_400']).toBeUndefined();
+    });
+
+    it('emits brand colors with version keys formatted as vN', () => {
+      const variables = themeCssVariables.generateThemeCssVariables();
+      expect(variables['--brand-primary-v600']).toBe(brand.primary.v_600);
+      expect(variables['--brand-secondary-v100']).toBe(brand.secondary.v_100);
+      // the `v_N` form should not be emitted
+      expect(variables['--brand-primary-v_600']).toBeUndefined();
+    });
+
+    it('emits theme tokens as-is, resolved to color values', () => {
+      const variables = themeCssVariables.generateThemeCssVariables();
+      // default token mapping: primary -> brand.primary.v_500,
+      // focusOutline -> palette.lightblue.v_400, text -> palette.black
+      expect(variables['--theme-primary']).toBe(brand.primary.v_500);
+      expect(variables['--theme-focusOutline']).toBe(palette.lightblue.v_400);
+      expect(variables['--theme-text']).toBe(palette.black);
+    });
+  });
+
+  describe('themeCssVariablesText', () => {
+    it('returns a :root rule containing the variables', () => {
+      const cssText = themeCssVariables.themeCssVariablesText();
+      expect(cssText).toMatch(/^:root\s*\{/);
+      expect(cssText).toContain(`--palette-grey-v400: ${palette.grey.v_400};`);
+      expect(cssText).toContain(`--brand-primary-v600: ${brand.primary.v_600};`);
+      expect(cssText).toContain(`--theme-primary: ${brand.primary.v_500};`);
+    });
+  });
+
+  describe('initThemeCssVariables', () => {
+    it('writes the variables to a style tag in the document head', () => {
+      themeCssVariables.default();
+      const styleTag = getStyleTag();
+      expect(styleTag).toBeInTheDocument();
+      expect(document.head).toContainElement(styleTag);
+      // exact-equality on textContent is intentional, to verify the exact serialized
+      // output (`toHaveTextContent` would normalize whitespace)
+      const cssText = styleTag.textContent;
+      expect(cssText).toEqual(themeCssVariables.themeCssVariablesText());
+    });
+
+    it('is initialized only once', async () => {
+      themeCssVariables.default();
+      themeCssVariables.default();
+      expect(
+        document.head.querySelectorAll(`#${themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID}`),
+      ).toHaveLength(1);
+      // updates keep working after a redundant initialization
+      theme.setBrandColors(TEST_BRAND_COLORS);
+      await Vue.nextTick();
+      expect(getStyleTag()).toHaveTextContent(
+        `--theme-primary: ${TEST_BRAND_COLORS.primary.v_500};`,
+      );
+    });
+
+    it('updates the variables when brand colors change', async () => {
+      themeCssVariables.default();
+      theme.setBrandColors(TEST_BRAND_COLORS);
+      await Vue.nextTick();
+      const styleTag = getStyleTag();
+      expect(styleTag).toHaveTextContent(
+        `--brand-primary-v500: ${TEST_BRAND_COLORS.primary.v_500};`,
+      );
+      expect(styleTag).toHaveTextContent(
+        `--brand-secondary-v600: ${TEST_BRAND_COLORS.secondary.v_600};`,
+      );
+      // `primary` token maps to `brand.primary.v_500`
+      expect(styleTag).toHaveTextContent(`--theme-primary: ${TEST_BRAND_COLORS.primary.v_500};`);
+      // unrelated variables are still emitted, unchanged
+      expect(styleTag).toHaveTextContent(`--palette-grey-v400: ${palette.grey.v_400};`);
+    });
+
+    it('updates the variables when the token mapping changes', async () => {
+      themeCssVariables.default();
+      theme.setTokenMapping({ primary: 'palette.green.v_500' });
+      await Vue.nextTick();
+      expect(getStyleTag()).toHaveTextContent(`--theme-primary: ${palette.green.v_500};`);
+    });
+
+    it('emits newly added tokens', async () => {
+      themeCssVariables.default();
+      theme.setTokenMapping({ customToken: 'palette.red.v_500' });
+      await Vue.nextTick();
+      expect(getStyleTag()).toHaveTextContent(`--theme-customToken: ${palette.red.v_500};`);
+    });
+  });
+
+  describe('with server-side rendering', () => {
+    it('does not touch the document on the server', () => {
+      // set the flag before the module is required, so that the test stays
+      // correct even if the SSR check were moved to import time
+      jest.resetModules();
+      process.server = true;
+      const ssrThemeCssVariables = require('../themeCssVariables');
+      ssrThemeCssVariables.default();
+      expect(document.head.querySelector('style')).toBeNull();
+      // the text used for server-side head injection is still generated
+      expect(ssrThemeCssVariables.themeCssVariablesText()).toContain('--theme-primary:');
+    });
+
+    it('takes over the server-rendered tag from vue-meta', () => {
+      // simulate a tag rendered into the head by the server via vue-meta
+      const ssrStyleTag = document.createElement('style');
+      ssrStyleTag.id = themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID;
+      ssrStyleTag.setAttribute('data-n-head', 'ssr');
+      ssrStyleTag.setAttribute('data-hid', themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID);
+      document.head.appendChild(ssrStyleTag);
+
+      themeCssVariables.default();
+      // vue-meta's marker attributes are removed so that vue-meta can neither
+      // remove the tag on head updates nor rewrite it with stale CSS
+      expect(ssrStyleTag).not.toHaveAttribute('data-n-head');
+      expect(ssrStyleTag).not.toHaveAttribute('data-hid');
+    });
+
+    it('reuses and updates the style tag written during server-side rendering', async () => {
+      // simulate a tag rendered into the head by the server
+      const ssrStyleTag = document.createElement('style');
+      ssrStyleTag.id = themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID;
+      ssrStyleTag.textContent = themeCssVariables.themeCssVariablesText();
+      document.head.appendChild(ssrStyleTag);
+
+      themeCssVariables.default();
+      expect(
+        document.head.querySelectorAll(`#${themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID}`),
+      ).toHaveLength(1);
+
+      theme.setBrandColors(TEST_BRAND_COLORS);
+      await Vue.nextTick();
+      expect(ssrStyleTag).toHaveTextContent(`--theme-primary: ${TEST_BRAND_COLORS.primary.v_500};`);
+    });
+  });
+});

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -17,9 +17,6 @@ const TEST_BRAND_COLORS = {
   },
 };
 
-// The tests assert against the serialized CSS text of the emitted `<style>`
-// tag rather than `getComputedStyle(document.documentElement)` because jsdom's
-// support for the custom property cascade is unreliable.
 describe('themeCssVariables', () => {
   let Vue;
   let themeCssVariables;
@@ -73,9 +70,18 @@ describe('themeCssVariables', () => {
       const variables = themeCssVariables.generateThemeCssVariables();
       // default token mapping: primary -> brand.primary.v_500,
       // focusOutline -> palette.lightblue.v_400, text -> palette.black
-      expect(variables['--theme-primary']).toBe(brand.primary.v_500);
-      expect(variables['--theme-focusOutline']).toBe(palette.lightblue.v_400);
-      expect(variables['--theme-text']).toBe(palette.black);
+      expect(variables['--tokens-primary']).toBe(brand.primary.v_500);
+      expect(variables['--tokens-focusOutline']).toBe(palette.lightblue.v_400);
+      expect(variables['--tokens-text']).toBe(palette.black);
+    });
+
+    it('skips and warns on a token name that would corrupt the CSS rule', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      theme.setTokenMapping({ 'evil: red; } body { color': 'palette.red.v_500' });
+      const variables = themeCssVariables.generateThemeCssVariables();
+      expect(Object.keys(variables).some(name => name.includes('evil'))).toBe(false);
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
     });
   });
 
@@ -85,7 +91,7 @@ describe('themeCssVariables', () => {
       expect(cssText).toMatch(/^:root\s*\{/);
       expect(cssText).toContain(`--palette-grey-v400: ${palette.grey.v_400};`);
       expect(cssText).toContain(`--brand-primary-v600: ${brand.primary.v_600};`);
-      expect(cssText).toContain(`--theme-primary: ${brand.primary.v_500};`);
+      expect(cssText).toContain(`--tokens-primary: ${brand.primary.v_500};`);
     });
   });
 
@@ -111,7 +117,7 @@ describe('themeCssVariables', () => {
       theme.setBrandColors(TEST_BRAND_COLORS);
       await Vue.nextTick();
       expect(getStyleTag()).toHaveTextContent(
-        `--theme-primary: ${TEST_BRAND_COLORS.primary.v_500};`,
+        `--tokens-primary: ${TEST_BRAND_COLORS.primary.v_500};`,
       );
     });
 
@@ -127,7 +133,7 @@ describe('themeCssVariables', () => {
         `--brand-secondary-v600: ${TEST_BRAND_COLORS.secondary.v_600};`,
       );
       // `primary` token maps to `brand.primary.v_500`
-      expect(styleTag).toHaveTextContent(`--theme-primary: ${TEST_BRAND_COLORS.primary.v_500};`);
+      expect(styleTag).toHaveTextContent(`--tokens-primary: ${TEST_BRAND_COLORS.primary.v_500};`);
       // unrelated variables are still emitted, unchanged
       expect(styleTag).toHaveTextContent(`--palette-grey-v400: ${palette.grey.v_400};`);
     });
@@ -136,14 +142,14 @@ describe('themeCssVariables', () => {
       themeCssVariables.default();
       theme.setTokenMapping({ primary: 'palette.green.v_500' });
       await Vue.nextTick();
-      expect(getStyleTag()).toHaveTextContent(`--theme-primary: ${palette.green.v_500};`);
+      expect(getStyleTag()).toHaveTextContent(`--tokens-primary: ${palette.green.v_500};`);
     });
 
     it('emits newly added tokens', async () => {
       themeCssVariables.default();
       theme.setTokenMapping({ customToken: 'palette.red.v_500' });
       await Vue.nextTick();
-      expect(getStyleTag()).toHaveTextContent(`--theme-customToken: ${palette.red.v_500};`);
+      expect(getStyleTag()).toHaveTextContent(`--tokens-customToken: ${palette.red.v_500};`);
     });
   });
 
@@ -157,7 +163,7 @@ describe('themeCssVariables', () => {
       ssrThemeCssVariables.default();
       expect(document.head.querySelector('style')).toBeNull();
       // the text used for server-side head injection is still generated
-      expect(ssrThemeCssVariables.themeCssVariablesText()).toContain('--theme-primary:');
+      expect(ssrThemeCssVariables.themeCssVariablesText()).toContain('--tokens-primary:');
     });
 
     it('takes over the server-rendered tag from vue-meta', () => {
@@ -189,7 +195,9 @@ describe('themeCssVariables', () => {
 
       theme.setBrandColors(TEST_BRAND_COLORS);
       await Vue.nextTick();
-      expect(ssrStyleTag).toHaveTextContent(`--theme-primary: ${TEST_BRAND_COLORS.primary.v_500};`);
+      expect(ssrStyleTag).toHaveTextContent(
+        `--tokens-primary: ${TEST_BRAND_COLORS.primary.v_500};`,
+      );
     });
   });
 });

--- a/lib/styles/globalThemeState.js
+++ b/lib/styles/globalThemeState.js
@@ -11,6 +11,10 @@ const globalThemeState = Vue.observable({
     brand: defaultBrandColors,
   },
   tokenMapping: defaultTokenMapping,
+  // Resolved semantic tokens from `theme.js`. Kept here to ensure reading
+  // `globalThemeState.tokens` registers a reactive dependency that
+  // triggers when tokens are added at runtime.
+  tokens: {},
 });
 
 export default globalThemeState;

--- a/lib/styles/theme.js
+++ b/lib/styles/theme.js
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import { set } from 'vue';
 import globalThemeState from './globalThemeState';
 
 function throwThemeError(tokenName, mapString) {
@@ -76,9 +76,9 @@ export function setBrandColors(brandColors) {
 }
 
 export function setTokenMapping(tokenMapping) {
-  // Vue.set so that watchers of globalThemeState also see newly added tokens
+  // `set` so that watchers of globalThemeState also see newly added tokens
   Object.keys(tokenMapping).forEach(tokenName => {
-    Vue.set(globalThemeState.tokenMapping, tokenName, tokenMapping[tokenName]);
+    set(globalThemeState.tokenMapping, tokenName, tokenMapping[tokenName]);
   });
   generateTokenToColorMapping();
 }

--- a/lib/styles/theme.js
+++ b/lib/styles/theme.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import globalThemeState from './globalThemeState';
 
 function throwThemeError(tokenName, mapString) {
@@ -75,6 +76,9 @@ export function setBrandColors(brandColors) {
 }
 
 export function setTokenMapping(tokenMapping) {
-  Object.assign(globalThemeState.tokenMapping, tokenMapping);
+  // Vue.set so that watchers of globalThemeState also see newly added tokens
+  Object.keys(tokenMapping).forEach(tokenName => {
+    Vue.set(globalThemeState.tokenMapping, tokenName, tokenMapping[tokenName]);
+  });
   generateTokenToColorMapping();
 }

--- a/lib/styles/theme.js
+++ b/lib/styles/theme.js
@@ -7,7 +7,8 @@ function throwThemeError(tokenName, mapString) {
 
 const HEX_COLOR_PATTERN = RegExp('#[0-9a-fA-F]{6}');
 
-const tokens = {};
+// allows the CSS variables watcher to update when tokens change or are added
+const tokens = globalThemeState.tokens;
 
 /*
  * Maps tokens to specific hex values
@@ -42,7 +43,9 @@ function generateTokenToColorMapping() {
     // if we end up at a valid string, use it
     newTokens[tokenName] = obj;
   });
-  Object.assign(tokens, newTokens);
+  Object.keys(newTokens).forEach(tokenName => {
+    set(tokens, tokenName, newTokens[tokenName]);
+  });
   return tokens;
 }
 

--- a/lib/styles/themeCssVariables.js
+++ b/lib/styles/themeCssVariables.js
@@ -1,9 +1,13 @@
 import Vue from 'vue';
 import { isNuxtServerSideRendering } from '../utils';
 import globalThemeState from './globalThemeState';
+// side-effect import: loading `theme.js` sets `globalThemeState.tokens`,
+// which the `--tokens-*` CSS variables are read from
+import './theme';
 
 export const THEME_CSS_VARIABLES_STYLE_ID = 'k-theme-css-variables';
 
+const VALID_CSS_VARIABLE_NAME_PATTERN = /^--[\w-]+$/;
 // characters that would end a declaration or rule and corrupt the emitted CSS
 const UNSAFE_CSS_VALUE_PATTERN = /[;{}<>]/;
 
@@ -13,7 +17,7 @@ function warnVariableIssue(name, value) {
 }
 
 function setVariable(variables, name, value) {
-  if (UNSAFE_CSS_VALUE_PATTERN.test(value)) {
+  if (!VALID_CSS_VARIABLE_NAME_PATTERN.test(name) || UNSAFE_CSS_VALUE_PATTERN.test(value)) {
     warnVariableIssue(name, value);
     return;
   }
@@ -24,50 +28,33 @@ function formatPathSegment(key) {
   return key.replace(/^v_(\d+)$/, 'v$1');
 }
 
-function collectColorVariables(prefix, value, variables) {
+// Returns `{ '--name': value }` object for a color tree, walking nested
+// objects and joining path segments with hyphens.
+function collectColorVariables(prefix, value) {
+  const variables = {};
   if (typeof value === 'string') {
     setVariable(variables, prefix, value);
   } else if (value && typeof value === 'object') {
     Object.keys(value).forEach(key => {
-      collectColorVariables(`${prefix}-${formatPathSegment(key)}`, value[key], variables);
+      Object.assign(
+        variables,
+        collectColorVariables(`${prefix}-${formatPathSegment(key)}`, value[key]),
+      );
     });
   }
-}
-
-// Intentionally duplicates resolution from `theme.js`: its resolved tokens
-// object is non-observable, so reading it here would not register the
-// reactive dependencies the watcher relies on.
-function resolveTokenValue(mapString) {
-  // a value without dots is a CSS color value, not a path
-  if (mapString.indexOf('.') === -1) {
-    return mapString;
-  }
-  const refs = mapString.split('.');
-  let obj = globalThemeState.colors;
-  while (refs.length && obj) {
-    obj = obj[refs.shift()];
-  }
-  return typeof obj === 'string' ? obj : null;
+  return variables;
 }
 
 /**
- * Returns an object mapping CSS variable names to color values, from
- * the current `globalThemeState`.
+ * Returns a `{ '--name': value }` object of all theme CSS variables,
+ * from the current `globalThemeState`.
  */
 export function generateThemeCssVariables() {
-  const variables = {};
-  collectColorVariables('--palette', globalThemeState.colors.palette, variables);
-  collectColorVariables('--brand', globalThemeState.colors.brand, variables);
-  Object.keys(globalThemeState.tokenMapping).forEach(tokenName => {
-    const name = `--theme-${tokenName}`;
-    const value = resolveTokenValue(globalThemeState.tokenMapping[tokenName]);
-    if (value === null) {
-      warnVariableIssue(name, globalThemeState.tokenMapping[tokenName]);
-    } else {
-      setVariable(variables, name, value);
-    }
-  });
-  return variables;
+  return {
+    ...collectColorVariables('--palette', globalThemeState.colors.palette),
+    ...collectColorVariables('--brand', globalThemeState.colors.brand),
+    ...collectColorVariables('--tokens', globalThemeState.tokens),
+  };
 }
 
 /**
@@ -87,7 +74,7 @@ function updateStyleTag(cssText) {
     document.head.appendChild(styleTag);
   }
   // Strip vue-meta's marker attributes from an SSR-rendered tag so vue-meta
-  // never rewrites it with stale CSS; this module is the tag's only writer.
+  // never rewrites it with stale CSS; this module is the tag's only writer
   styleTag.removeAttribute('data-n-head');
   styleTag.removeAttribute('data-hid');
   styleTag.textContent = cssText;
@@ -105,9 +92,8 @@ export default function initThemeCssVariables() {
   if (watcherVm || isNuxtServerSideRendering() || typeof document === 'undefined') {
     return;
   }
-  updateStyleTag(themeCssVariablesText());
   // `globalThemeState` is a Vue observable, so the watcher re-runs whenever
-  // any value the CSS text is derived from changes
+  // any value that the CSS text is derived from changes
   watcherVm = new Vue();
-  watcherVm.$watch(themeCssVariablesText, newText => updateStyleTag(newText));
+  watcherVm.$watch(themeCssVariablesText, newText => updateStyleTag(newText), { immediate: true });
 }

--- a/lib/styles/themeCssVariables.js
+++ b/lib/styles/themeCssVariables.js
@@ -1,0 +1,113 @@
+import Vue from 'vue';
+import { isNuxtServerSideRendering } from '../utils';
+import globalThemeState from './globalThemeState';
+
+export const THEME_CSS_VARIABLES_STYLE_ID = 'k-theme-css-variables';
+
+// characters that would end a declaration or rule and corrupt the emitted CSS
+const UNSAFE_CSS_VALUE_PATTERN = /[;{}<>]/;
+
+function warnVariableIssue(name, value) {
+  // eslint-disable-next-line no-console
+  console.warn(`Theme CSS variables issue: unable to emit '${name}' with value '${value}'`);
+}
+
+function setVariable(variables, name, value) {
+  if (UNSAFE_CSS_VALUE_PATTERN.test(value)) {
+    warnVariableIssue(name, value);
+    return;
+  }
+  variables[name] = value;
+}
+
+function formatPathSegment(key) {
+  return key.replace(/^v_(\d+)$/, 'v$1');
+}
+
+function collectColorVariables(prefix, value, variables) {
+  if (typeof value === 'string') {
+    setVariable(variables, prefix, value);
+  } else if (value && typeof value === 'object') {
+    Object.keys(value).forEach(key => {
+      collectColorVariables(`${prefix}-${formatPathSegment(key)}`, value[key], variables);
+    });
+  }
+}
+
+// Intentionally duplicates resolution from `theme.js`: its resolved tokens
+// object is non-observable, so reading it here would not register the
+// reactive dependencies the watcher relies on.
+function resolveTokenValue(mapString) {
+  // a value without dots is a CSS color value, not a path
+  if (mapString.indexOf('.') === -1) {
+    return mapString;
+  }
+  const refs = mapString.split('.');
+  let obj = globalThemeState.colors;
+  while (refs.length && obj) {
+    obj = obj[refs.shift()];
+  }
+  return typeof obj === 'string' ? obj : null;
+}
+
+/**
+ * Returns an object mapping CSS variable names to color values, from
+ * the current `globalThemeState`.
+ */
+export function generateThemeCssVariables() {
+  const variables = {};
+  collectColorVariables('--palette', globalThemeState.colors.palette, variables);
+  collectColorVariables('--brand', globalThemeState.colors.brand, variables);
+  Object.keys(globalThemeState.tokenMapping).forEach(tokenName => {
+    const name = `--theme-${tokenName}`;
+    const value = resolveTokenValue(globalThemeState.tokenMapping[tokenName]);
+    if (value === null) {
+      warnVariableIssue(name, globalThemeState.tokenMapping[tokenName]);
+    } else {
+      setVariable(variables, name, value);
+    }
+  });
+  return variables;
+}
+
+/**
+ * Returns a `:root` CSS rule, setting all theme CSS variables.
+ */
+export function themeCssVariablesText() {
+  const variables = generateThemeCssVariables();
+  const declarations = Object.keys(variables).map(name => `  ${name}: ${variables[name]};`);
+  return `:root {\n${declarations.join('\n')}\n}`;
+}
+
+function updateStyleTag(cssText) {
+  let styleTag = document.getElementById(THEME_CSS_VARIABLES_STYLE_ID);
+  if (!styleTag) {
+    styleTag = document.createElement('style');
+    styleTag.id = THEME_CSS_VARIABLES_STYLE_ID;
+    document.head.appendChild(styleTag);
+  }
+  // Strip vue-meta's marker attributes from an SSR-rendered tag so vue-meta
+  // never rewrites it with stale CSS; this module is the tag's only writer.
+  styleTag.removeAttribute('data-n-head');
+  styleTag.removeAttribute('data-hid');
+  styleTag.textContent = cssText;
+}
+
+// non-null also serves as the initialization guard
+let watcherVm = null;
+
+/**
+ * Emits theme CSS variables to a `<style>` tag in the document head, reusing
+ * the tag written during server-side rendering if there is one, and keeps them
+ * in sync with `globalThemeState`.
+ */
+export default function initThemeCssVariables() {
+  if (watcherVm || isNuxtServerSideRendering() || typeof document === 'undefined') {
+    return;
+  }
+  updateStyleTag(themeCssVariablesText());
+  // `globalThemeState` is a Vue observable, so the watcher re-runs whenever
+  // any value the CSS text is derived from changes
+  watcherVm = new Vue();
+  watcherVm.$watch(themeCssVariablesText, newText => updateStyleTag(newText));
+}


### PR DESCRIPTION

## Description
This PR adds the file `themeCSSVariables.js`, and emits theme values (`--tokens-*`, `--brand-*`, and `--palette-*`) as CSS variables in a `:root` rule so they can be referenced directly with `var(--tokens-X)`, without going through Aphrodite. With server-side rendering, the initial values are rendered into a head <style> tag so the content is themed before any JavaScript runs.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1300 

## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Theme values are now emitted as CSS variables (`--tokens-*`, `--brand-*`, and `--palette-*`) in a `<style id="k-theme-css-variables">` tag in the document head, initialized by `KThemePlugin`, and kept in sync with `globalThemeState` at runtime. Version keys are emitted as `vN` (e.g. `palette.grey.v_400` -> `--palette-grey-v400`); token names are used as-is (e.g. `--theme-primary`). Also exports `themeCssVariablesText()` from `lib/styles/themeCssVariables` for SSR head injection.
  - **Products impact:** new API
  - **Addresses:** [Emit theme values as CSS variables on :root #1300](https://github.com/learningequality/kolibri-design-system/issues/1300)
  - **Components:** N/A
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** Styles can now reference theme values directly with `var(--theme-primary)`, `var(--brand-primary-v600)`, `var(--palette-grey-v400)`, etc., as an alternative to `$themeTokens`/`$themeBrand`/`$themePalette`. Existing APIs are unchanged.

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test

1. Run `yarn dev` and open the docs.
2. In devtools, confirm that the document head contains `<style id="k-theme-css-variables">` with a `:root` rule that defines `--palette-*`, `--brand-*`, and `--tokens-*` variables, and that the variables accurately correspond to the token mapping found in the files `colorsDefault.js` and `colorsMaterial.js`.
3. View the page source (SSR output) and confirm the same `<style>` tag with the variables is present in the head markup itself, i.e. before any JavaScript runs.
4. Navigate between doc pages client-side and confirm that the tag remains present and unchanged (to verify that vue-meta head updates don't remove or rewrite it).

## (optional) Implementation notes

### At a high level, how did you implement this?

- `lib/styles/themeCssVariables.js`: draws the variables from `globalThemeState` (`v_N` -> `vN` key formatting for palette and brand values; tokens resolved through `tokenMapping`), serializes them to a `:root` rule, and writes it to a `<style id="k-theme-css-variables">` tag in the document head.
- `initThemeCssVariables()` is called once from `KThemePlugin`. A `$watch` on the serialized CSS text re-runs whenever any brand color or token mapping it derives from changes, and rewrites the tag.
- `setTokenMapping()` in `theme.js` now uses `Vue.set` instead of `Object.assign`, so tokens added at runtime are reactive and picked up by the watcher.
- The Nuxt plugin registers the initial CSS as a head style entry on the server only. On the client, the watcher takes over the server-rendered tag and strips the vue-meta's marker attributes (`data-n-head`, `data-hid`) so vue-meta never removes it or rewrites it with stale CSS.
- Token resolution is intentionally duplicated from `theme.js`. The resolved tokens object there is non-observable, so reading it would not register the reactive dependencies relied upon by the watcher. The values are also checked against characters that would corrupt the emitted CSS.

### Does this introduce any tech-debt items?
- The token resolution logic exists in both `theme.js` and `themeCssVariables.js` because it is necessary for reactivity, documented in a code comment.
- The `v_N` -> `vN` reformatting will be removed after the JavaScript keys are renamed.

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [X] Contributor has fully tested the PR manually
- [X] Critical and brittle code paths are covered by unit tests
- [X] The change is described in the changelog section above

## Reviewer guidance
<!-- Delete anything that doesn't apply so your reviewer knows what to check for -->

- [ ] Is the code clean and well-commented?
- [ ] Are there tests for this change?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?
- [ ] _Add other things to check for here_

## Comments
I verified the SSR head output, hydration takeover of the SSR tag, and client-side navigation against the docs app in addition to the unit tests. I used Claude 🤖 to do a review of my initial changes and updated the code based on its findings.