### PR TITLE
Implement JS generated global styles with CSS variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["**.vue", "**.js", "yarn.lock"]'
+          paths: '["**.vue", "**.js", "yarn.lock", "**.scss"]'
   test:
     name: Frontend tests
     needs: pre_job

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -2,4 +2,6 @@ const stylelintConfig = require('kolibri-format/.stylelintrc');
 
 stylelintConfig['rules']['selector-pseudo-element-no-unknown'] = [true, { ignorePseudoElements: ['v-deep'] }];
 
+stylelintConfig['rules']['custom-property-pattern'] = ['^([a-z][a-zA-Z0-9]*)(-[a-zA-Z0-9]+)*$'];
+
 module.exports = stylelintConfig;

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -41,7 +41,7 @@ a {
   }
 }
 
-*:focus {
+*:focus-visible {
   outline: 5px solid #757575;
   outline-offset: 2px;
 }

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -1,5 +1,5 @@
 @import '~/assets/definitions';
-@import '../../lib/styles/common';
+@import '../../lib/styles/helper-styles';
 
 code {
   padding-right: 0.25em;

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -41,7 +41,7 @@ a {
   }
 }
 
-*:focus-visible {
+*:focus {
   outline: 5px solid #757575;
   outline-offset: 2px;
 }

--- a/docs/common/DocsColorBlock.vue
+++ b/docs/common/DocsColorBlock.vue
@@ -3,7 +3,7 @@
   <div class="block-wrapper">
     <div
       class="color-block"
-      :style="{ backgroundColor: value }"
+      :style="{ '--block-color': value }"
     ></div>
     <div class="code name">
       <code>{{ name }}</code><DocsAnchorTarget
@@ -101,8 +101,18 @@
     width: 40px;
     height: 40px;
     color: black;
+    background-color: var(--block-color);
     border: 1px solid #212121;
     border-radius: 4px;
+  }
+
+  // lib/styles/common.scss prints `* { background: none !important }`, which an inline
+  // style cannot outrank. The swatch is the content on these pages, so opt it back in
+  @media print {
+    .color-block {
+      background-color: var(--block-color) !important;
+      print-color-adjust: exact;
+    }
   }
 
   .code {

--- a/docs/common/DocsColorBlock.vue
+++ b/docs/common/DocsColorBlock.vue
@@ -3,7 +3,7 @@
   <div class="block-wrapper">
     <div
       class="color-block"
-      :style="{ '--block-color': value }"
+      :style="{ backgroundColor: value }"
     ></div>
     <div class="code name">
       <code>{{ name }}</code><DocsAnchorTarget
@@ -101,18 +101,8 @@
     width: 40px;
     height: 40px;
     color: black;
-    background-color: var(--block-color);
     border: 1px solid #212121;
     border-radius: 4px;
-  }
-
-  // lib/styles/common.scss prints `* { background: none !important }`, which an inline
-  // style cannot outrank. The swatch is the content on these pages, so opt it back in
-  @media print {
-    .color-block {
-      background-color: var(--block-color) !important;
-      print-color-adjust: exact;
-    }
   }
 
   .code {

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -128,11 +128,7 @@
       <p>This will display:</p>
 
       <DocsShow>
-        <div
-          :style="{ color: $themeTokens.primary }"
-        >
-          This is not an error
-        </div>
+        <div :style="{ color: $themeTokens.primary }">This is not an error</div>
       </DocsShow>
 
       <p>Move style definitions from the template to computed props if the style gets complex.</p>

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -576,22 +576,22 @@
 
 <style lang="scss" scoped>
 
-  .palette-block {
-    display: inline-block;
-    width: 350px;
-  }
+      .palette-block {
+        display: inline-block;
+        width: 350px;
+      }
 
-  .darken-block {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 140px;
-    height: 140px;
+      .darken-block {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 140px;
+        height: 140px;
 
-    code {
-      padding: 4px;
-      background-color: rgba(255, 255, 255, 0.8);
-    }
-  }
+        code {
+          padding: 4px;
+          background-color: rgba(255, 255, 255, 0.8);
+        }
+      }
 
 </style>

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -91,7 +91,7 @@
       <p>This will display:</p>
 
       <DocsShow>
-        <div class="error-message">This is an error</div>
+        <div class="error-message text-block">This is an error</div>
       </DocsShow>
       <p>
         For palette and brand variables, replace the dots in the path with hyphens and drop the
@@ -114,7 +114,7 @@
 
       <p>
         Use these for inline <code>:style</code> bindings and for values computed at runtime. For
-        example, to color text using <code>$themeTokens.success</code> with a
+        example, to color text using <code>$themeTokens.primary</code> with a
         <DocsExternalLink
           text="computed style"
           href="https://vuejs.org/v2/guide/class-and-style.html"
@@ -122,13 +122,18 @@
       </p>
 
       <DocsShowCode language="html">
-        <div :style="{ color: $themeTokens.success }">This is not an error</div>
+        <div :style="{ color: $themeTokens.primary }">This is not an error</div>
       </DocsShowCode>
 
       <p>This will display:</p>
 
       <DocsShow>
-        <div :style="{ color: $themeTokens.success }">This is not an error</div>
+        <div
+          class="text-block"
+          :style="{ color: $themeTokens.primary }"
+        >
+          This is not an error
+        </div>
       </DocsShow>
 
       <p>Move style definitions from the template to computed props if the style gets complex.</p>
@@ -600,6 +605,10 @@
           padding: 4px;
           background-color: rgba(255, 255, 255, 0.8);
         }
+      }
+
+      .text-block {
+        font-size: 17px;
       }
 
       .error-message {

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -39,12 +39,63 @@
       title="Usage"
       anchor="#usage"
     >
+      <p>Colors can be referenced in two ways:</p>
+      <ul>
+        <li>
+          <strong>CSS variables</strong> in <code>&lt;style&gt;</code> blocks and SCSS files. Use
+          these by default.
+        </li>
+        <li>
+          <strong>JavaScript accessors</strong> on Vue components, for inline <code>:style</code>
+          bindings and for colors that need to be built at runtime (for example, a color combined
+          with a custom opacity).
+        </li>
+      </ul>
+      <p>
+        Both are set up by <code>Vue.use(KThemePlugin)</code> (see
+        <DocsInternalLink
+          href="/installation"
+          text="Installation"
+        />) and stay in sync when brand colors change at runtime via
+        <code>setBrandColors()</code> or <code>setTokenMapping()</code>.
+      </p>
+
+      <h3>CSS variables</h3>
+
+      <p>Theme values are emitted as CSS variables on <code>:root</code> in three layers:</p>
+      <ul>
+        <li><code>--tokens-*</code> for named color tokens (e.g. <code>--tokens-primary</code>)</li>
+        <li>
+          <code>--brand-*</code> for brand color scales (e.g. <code>--brand-primary-v500</code>)
+        </li>
+        <li>
+          <code>--palette-*</code> for the full palette (e.g. <code>--palette-grey-v200</code>)
+        </li>
+      </ul>
+      <p>
+        Reference them directly with <code>var(--name)</code>. For example, to color text using the
+        <code>error</code> token:
+      </p>
+      <!-- eslint-disable -->
+      <!-- prettier-ignore -->
+      <DocsShowCode language="html">
+        <style scoped>
+          .error-message {
+            color: var(--tokens-error);
+          }
+        </style>
+      </DocsShowCode>
+      <!-- eslint-enable -->
+      <p>
+        For palette and brand variables, replace the dots in the path with hyphens (<code>palette.grey.v_400</code>
+        becomes <code>--palette-grey-v400</code>). Token names are used as-is.
+      </p>
+
       <h3>Computed styles</h3>
 
       <p>
-        For technical reasons relating to supporting dynamic themes colors must be set using
-        Javascript. Adding <code>Vue.use(KThemePlugin)</code> makes all colors available on every
-        Vue component in your application under the following objects:
+        Colors are also available on every Vue component as JavaScript objects. Adding
+        <code>Vue.use(KThemePlugin)</code> makes the following objects available:
       </p>
 
       <ul>
@@ -54,12 +105,12 @@
       </ul>
 
       <p>
-        For example, to color text using <code>$themeTokens.error</code> you use can a
+        Use these for inline <code>:style</code> bindings and for values computed at runtime. For
+        example, to color text using <code>$themeTokens.error</code> with a
         <DocsExternalLink
           text="computed style"
           href="https://vuejs.org/v2/guide/class-and-style.html"
-        />
-        to write:
+        />:
       </p>
 
       <DocsShowCode language="html">
@@ -77,9 +128,8 @@
       <h3>Computed classes</h3>
 
       <p>
-        We also attach a special helper function <code>$computedClass</code> which can be used to
-        dynamically create new classes. This is useful for specifying colors in pseudo-elements such
-        as <code>:hover</code> or <code>:focus</code>. For example:
+        <code>$computedClass</code> can be used to dynamically create new classes for
+        pseudo-elements such as <code>:hover</code> or <code>:focus</code>. For example:
       </p>
 
       <DocsShowCode language="html">
@@ -87,16 +137,25 @@
       </DocsShowCode>
 
       <p>
-        This is usually not necessary, and using <code>style</code> is preferred for simplicity when
-        possible.
+        This is usually not necessary, use a <code>&lt;style&gt;</code> block with
+        <code>var(--tokens-*)</code> for static pseudo-class colors.
       </p>
 
       <h3>Notation</h3>
       <p>In the references below we use the following shorthand:</p>
       <ul>
-        <li><code>brand</code> refers to <code>$themeBrand</code></li>
-        <li><code>tokens</code> refers to <code>$themeTokens</code></li>
-        <li><code>palette</code> refers to <code>$themePalette</code></li>
+        <li>
+          <code>brand</code> refers to <code>$themeBrand</code> in JavaScript, or
+          <code>--brand-*</code> in CSS
+        </li>
+        <li>
+          <code>tokens</code> refers to <code>$themeTokens</code> in JavaScript, or
+          <code>--tokens-*</code> in CSS
+        </li>
+        <li>
+          <code>palette</code> refers to <code>$themePalette</code> in JavaScript, or
+          <code>--palette-*</code> in CSS
+        </li>
       </ul>
 
       <h3>Darken utilities</h3>

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -91,7 +91,7 @@
       <p>This will display:</p>
 
       <DocsShow>
-        <div class="error-message text-block">This is an error</div>
+        <div class="error-message">This is an error</div>
       </DocsShow>
       <p>
         For palette and brand variables, replace the dots in the path with hyphens and drop the
@@ -129,7 +129,6 @@
 
       <DocsShow>
         <div
-          class="text-block"
           :style="{ color: $themeTokens.primary }"
         >
           This is not an error
@@ -605,10 +604,6 @@
           padding: 4px;
           background-color: rgba(255, 255, 255, 0.8);
         }
-      }
-
-      .text-block {
-        font-size: 17px;
       }
 
       .error-message {

--- a/docs/pages/colors.vue
+++ b/docs/pages/colors.vue
@@ -79,16 +79,24 @@
       <!-- eslint-disable -->
       <!-- prettier-ignore -->
       <DocsShowCode language="html">
-        <style scoped>
+        <div class="error-message">This is an error</div>
+        <style>
           .error-message {
             color: var(--tokens-error);
           }
         </style>
       </DocsShowCode>
       <!-- eslint-enable -->
+
+      <p>This will display:</p>
+
+      <DocsShow>
+        <div class="error-message">This is an error</div>
+      </DocsShow>
       <p>
-        For palette and brand variables, replace the dots in the path with hyphens (<code>palette.grey.v_400</code>
-        becomes <code>--palette-grey-v400</code>). Token names are used as-is.
+        For palette and brand variables, replace the dots in the path with hyphens and drop the
+        underscore (<code>palette.grey.v_400</code> becomes <code>--palette-grey-v400</code>). Token
+        names are used as-is.
       </p>
 
       <h3>Computed styles</h3>
@@ -106,7 +114,7 @@
 
       <p>
         Use these for inline <code>:style</code> bindings and for values computed at runtime. For
-        example, to color text using <code>$themeTokens.error</code> with a
+        example, to color text using <code>$themeTokens.success</code> with a
         <DocsExternalLink
           text="computed style"
           href="https://vuejs.org/v2/guide/class-and-style.html"
@@ -114,13 +122,13 @@
       </p>
 
       <DocsShowCode language="html">
-        <div :style="{ color: $themeTokens.error }">This is an error</div>
+        <div :style="{ color: $themeTokens.success }">This is not an error</div>
       </DocsShowCode>
 
       <p>This will display:</p>
 
       <DocsShow>
-        <div :style="{ color: $themeTokens.error }">This is an error</div>
+        <div :style="{ color: $themeTokens.success }">This is not an error</div>
       </DocsShow>
 
       <p>Move style definitions from the template to computed props if the style gets complex.</p>
@@ -592,6 +600,10 @@
           padding: 4px;
           background-color: rgba(255, 255, 255, 0.8);
         }
+      }
+
+      .error-message {
+        color: var(--tokens-error);
       }
 
 </style>

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -73,9 +73,8 @@
         @import '~kolibri-design-system/lib/styles/common';
       </DocsShowCode>
 
-      <code>common.scss</code> registers both the global styles, such as those needed for components
-      to display correctly, as well as the page background, text color, focus outline, text
-      selection, and print styles, and the
+      <code>common.scss</code> registers both the global styles, such as the page background, text
+      color, focus outline, text selection, and print styles, and the
       <DocsInternalLink
         href="/styling#helper-styles"
         text="helper styles"

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -73,12 +73,15 @@
         @import '~kolibri-design-system/lib/styles/common';
       </DocsShowCode>
 
-      This registers the styles needed for components to display correctly, along with global styles
-      for the page background, text color, focus outline, text selection, and print. It also exposes
+      <code>common.scss</code> registers both the global styles, such as those needed for components to
+      display correctly, as well as the page background, text color, focus outline, text selection,
+      and print styles, and the
       <DocsInternalLink
         href="/styling#helper-styles"
         text="helper styles"
-      />.
+      />. The helper styles are also a public entry point of their own. An application that
+      doesn't need the global layer can import
+      <code>~kolibri-design-system/lib/styles/helper-styles</code> instead.
     </DocsPageSection>
 
     <DocsPageSection

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -30,8 +30,8 @@
         <li>
           Makes theme values available in two forms: as reactive objects on every Vue instance
           (<code>$themeBrand</code>,
-          <code>$themeTokens</code> <code>$themePalette</code>, <code>$computedClass</code>) for use
-          in JavaScript, and as CSS variables (<code>--tokens-*</code>, <code>--brand-*</code>,
+          <code>$themeTokens</code>, <code>$themePalette</code>, <code>$computedClass</code>) for
+          use in JavaScript, and as CSS variables (<code>--tokens-*</code>, <code>--brand-*</code>,
           <code>--palette-*</code>) emitted to a <code>&lt;style&gt;</code> tag with
           <code>#k-theme-css-variables</code> in the document head for use in style blocks. Both
           stay in sync when the theme changes via <code>setBrandColors()</code> or

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -28,12 +28,18 @@
 
       <ul>
         <li>
-          Installs <code>$themeBrand</code>, <code>$themeTokens</code> <code>$themePalette</code>,
-          and <code>$computedClass</code> helpers on all Vue instances (see
+          Makes theme values available in two forms: as reactive objects on every Vue instance
+          (<code>$themeBrand</code>,
+          <code>$themeTokens</code> <code>$themePalette</code>, <code>$computedClass</code>) for use
+          in JavaScript, and as CSS variables (<code>--tokens-*</code>, <code>--brand-*</code>,
+          <code>--palette-*</code>) emitted to a <code>&lt;style&gt;</code> tag with
+          <code>#k-theme-css-variables</code> in the document head for use in style blocks. Both
+          stay in sync when the theme changes via <code>setBrandColors()</code> or
+          <code>setTokenMapping()</code>. See
           <DocsInternalLink
             href="/colors/#usage"
             text="Colors"
-          />).
+          />.
         </li>
         <li>
           Provides <code>$coreOutline</code>, <code>$inputModality</code>, <code>$mediaType</code>,
@@ -41,14 +47,6 @@
           Vue instances.
         </li>
         <li>Globally registers all KDS Vue components.</li>
-        <li>
-          Emits theme values as CSS variables (<code>--tokens-*</code>, <code>--brand-*</code>, and
-          <code>--palette-*</code>) to a <code>&lt;style&gt;</code> tag
-          <code>#k-theme-css-variables</code> in an application's document head so that styles can
-          reference them directly, for example <code>var(--tokens-primary)</code>. The variables are
-          updated whenever the theme changes via <code>setBrandColors()</code> or
-          <code>setTokenMapping()</code>.
-        </li>
         <li>
           Inserts assertive and polite ARIA live regions <code>#k-live-region</code> to an
           application's document body (see
@@ -75,7 +73,8 @@
         @import '~kolibri-design-system/lib/styles/common';
       </DocsShowCode>
 
-      This globally registers styles needed for components to display correctly and also exposes
+      This registers the styles needed for components to display correctly, along with global styles
+      for the page background, text color, focus outline, text selection, and print. It also exposes
       <DocsInternalLink
         href="/styling#helper-styles"
         text="helper styles"

--- a/docs/pages/installation.vue
+++ b/docs/pages/installation.vue
@@ -73,14 +73,14 @@
         @import '~kolibri-design-system/lib/styles/common';
       </DocsShowCode>
 
-      <code>common.scss</code> registers both the global styles, such as those needed for components to
-      display correctly, as well as the page background, text color, focus outline, text selection,
-      and print styles, and the
+      <code>common.scss</code> registers both the global styles, such as those needed for components
+      to display correctly, as well as the page background, text color, focus outline, text
+      selection, and print styles, and the
       <DocsInternalLink
         href="/styling#helper-styles"
         text="helper styles"
-      />. The helper styles are also a public entry point of their own. An application that
-      doesn't need the global layer can import
+      />. The helper styles are also a public entry point of their own. An application that doesn't
+      need the global layer can import
       <code>~kolibri-design-system/lib/styles/helper-styles</code> instead.
     </DocsPageSection>
 

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -93,20 +93,26 @@
       </h3>
 
       <p>
-        In order for Kolibri to be dynamically themed colors cannot be defined as SCSS constants.
-        Instead, colors are defined in Javascript. Every Vue component instance gets a few reactive
-        Vue objects attached to it which can be accessed in computed styles:
+        Kolibri supports dynamic theming and colors update at runtime rather than being fixed SCSS
+        constants. They are available in two forms:
       </p>
       <ul>
-        <li><code>$themeBrand</code> contains colors related to the aesthetic color scheme</li>
-        <li><code>$themeTokens</code> contains colors with special meanings in Kolibri</li>
-        <li><code>$themePalette</code> contains a wide range of additional compatible colors</li>
+        <li>
+          As CSS variables (<code>--tokens-*</code>, <code>--brand-*</code>,
+          <code>--palette-*</code>) for use in <code>&lt;style&gt;</code> blocks and SCSS files.
+          Reference them with <code>var(--name)</code>.
+        </li>
+        <li>
+          As reactive objects on every Vue component instance (<code>$themeBrand</code>,
+          <code>$themeTokens</code>, <code>$themePalette</code>) for use in computed styles and
+          inline <code>:style</code> bindings.
+        </li>
       </ul>
       <p>
-        For more informatiom see the
+        For more information see the
         <DocsInternalLink
           text="Colors page"
-          href="/colors"
+          href="/colors#usage"
         />.
       </p>
 
@@ -121,7 +127,7 @@
           href="/installation#register-global-styles"
           text="installation step"
         />
-        globally exposes the following helper styles:
+        globally exposes the following:
       </p>
 
       <ul>
@@ -129,7 +135,26 @@
           <code>.visuallyhidden</code> class: hides an element visually but keeps it accessible to
           screen readers
         </li>
+        <li>
+          Global styles for page background, text color, text selection, focus outline, and print,
+          using the theme CSS variables
+        </li>
       </ul>
+
+      <h3>
+        Focus outline
+        <DocsAnchorTarget anchor="#focus-outline" />
+      </h3>
+      <p>
+        We provide a consistent, high-contrast focus highlight that is enabled only when we detect
+        that the user is navigating using the keyboard (i.e. tabbing from item to item).
+      </p>
+      <p>
+        It is also applied globally to focused elements as part of the installation step, using the
+        <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline color
+        needs to be read in JavaScript, use the <code>$coreOutline</code> attribute attached to Vue
+        objects.
+      </p>
     </DocsPageSection>
 
     <DocsPageSection
@@ -276,17 +301,6 @@
         }
       </DocsShowCode>
       <!-- eslint-enable -->
-    </DocsPageSection>
-
-    <DocsPageSection
-      title="Focus outline"
-      anchor="#focus-outline"
-    >
-      <p>
-        We provide a consistent, high-contrast focus highlight that is enabled only when we detect
-        that the user is navigating using the keyboard (i.e. tabbing from item to item). Use the
-        <code>$coreOutline</code> attribute attached to Vue objects for this.
-      </p>
     </DocsPageSection>
   </DocsPageTemplate>
 

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -117,7 +117,7 @@
       </p>
 
       <h3>
-        Helper styles
+        Global and helper styles
         <DocsAnchorTarget anchor="#helper-styles" />
       </h3>
 
@@ -146,14 +146,10 @@
         <DocsAnchorTarget anchor="#focus-outline" />
       </h3>
       <p>
-        We provide a consistent, high-contrast focus highlight that is enabled only when we detect
-        that the user is navigating using the keyboard (i.e. tabbing from item to item).
-      </p>
-      <p>
-        It is also applied globally to focused elements as part of the installation step, using the
-        <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline color
-        needs to be read in JavaScript, use the <code>$coreOutline</code> attribute attached to Vue
-        objects.
+        We provide a consistent, high-contrast focus highlight, using the
+        <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline needs
+        to be applied from JavaScript, use the <code>$coreOutline</code> computed property available
+        on all Vue instances.
       </p>
     </DocsPageSection>
 

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -146,11 +146,11 @@
         <DocsAnchorTarget anchor="#focus-outline" />
       </h3>
       <p>
-        We provide a consistent, high-contrast focus highlight that is enabled only when we detect
-        that the user is navigating using the keyboard (i.e. tabbing from item to item), using the
-        <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline needs
-        to be applied from JavaScript, use the <code>$coreOutline</code> computed property available
-        on all Vue instances.
+        We provide a consistent, high-contrast focus highlight, using the <code>--tokens-focusOutline</code>
+        CSS variable. The global styles apply it to any focused element, limited to keyboard navigation
+        (i.e. tabbing from item to item). To apply this within a component, use the `<code>$coreOutline</code>`
+        computed property available on Vue instances, because CSS alone cannot limit the highlight to keyboard
+        focus across all supported browsers.
       </p>
     </DocsPageSection>
 

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -146,11 +146,12 @@
         <DocsAnchorTarget anchor="#focus-outline" />
       </h3>
       <p>
-        We provide a consistent, high-contrast focus highlight, using the <code>--tokens-focusOutline</code>
-        CSS variable. The global styles apply it to any focused element, limited to keyboard navigation
-        (i.e. tabbing from item to item). To apply this within a component, use the `<code>$coreOutline</code>`
-        computed property available on Vue instances, because CSS alone cannot limit the highlight to keyboard
-        focus across all supported browsers.
+        We provide a consistent, high-contrast focus highlight, using the
+        <code>--tokens-focusOutline</code>
+        CSS variable. The global styles apply it to any focused element, limited to keyboard
+        navigation (i.e. tabbing from item to item). To apply this within a component, use the
+        `<code>$coreOutline</code>` computed property available on Vue instances, because CSS alone
+        cannot limit the highlight to keyboard focus across all supported browsers.
       </p>
     </DocsPageSection>
 

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -147,8 +147,8 @@
       </h3>
       <p>
         We provide a consistent, high-contrast focus highlight that is enabled only when we detect
-        that the user is navigating using the keyboard (i.e. tabbing from item to item), using
-        the <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline needs
+        that the user is navigating using the keyboard (i.e. tabbing from item to item), using the
+        <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline needs
         to be applied from JavaScript, use the <code>$coreOutline</code> computed property available
         on all Vue instances.
       </p>

--- a/docs/pages/styling/index.vue
+++ b/docs/pages/styling/index.vue
@@ -146,8 +146,9 @@
         <DocsAnchorTarget anchor="#focus-outline" />
       </h3>
       <p>
-        We provide a consistent, high-contrast focus highlight, using the
-        <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline needs
+        We provide a consistent, high-contrast focus highlight that is enabled only when we detect
+        that the user is navigating using the keyboard (i.e. tabbing from item to item), using
+        the <code>--tokens-focusOutline</code> CSS variable. For dynamic cases where the outline needs
         to be applied from JavaScript, use the <code>$coreOutline</code> computed property available
         on all Vue instances.
       </p>

--- a/lib/KDateRange/KDateCalendar.vue
+++ b/lib/KDateRange/KDateCalendar.vue
@@ -513,6 +513,9 @@
        */
       monthString(monthIndex) {
         const date = new Date();
+        // set the day first to avoid rolling over into the following month when
+        // today's date doesn't exist in the target month (e.g. 31st -> November)
+        date.setDate(1);
         date.setMonth(monthIndex);
         return this.$formatDate(date, { month: 'long' });
       },

--- a/lib/KDateRange/KDateDay.vue
+++ b/lib/KDateRange/KDateDay.vue
@@ -112,6 +112,9 @@
     methods: {
       toMonthName(monthNumber) {
         const date = new Date();
+        // set the day first to avoid rolling over into the following month when
+        // today's date doesn't exist in the target month (e.g. 31st -> November)
+        date.setDate(1);
         date.setMonth(monthNumber);
         return this.$formatDate(date, { month: 'long' });
       },

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -165,7 +165,9 @@ describe('themeCssVariables', () => {
       expect(usages).not.toHaveLength(0);
       expect(usages.filter(usage => !listed.includes(usage))).toEqual([]);
       // verify that the file is still importing globals.scss, where the variables are defined
-      expect(fs.readFileSync(path.resolve(__dirname, '../common.scss'), 'utf8')).toContain("@import 'globals';");
+      expect(fs.readFileSync(path.resolve(__dirname, '../common.scss'), 'utf8')).toContain(
+        "@import 'globals';",
+      );
     });
 
     it('falls back to the value the theme emits for each variable', () => {

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -155,6 +155,14 @@ describe('themeCssVariables', () => {
   });
 
   describe('globals.scss', () => {
+    it('is imported in common.scss', () => {
+      const css = require('node-sass')
+        .renderSync({ file: path.resolve(__dirname, '../common.scss') })
+        .css.toString();
+      expect(css).toContain('outline-offset: 4px'); // globals.scss
+      expect(css).toContain('.visuallyhidden'); // helper-styles.scss
+    });
+
     it('uses only the var() fallbacks listed above', () => {
       // deliberately flat matching: a nested or function-valued fallback fails this
       // test rather than being parsed, prompting an update to the table
@@ -164,10 +172,6 @@ describe('themeCssVariables', () => {
       );
       expect(usages).not.toHaveLength(0);
       expect(usages.filter(usage => !listed.includes(usage))).toEqual([]);
-      // verify that the file is still importing globals.scss, where the variables are defined
-      expect(fs.readFileSync(path.resolve(__dirname, '../common.scss'), 'utf8')).toContain(
-        "@import 'globals';",
-      );
     });
 
     it('falls back to the value the theme emits for each variable', () => {

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -1,3 +1,65 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const COMMON_SCSS_PATH = path.resolve(__dirname, '../common.scss');
+
+// Splits var() args on the top-level comma so a comma inside a function-valued
+// fallback is not mistaken for the separator. fallback is null when absent
+function splitVarArgs(args) {
+  let depth = 0;
+  for (let i = 0; i < args.length; i++) {
+    const character = args[i];
+    if (character === '(') {
+      depth++;
+    } else if (character === ')') {
+      depth--;
+    } else if (character === ',' && depth === 0) {
+      return { name: args.slice(0, i).trim(), fallback: args.slice(i + 1).trim() };
+    }
+  }
+  return { name: args.trim(), fallback: null };
+}
+
+// Parses every var() usage, matching parenthesis by depth so a function-valued fallback
+// such as rgba(0, 0, 0, 0.5) is captured whole rather than truncated at the first ')'
+function parseVarUsages(scss) {
+  const usages = [];
+  let start = scss.indexOf('var(');
+  while (start !== -1) {
+    const argsStart = start + 'var('.length;
+    let depth = 1;
+    let end = argsStart;
+    while (end < scss.length && depth > 0) {
+      if (scss[end] === '(') {
+        depth++;
+      } else if (scss[end] === ')') {
+        depth--;
+      }
+      end++;
+    }
+    // unclosed usage -> reported as missing a fallback rather than dropped
+    usages.push(splitVarArgs(depth === 0 ? scss.slice(argsStart, end - 1) : ''));
+    // resume inside the args so a nested var() is parsed in its own right too
+    start = scss.indexOf('var(', argsStart);
+  }
+  return usages;
+}
+
+let cachedScan;
+
+// Reads/parses common.scss once; Returns data only: occurrences is counted
+// without the parser so the coverage test cross-checks parseVarUsages
+function scanCommonScss() {
+  if (!cachedScan) {
+    const scss = fs.readFileSync(COMMON_SCSS_PATH, 'utf8');
+    cachedScan = {
+      occurrences: (scss.match(/var\(/g) || []).length,
+      usages: parseVarUsages(scss),
+    };
+  }
+  return cachedScan;
+}
+
 const TEST_BRAND_COLORS = {
   primary: {
     v_100: '#CCE7E7',
@@ -17,12 +79,14 @@ const TEST_BRAND_COLORS = {
   },
 };
 
+// required once: tests only read their color strings and never mutate them
+const palette = require('../colorsMaterial').default;
+const brand = require('../colorsDefault').defaultBrandColors;
+
 describe('themeCssVariables', () => {
   let Vue;
   let themeCssVariables;
   let theme;
-  let palette;
-  let brand;
 
   beforeEach(() => {
     // fresh modules so that the `initialized` flag and
@@ -32,11 +96,11 @@ describe('themeCssVariables', () => {
     Vue = require('vue');
     themeCssVariables = require('../themeCssVariables');
     theme = require('../theme');
-    palette = require('../colorsMaterial').default;
-    brand = require('../colorsDefault').defaultBrandColors;
   });
 
   afterEach(() => {
+    // process.server is a real global that resetModules cannot undo; theme mutations
+    // are discarded with the module in the next beforeEach
     delete process.server;
   });
 
@@ -44,17 +108,13 @@ describe('themeCssVariables', () => {
     return document.getElementById(themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID);
   }
 
-  it('smoke test: initializes without throwing', () => {
-    expect(() => themeCssVariables.default()).not.toThrow();
-  });
-
   describe('generateThemeCssVariables', () => {
     it('emits palette colors with version keys formatted as vN', () => {
       const variables = themeCssVariables.generateThemeCssVariables();
       expect(variables['--palette-grey-v400']).toBe(palette.grey.v_400);
       expect(variables['--palette-black']).toBe(palette.black);
       expect(variables['--palette-white']).toBe(palette.white);
-      // the `v_N` form should not be emitted
+      // the v_N form should not be emitted
       expect(variables['--palette-grey-v_400']).toBeUndefined();
     });
 
@@ -62,13 +122,11 @@ describe('themeCssVariables', () => {
       const variables = themeCssVariables.generateThemeCssVariables();
       expect(variables['--brand-primary-v600']).toBe(brand.primary.v_600);
       expect(variables['--brand-secondary-v100']).toBe(brand.secondary.v_100);
-      // the `v_N` form should not be emitted
-      expect(variables['--brand-primary-v_600']).toBeUndefined();
     });
 
-    it('emits theme tokens as-is, resolved to color values', () => {
+    it('emits theme tokens resolved to color values', () => {
       const variables = themeCssVariables.generateThemeCssVariables();
-      // default token mapping: primary -> brand.primary.v_500,
+      // default mapping: primary -> brand.primary.v_500,
       // focusOutline -> palette.lightblue.v_400, text -> palette.black
       expect(variables['--tokens-primary']).toBe(brand.primary.v_500);
       expect(variables['--tokens-focusOutline']).toBe(palette.lightblue.v_400);
@@ -79,18 +137,16 @@ describe('themeCssVariables', () => {
       const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
       theme.setTokenMapping({ 'evil: red; } body { color': 'palette.red.v_500' });
       const variables = themeCssVariables.generateThemeCssVariables();
-      expect(Object.keys(variables).some(name => name.includes('evil'))).toBe(false);
+      expect(Object.keys(variables)).not.toContainEqual(expect.stringContaining('evil'));
       expect(warn).toHaveBeenCalled();
       warn.mockRestore();
     });
   });
 
   describe('themeCssVariablesText', () => {
-    it('returns a :root rule containing the variables', () => {
+    it('wraps the variables in a :root rule', () => {
       const cssText = themeCssVariables.themeCssVariablesText();
       expect(cssText).toMatch(/^:root\s*\{/);
-      expect(cssText).toContain(`--palette-grey-v400: ${palette.grey.v_400};`);
-      expect(cssText).toContain(`--brand-primary-v600: ${brand.primary.v_600};`);
       expect(cssText).toContain(`--tokens-primary: ${brand.primary.v_500};`);
     });
   });
@@ -101,10 +157,9 @@ describe('themeCssVariables', () => {
       const styleTag = getStyleTag();
       expect(styleTag).toBeInTheDocument();
       expect(document.head).toContainElement(styleTag);
-      // exact-equality on textContent is intentional, to verify the exact serialized
-      // output (`toHaveTextContent` would normalize whitespace)
-      const cssText = styleTag.textContent;
-      expect(cssText).toEqual(themeCssVariables.themeCssVariablesText());
+      // verify the exact output (toHaveTextContent normalizes whitespace)
+      // eslint-disable-next-line jest-dom/prefer-to-have-text-content
+      expect(styleTag.textContent).toEqual(themeCssVariables.themeCssVariablesText());
     });
 
     it('is initialized only once', async () => {
@@ -113,7 +168,7 @@ describe('themeCssVariables', () => {
       expect(
         document.head.querySelectorAll(`#${themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID}`),
       ).toHaveLength(1);
-      // updates keep working after a redundant initialization
+      // updates keep working after a redundant init
       theme.setBrandColors(TEST_BRAND_COLORS);
       await Vue.nextTick();
       expect(getStyleTag()).toHaveTextContent(
@@ -132,42 +187,78 @@ describe('themeCssVariables', () => {
       expect(styleTag).toHaveTextContent(
         `--brand-secondary-v600: ${TEST_BRAND_COLORS.secondary.v_600};`,
       );
-      // `primary` token maps to `brand.primary.v_500`
       expect(styleTag).toHaveTextContent(`--tokens-primary: ${TEST_BRAND_COLORS.primary.v_500};`);
-      // unrelated variables are still emitted, unchanged
+      // unrelated variables stay emitted and unchanged
       expect(styleTag).toHaveTextContent(`--palette-grey-v400: ${palette.grey.v_400};`);
     });
 
-    it('updates the variables when the token mapping changes', async () => {
+    it('regenerates tokens when the mapping changes, including newly added tokens', async () => {
       themeCssVariables.default();
-      theme.setTokenMapping({ primary: 'palette.green.v_500' });
+      theme.setTokenMapping({ primary: 'palette.green.v_500', customToken: 'palette.red.v_500' });
       await Vue.nextTick();
-      expect(getStyleTag()).toHaveTextContent(`--tokens-primary: ${palette.green.v_500};`);
+      const styleTag = getStyleTag();
+      expect(styleTag).toHaveTextContent(`--tokens-primary: ${palette.green.v_500};`);
+      expect(styleTag).toHaveTextContent(`--tokens-customToken: ${palette.red.v_500};`);
+    });
+  });
+
+  describe('literal fallbacks in common.scss', () => {
+    // Fallbacks must stay in sync with the defaults in colorsDefault.js / colorsMaterial.js
+    let withFallback;
+    let withoutFallback;
+
+    beforeAll(() => {
+      const { usages } = scanCommonScss();
+      withFallback = usages.filter(usage => usage.fallback !== null);
+      withoutFallback = usages.filter(usage => usage.fallback === null);
     });
 
-    it('emits newly added tokens', async () => {
-      themeCssVariables.default();
-      theme.setTokenMapping({ customToken: 'palette.red.v_500' });
-      await Vue.nextTick();
-      expect(getStyleTag()).toHaveTextContent(`--tokens-customToken: ${palette.red.v_500};`);
+    it('are parsed from every var() usage in the file', () => {
+      const { occurrences, usages } = scanCommonScss();
+      expect(occurrences).toBeGreaterThan(0);
+      expect(usages).toHaveLength(occurrences);
+    });
+
+    it('are present on every themed variable used in common.scss', () => {
+      expect(withoutFallback.map(usage => usage.name)).toEqual([]);
+    });
+
+    it('are literal values rather than another var()', () => {
+      // a var() fallback would reintroduce the invalidation the fallbacks exist to prevent
+      const nonLiteral = withFallback.filter(usage => usage.fallback.includes('var('));
+      expect(nonLiteral.map(usage => usage.name)).toEqual([]);
+    });
+
+    it('match the default values of the variables they fall back to', () => {
+      const variables = themeCssVariables.generateThemeCssVariables();
+      // compared as lists so a failure names the offending variables and every fallback
+      // of a repeated variable is checked
+      const fallbacks = withFallback.map(
+        ({ name, fallback }) => `${name}: ${fallback.toLowerCase()}`,
+      );
+      // undefined for a never-emitted variable, which is also a mismatch
+      const defaults = withFallback.map(
+        ({ name }) => `${name}: ${variables[name] && variables[name].toLowerCase()}`,
+      );
+      expect(fallbacks).toEqual(defaults);
     });
   });
 
   describe('with server-side rendering', () => {
     it('does not touch the document on the server', () => {
-      // set the flag before the module is required, so that the test stays
-      // correct even if the SSR check were moved to import time
-      jest.resetModules();
+      // flag set before require so the test holds even if the SSR check moves to import
+      // time; isolateModules scopes this registry, leaving beforeEach's in place
       process.server = true;
-      const ssrThemeCssVariables = require('../themeCssVariables');
-      ssrThemeCssVariables.default();
-      expect(document.head.querySelector('style')).toBeNull();
-      // the text used for server-side head injection is still generated
-      expect(ssrThemeCssVariables.themeCssVariablesText()).toContain('--tokens-primary:');
+      jest.isolateModules(() => {
+        const ssrThemeCssVariables = require('../themeCssVariables');
+        ssrThemeCssVariables.default();
+        expect(document.head.querySelector('style')).toBeNull();
+        // text for server-side head injection is still generated
+        expect(ssrThemeCssVariables.themeCssVariablesText()).toContain('--tokens-primary:');
+      });
     });
 
     it('takes over the server-rendered tag from vue-meta', () => {
-      // simulate a tag rendered into the head by the server via vue-meta
       const ssrStyleTag = document.createElement('style');
       ssrStyleTag.id = themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID;
       ssrStyleTag.setAttribute('data-n-head', 'ssr');
@@ -175,14 +266,12 @@ describe('themeCssVariables', () => {
       document.head.appendChild(ssrStyleTag);
 
       themeCssVariables.default();
-      // vue-meta's marker attributes are removed so that vue-meta can neither
-      // remove the tag on head updates nor rewrite it with stale CSS
+      // markers removed so vue-meta cannot drop the tag or rewrite it with stale CSS
       expect(ssrStyleTag).not.toHaveAttribute('data-n-head');
       expect(ssrStyleTag).not.toHaveAttribute('data-hid');
     });
 
     it('reuses and updates the style tag written during server-side rendering', async () => {
-      // simulate a tag rendered into the head by the server
       const ssrStyleTag = document.createElement('style');
       ssrStyleTag.id = themeCssVariables.THEME_CSS_VARIABLES_STYLE_ID;
       ssrStyleTag.textContent = themeCssVariables.themeCssVariablesText();

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -164,6 +164,8 @@ describe('themeCssVariables', () => {
       );
       expect(usages).not.toHaveLength(0);
       expect(usages.filter(usage => !listed.includes(usage))).toEqual([]);
+      // verify that the file is still importing globals.scss, where the variables are defined
+      expect(fs.readFileSync(path.resolve(__dirname, '../common.scss'), 'utf8')).toContain("@import 'globals';");
     });
 
     it('falls back to the value the theme emits for each variable', () => {

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -2,63 +2,15 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const COMMON_SCSS_PATH = path.resolve(__dirname, '../common.scss');
+const commonScss = fs.readFileSync(COMMON_SCSS_PATH, 'utf8');
 
-// Splits var() args on the top-level comma so a comma inside a function-valued
-// fallback is not mistaken for the separator. fallback is null when absent
-function splitVarArgs(args) {
-  let depth = 0;
-  for (let i = 0; i < args.length; i++) {
-    const character = args[i];
-    if (character === '(') {
-      depth++;
-    } else if (character === ')') {
-      depth--;
-    } else if (character === ',' && depth === 0) {
-      return { name: args.slice(0, i).trim(), fallback: args.slice(i + 1).trim() };
-    }
-  }
-  return { name: args.trim(), fallback: null };
-}
-
-// Parses every var() usage, matching parenthesis by depth so a function-valued fallback
-// such as rgba(0, 0, 0, 0.5) is captured whole rather than truncated at the first ')'
-function parseVarUsages(scss) {
-  const usages = [];
-  let start = scss.indexOf('var(');
-  while (start !== -1) {
-    const argsStart = start + 'var('.length;
-    let depth = 1;
-    let end = argsStart;
-    while (end < scss.length && depth > 0) {
-      if (scss[end] === '(') {
-        depth++;
-      } else if (scss[end] === ')') {
-        depth--;
-      }
-      end++;
-    }
-    // unclosed usage -> reported as missing a fallback rather than dropped
-    usages.push(splitVarArgs(depth === 0 ? scss.slice(argsStart, end - 1) : ''));
-    // resume inside the args so a nested var() is parsed in its own right too
-    start = scss.indexOf('var(', argsStart);
-  }
-  return usages;
-}
-
-let cachedScan;
-
-// Reads/parses common.scss once; Returns data only: occurrences is counted
-// without the parser so the coverage test cross-checks parseVarUsages
-function scanCommonScss() {
-  if (!cachedScan) {
-    const scss = fs.readFileSync(COMMON_SCSS_PATH, 'utf8');
-    cachedScan = {
-      occurrences: (scss.match(/var\(/g) || []).length,
-      usages: parseVarUsages(scss),
-    };
-  }
-  return cachedScan;
-}
+// Every var() usage in common.scss
+const COMMON_SCSS_VAR_FALLBACKS = [
+  ['--tokens-text', '#000000'],
+  ['--palette-grey-v100', '#f5f5f5'],
+  ['--tokens-focusOutline', '#33acf5'],
+  ['--brand-secondary-v100', '#fff5cc'],
+];
 
 const TEST_BRAND_COLORS = {
   primary: {
@@ -202,45 +154,36 @@ describe('themeCssVariables', () => {
     });
   });
 
-  describe('literal fallbacks in common.scss', () => {
-    // Fallbacks must stay in sync with the defaults in colorsDefault.js / colorsMaterial.js
-    let withFallback;
-    let withoutFallback;
-
-    beforeAll(() => {
-      const { usages } = scanCommonScss();
-      withFallback = usages.filter(usage => usage.fallback !== null);
-      withoutFallback = usages.filter(usage => usage.fallback === null);
-    });
-
-    it('are parsed from every var() usage in the file', () => {
-      const { occurrences, usages } = scanCommonScss();
-      expect(occurrences).toBeGreaterThan(0);
-      expect(usages).toHaveLength(occurrences);
-    });
-
-    it('are present on every themed variable used in common.scss', () => {
-      expect(withoutFallback.map(usage => usage.name)).toEqual([]);
-    });
-
-    it('are literal values rather than another var()', () => {
-      // a var() fallback would reintroduce the invalidation the fallbacks exist to prevent
-      const nonLiteral = withFallback.filter(usage => usage.fallback.includes('var('));
-      expect(nonLiteral.map(usage => usage.name)).toEqual([]);
-    });
-
-    it('match the default values of the variables they fall back to', () => {
-      const variables = themeCssVariables.generateThemeCssVariables();
-      // compared as lists so a failure names the offending variables and every fallback
-      // of a repeated variable is checked
-      const fallbacks = withFallback.map(
-        ({ name, fallback }) => `${name}: ${fallback.toLowerCase()}`,
+  describe('common.scss', () => {
+    it('uses only the var() fallbacks listed above', () => {
+      // deliberately flat matching: a nested or function-valued fallback fails this
+      // test rather than being parsed, prompting an update to the table
+      const usages = commonScss.match(/var\([^)]*\)/g) || [];
+      const listed = COMMON_SCSS_VAR_FALLBACKS.map(
+        ([name, fallback]) => `var(${name}, ${fallback})`,
       );
+      expect(usages).not.toHaveLength(0);
+      expect(usages.filter(usage => !listed.includes(usage))).toEqual([]);
+    });
+
+    it('falls back to the value the theme emits for each variable', () => {
+      const variables = themeCssVariables.generateThemeCssVariables();
+      const fallbacks = COMMON_SCSS_VAR_FALLBACKS.map(([name, fallback]) => `${name}: ${fallback}`);
       // undefined for a never-emitted variable, which is also a mismatch
-      const defaults = withFallback.map(
-        ({ name }) => `${name}: ${variables[name] && variables[name].toLowerCase()}`,
+      const defaults = COMMON_SCSS_VAR_FALLBACKS.map(
+        ([name]) => `${name}: ${variables[name] && variables[name].toLowerCase()}`,
       );
       expect(fallbacks).toEqual(defaults);
+    });
+
+    it('keeps the *:focus ring in sync with themeOutlineStyle()', () => {
+      const outline = theme.themeOutlineStyle();
+      expect(commonScss).toContain(`outline-width: ${outline.outlineWidth};`);
+      expect(commonScss).toContain(`outline-style: ${outline.outlineStyle};`);
+      expect(commonScss).toContain(`outline-offset: ${outline.outlineOffset};`);
+      expect(outline.outlineColor).toBe(
+        themeCssVariables.generateThemeCssVariables()['--tokens-focusOutline'],
+      );
     });
   });
 

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -159,7 +159,7 @@ describe('themeCssVariables', () => {
       const css = require('node-sass')
         .renderSync({ file: path.resolve(__dirname, '../common.scss') })
         .css.toString();
-      expect(css).toContain('outline-offset: 4px'); // globals.scss
+      expect(css).toContain(`outline-offset: ${theme.themeOutlineStyle().outlineOffset}`);
       expect(css).toContain('.visuallyhidden'); // helper-styles.scss
     });
 

--- a/lib/styles/__tests__/themeCssVariables.spec.js
+++ b/lib/styles/__tests__/themeCssVariables.spec.js
@@ -1,11 +1,11 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
-const COMMON_SCSS_PATH = path.resolve(__dirname, '../common.scss');
-const commonScss = fs.readFileSync(COMMON_SCSS_PATH, 'utf8');
+const GLOBALS_SCSS_PATH = path.resolve(__dirname, '../globals.scss');
+const globalsScss = fs.readFileSync(GLOBALS_SCSS_PATH, 'utf8');
 
-// Every var() usage in common.scss
-const COMMON_SCSS_VAR_FALLBACKS = [
+// Every var() usage in globals.scss
+const GLOBALS_SCSS_VAR_FALLBACKS = [
   ['--tokens-text', '#000000'],
   ['--palette-grey-v100', '#f5f5f5'],
   ['--tokens-focusOutline', '#33acf5'],
@@ -154,12 +154,12 @@ describe('themeCssVariables', () => {
     });
   });
 
-  describe('common.scss', () => {
+  describe('globals.scss', () => {
     it('uses only the var() fallbacks listed above', () => {
       // deliberately flat matching: a nested or function-valued fallback fails this
       // test rather than being parsed, prompting an update to the table
-      const usages = commonScss.match(/var\([^)]*\)/g) || [];
-      const listed = COMMON_SCSS_VAR_FALLBACKS.map(
+      const usages = globalsScss.match(/var\([^)]*\)/g) || [];
+      const listed = GLOBALS_SCSS_VAR_FALLBACKS.map(
         ([name, fallback]) => `var(${name}, ${fallback})`,
       );
       expect(usages).not.toHaveLength(0);
@@ -168,9 +168,11 @@ describe('themeCssVariables', () => {
 
     it('falls back to the value the theme emits for each variable', () => {
       const variables = themeCssVariables.generateThemeCssVariables();
-      const fallbacks = COMMON_SCSS_VAR_FALLBACKS.map(([name, fallback]) => `${name}: ${fallback}`);
+      const fallbacks = GLOBALS_SCSS_VAR_FALLBACKS.map(
+        ([name, fallback]) => `${name}: ${fallback}`,
+      );
       // undefined for a never-emitted variable, which is also a mismatch
-      const defaults = COMMON_SCSS_VAR_FALLBACKS.map(
+      const defaults = GLOBALS_SCSS_VAR_FALLBACKS.map(
         ([name]) => `${name}: ${variables[name] && variables[name].toLowerCase()}`,
       );
       expect(fallbacks).toEqual(defaults);
@@ -178,9 +180,9 @@ describe('themeCssVariables', () => {
 
     it('keeps the *:focus ring in sync with themeOutlineStyle()', () => {
       const outline = theme.themeOutlineStyle();
-      expect(commonScss).toContain(`outline-width: ${outline.outlineWidth};`);
-      expect(commonScss).toContain(`outline-style: ${outline.outlineStyle};`);
-      expect(commonScss).toContain(`outline-offset: ${outline.outlineOffset};`);
+      expect(globalsScss).toContain(`outline-width: ${outline.outlineWidth};`);
+      expect(globalsScss).toContain(`outline-style: ${outline.outlineStyle};`);
+      expect(globalsScss).toContain(`outline-offset: ${outline.outlineOffset};`);
       expect(outline.outlineColor).toBe(
         themeCssVariables.generateThemeCssVariables()['--tokens-focusOutline'],
       );

--- a/lib/styles/common.scss
+++ b/lib/styles/common.scss
@@ -1,49 +1,5 @@
-// Each theme variable below intentionally includes a literal fallback. Unresolved variables
-// make the entire declaration invalid at computed-value time, they only become
-// valid after `initThemeCssVariables()` is called. Fallbacks mirror the defaults
-// in colorsDefault.js / colorsMaterial.js
+// The full set of unscoped KDS styles; documented entry point for consumers
+// import `helper-styles` directly to opt out of the global theming layer
 
-html,
-body {
-  color: var(--tokens-text, #000000);
-  background-color: var(--palette-grey-v100, #f5f5f5);
-}
-
-// Outline for keyboard-modality tab-focus, sourced from themeOutlineStyle()
-*:focus {
-  outline-width: 3px;
-  outline-style: solid;
-  outline-color: var(--tokens-focusOutline, #33acf5);
-  outline-offset: 4px;
-}
-
-// Remove the focus outline for mouse clicks
-*:focus:not(:focus-visible) {
-  outline: none;
-}
-
-::selection {
-  color: var(--tokens-text, #000000);
-  background: var(--brand-secondary-v100, #fff5cc);
-}
-
-@media print {
-  * {
-    // Intentionally hardcoded because print ink must not be themeable
-    // and a literal cannot be invalidated by a missing custom property
-    color: #000000 !important;
-    background: none !important;
-    box-shadow: none !important;
-  }
-}
-
-.visuallyhidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  border: 0;
-}
+@import 'globals';
+@import 'helper-styles';

--- a/lib/styles/common.scss
+++ b/lib/styles/common.scss
@@ -1,23 +1,29 @@
+// Each theme variable below intentionally includes a literal fallback. Unresolved variables
+// make the entire declaration invalid at computed-value time, they only become
+// valid after `initThemeCssVariables()` is called. Fallbacks mirror the defaults
+// in colorsDefault.js / colorsMaterial.js
+
 html,
 body {
-  color: var(--tokens-text);
-  background-color: var(--palette-grey-v100);
+  color: var(--tokens-text, #000000);
+  background-color: var(--palette-grey-v100, #f5f5f5);
 }
 
-*:focus,
-*:focus:hover {
+*:focus {
   outline-width: 3px;
   outline-style: solid;
-  outline-color: var(--tokens-focusOutline);
+  outline-color: var(--tokens-focusOutline, #33acf5);
   outline-offset: 4px;
 }
 
 ::selection {
-  background: var(--brand-secondary-v100);
+  background: var(--brand-secondary-v100, #fff5cc);
 }
 
 @media print {
   * {
+    // Intentionally hardcoded because print ink must not be themeable
+    // and a literal cannot be invalidated by a missing custom property
     color: #000000 !important;
     background: none !important;
     box-shadow: none !important;

--- a/lib/styles/common.scss
+++ b/lib/styles/common.scss
@@ -1,3 +1,29 @@
+html,
+body {
+  color: var(--tokens-text);
+  background-color: var(--palette-grey-v100);
+}
+
+*:focus,
+*:focus:hover {
+  outline-width: 3px;
+  outline-style: solid;
+  outline-color: var(--tokens-focusOutline);
+  outline-offset: 4px;
+}
+
+::selection {
+  background: var(--brand-secondary-v100);
+}
+
+@media print {
+  * {
+    color: #000000 !important;
+    background: none !important;
+    box-shadow: none !important;
+  }
+}
+
 .visuallyhidden {
   position: absolute;
   width: 1px;

--- a/lib/styles/common.scss
+++ b/lib/styles/common.scss
@@ -9,6 +9,7 @@ body {
   background-color: var(--palette-grey-v100, #f5f5f5);
 }
 
+// Outline for keyboard-modality tab-focus, sourced from themeOutlineStyle()
 *:focus {
   outline-width: 3px;
   outline-style: solid;
@@ -16,7 +17,13 @@ body {
   outline-offset: 4px;
 }
 
+// Remove the focus outline for mouse clicks
+*:focus:not(:focus-visible) {
+  outline: none;
+}
+
 ::selection {
+  color: var(--tokens-text, #000000);
   background: var(--brand-secondary-v100, #fff5cc);
 }
 

--- a/lib/styles/globals.scss
+++ b/lib/styles/globals.scss
@@ -1,0 +1,38 @@
+// Each theme variable below intentionally includes a literal fallback. Unresolved variables
+// make the entire declaration invalid at computed-value time, they only become
+// valid after `initThemeCssVariables()` is called. Fallbacks mirror the defaults
+// in colorsDefault.js / colorsMaterial.js
+
+html,
+body {
+  color: var(--tokens-text, #000000);
+  background-color: var(--palette-grey-v100, #f5f5f5);
+}
+
+// Outline for keyboard-modality tab-focus, sourced from themeOutlineStyle()
+*:focus {
+  outline-width: 3px;
+  outline-style: solid;
+  outline-color: var(--tokens-focusOutline, #33acf5);
+  outline-offset: 4px;
+}
+
+// Remove the focus outline for mouse clicks
+*:focus:not(:focus-visible) {
+  outline: none;
+}
+
+::selection {
+  color: var(--tokens-text, #000000);
+  background: var(--brand-secondary-v100, #fff5cc);
+}
+
+@media print {
+  * {
+    // Intentionally hardcoded because print ink must not be themeable
+    // and a literal cannot be invalidated by a missing custom property
+    color: #000000 !important;
+    background: none !important;
+    box-shadow: none !important;
+  }
+}

--- a/lib/styles/helper-styles.scss
+++ b/lib/styles/helper-styles.scss
@@ -1,0 +1,12 @@
+// Utility classes
+
+.visuallyhidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@vuedoc/parser": "^3.4.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^30.2.0",
-    "browserslist-config-kolibri": "0.18.0",
+    "browserslist-config-kolibri": "0.20.0",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^9.1.0",
     "consola": "^2.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4325,10 +4325,10 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist-config-kolibri@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/browserslist-config-kolibri/-/browserslist-config-kolibri-0.18.0.tgz#976ae039857c280cb99ae91173fed27873cb789a"
-  integrity sha512-d8JCoLUG8XlgfaE/wB7P58ok6ddiGGjChm6dVsL3W2702ibgFjOx+NtFHrLKCpkSuiaR2/gevvaQsIFwkVNNiA==
+browserslist-config-kolibri@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/browserslist-config-kolibri/-/browserslist-config-kolibri-0.20.0.tgz#b064885bd0f2085ba60226a5fcecfa11d2f175fb"
+  integrity sha512-n4d0LArmEqXq5F0hXAzOu+Rpzw+lcHWWhfTAsf1Au52vmGcWx1ej0I4cIkXn/5d23qOSx1yDSTZLTGkusANyvQ==
 
 browserslist@^4.0.0, browserslist@^4.21.4, browserslist@^4.23.1, browserslist@^4.23.3, browserslist@^4.24.0, browserslist@^4.24.3:
   version "4.24.4"


### PR DESCRIPTION
## Description
This PR adds the global styles (page background and text color, focus outline, text selection color, and print styles) to the existing global-rules stylesheet `lib/styles/common.scss`, using static CSS variables. This is an incremental step towards removing Aphrodite.

The installation, colors, and styling documentation pages were updated to include CSS variable usage guidance and information.

#### Issue addressed
<!-- Only necessary if applicable -->

Addresses #1301 


## Changelog
<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG START -->

<!--
  - Fill in the changelog item(s) below. If there are more groups of closely
    related changes, prepare more changelog items for each one of them.
    At a minimum, always separete non-breaking changes from breaking changes.
  - This needs to be pasted to CHANGELOG.md before merging a PR.
  - See changelog guidelines https://www.notion.so/learningequality/DRAFT-Changelog-Guidelines-106b6ebbdeda4ba5b3b3e7c490c5a4fe and existing
    items in CHANGELOG.md as examples
 -->

  - **Description:** Implement JS generated global styles with CSS variables
  - **Products impact:** none
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/1301
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -

<!-- [DO NOT REMOVE-USED BY GH ACTION] CHANGELOG END -->

## Steps to test
I ran the Kolibri devserver with my local KDS changes and manually confirmed:
1. **Focus outline**: tabbing through interactive elements with the keyboard displays the 3px solid lightblue outline with 4px offset (`--tokens-focusOutline`).
2. **Text selection**: when selecting page text, the highlight background is the secondary brand color (`--brand-secondary-v100`)
3. **Page background/text**: `html`/`body` show grey background (`--palette-grey-v100`) and default text color (`--tokens-text`); visually matches the previous appearance.
4. **Print**: when opening the print preview, the text is black and the backgrounds/box-shadows are removed.

https://github.com/user-attachments/assets/1c1ca049-6d0b-4289-b258-2d14c053f82a


## (optional) Implementation notes

### At a high level, how did you implement this?
`generateGlobalStyles.js` uses Aphrodite to inject a set of global styles at runtime. Now that every theme value is exposed as a CSS variable, these rules no longer need to be computed in JS. 

The global styles for the page background and text color, focus outline, text selection color, and printing, where added to the existing global-rules stylesheet `lib/styles/common.scss`, using static CSS variables.

This PR also updates `.stylelintrc.js` to allow camelCase in custom property names. This is necessary because Theme CSS variables mirror camelCase token names, e.g. `--tokens-focusOutline`.

These changes do not include completely removing `generateGlobalStyles.js `or Aphrodite, only adding the static equivalent.

<p class="p1">The four global styles mapped to CSS-variables:</p>

  | Old (Aphrodite) value | CSS variable
-- | -- | --
html/body text color | `themeTokens().text` | `var(--tokens-text)`
html/body bg | `themePalette().grey.v_100` | `var(--palette-grey-v100)`
focus outline color | `themeOutlineStyle().outlineColor` (`tokens.focusOutline`) | `var(--tokens-focusOutline)`
text selection bg | `themeBrand().secondary.v_100` | `var(--brand-secondary-v100)`


<p class="p1">The outline width (3px) / offset (4px) / style (solid) for focus and the print colors remain hardcoded, they are not tokens.


### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->

## Testing checklist
<!-- Complete the checklist before submitting a PR; delete anything that doesn't apply -->

- [x] Contributor has fully tested the PR manually
- [x] The change is described in the changelog section above

## Reviewer guidance

- [ ] Is the code clean and well-commented?
- [ ] Are all UI components LTR and RTL compliant (if applicable)?